### PR TITLE
feat: add docker mysql start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,19 @@ Note that this project depends on docker, so make sure that docker is installed 
    ```
 
 2. start application
+
    ```shell
    pnpm docker:start
    ```
-3. init data of database (It only needs to be executed the first time the database is created)
+
+3. stop application
+
+   ```shell
+   pnpm docker:stop
+   ```
+
+4. init data of database (It only needs to be executed the first time the database is created)
+
    ```shell
    pnpm db:init
    ```
@@ -73,13 +82,21 @@ ReferenceError: Request is not defined
 
 ### 贡献指北
 
-由于修改、调试项目需要 mysql 服务，这里我们可以只用 docker 跑个 mysql 服务
-```bash
+由于本地调试、修改项目时需要使用到 mysql 服务，这里我们可以只用 docker 跑个 mysql 服务
+
+```shell
 docker compose -f docker-compose-dev.yaml up -d
+
+# 老版本 docker 兼容命令
+docker-compose -f docker-compose-dev.yaml up -d
+
+# 或者可以通过 package.json 的命令来启动
+pnpm docker:mysql
 ```
-如果是老版本 docker 应该是`docker-compose -f docker-compose-dev.yaml up -d`  
+
 然后顺序执行下列命令即可
-```bash
+
+```shell
 pnpm install
 pnpm db:init
 pnpm dev

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "lint": "next lint",
     "postinstall": "prisma generate",
     "docker:start": "docker-compose up -d",
+    "docker:mysql": "docker-compose up -d mysql",
     "docker:stop": "docker-compose stop",
     "db:init": "npx prisma migrate dev && node scripts/createCourses.js && node scripts/uploadCourseData.js",
     "db:update": "node scripts/createCourses.js && node scripts/uploadCourseData.js"


### PR DESCRIPTION
由于本地调试或者更改项目时需要用到 mysql 服务，配置 `pnpm docker:mysql` 命令用于单独启动一个 docker mysql 服务方便使用

![](https://github.com/cuixiaorui/earthworm/assets/48991003/07dd57bb-7893-4a88-b6f9-88bb6ff0122c)

当然，停止还是可以使用 `pnpm docker:stop` 来控制

![](https://github.com/cuixiaorui/earthworm/assets/48991003/fdcd6c5d-7206-405b-8cad-00ba61d6e953)
