### PR TITLE
feat: better deployment with docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # 使用官方 Node.js 镜像作为基础镜像
 FROM node:20.10.0
 
+# 设置 taobao 镜像源
+RUN npm config set registry https://registry.npm.taobao.org
+
 # 安装 pnpm
 RUN npm install -g pnpm
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "start": "next start",
     "lint": "next lint",
     "postinstall": "prisma generate",
-    "docker:start": "docker-compose up",
+    "docker:start": "docker-compose up -d",
+    "docker:stop": "docker-compose stop",
     "db:init": "npx prisma migrate dev && node scripts/createCourses.js && node scripts/uploadCourseData.js",
     "db:update": "node scripts/createCourses.js && node scripts/uploadCourseData.js"
   },


### PR DESCRIPTION
添加 npm 镜像源是因为执行了 `pnpm docker:start` 发现，next 在内部构建镜像时，通过 `npm` 全局安装 `pnpm` 时一直超时，如图：

<img width="872" alt="image" src="https://github.com/cuixiaorui/earthworm/assets/48991003/86c14810-d5fb-4594-a74e-89e7baace437">

配置 docker 命令时因为在体验过程中，不小心把终端关闭后服务就自动停止了，所以设置 `docker:start` 添加 `-d` 参数保持服务后台挂起而不是占用终端窗口，同时提供了 `docker:stop` 来手动停止服务。

![image](https://github.com/cuixiaorui/earthworm/assets/48991003/8954d6de-f386-4d2c-9c5d-cd805b6eb8ef)