### PR TITLE
Start in window

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,1 @@
+node_modules


### PR DESCRIPTION
-  window 电脑  pnpm 使用了一个全局的存储目录来存储依赖，然后在 node_modules 目录中创建链接。当在将 node_modules 目录复制到 Docker 容器中时，这些链接会指向本地机器上的存储目录, 导致初始化运行报错.  所有应该忽略 node_modules 文件的复制
- liunx系统可能也有这个问题
- 测试后 mac 不受影响