### PR TITLE
fix: about more courses

### DIFF
--- a/app/course/_components/CourseCard.tsx
+++ b/app/course/_components/CourseCard.tsx
@@ -6,12 +6,15 @@ export function CourseCard({
   course: { id: Course["id"]; title: Course["title"] };
 }) {
   return (
-    <div
-      className="w-52 h-24 bg-indigo-500   rounded-md p-1 
-    shadow-lg hover:bg-indigo-700  cursor-pointer 
-  flex justify-center items-center transition-colors"
-    >
-      <Link className="truncate" href={`/?courseId=${course.id}`}>{course.title}</Link>
-    </div>
+    <Link className="truncate" href={`/?courseId=${course.id}`}>
+      <div
+        className="w-52 h-24 bg-indigo-500 rounded-md p-1 
+        shadow-lg hover:bg-indigo-700  cursor-pointer 
+        flex justify-center items-center transition-colors text-slate-200"
+      >
+        {course.title}
+      </div>
+    </Link>
   );
 }
+

--- a/app/course/page.tsx
+++ b/app/course/page.tsx
@@ -14,8 +14,8 @@ export default async function Course() {
             viewBox="0 0 24 24"
             width="1.2em"
             height="1.2em"
-            className="absolute right-20 top-5 mr-2 h-7 w-7 cursor-pointer 
-         text-gray-400 dark:text-indigo-500"
+            className="absolute right-20 top-5 mr-2 h-7 w-7 cursor-pointer
+            text-gray-400 dark:text-indigo-500"
           >
             <path
               fill="none"
@@ -27,7 +27,7 @@ export default async function Course() {
             ></path>
           </svg>
         </Link>
-        <h1 className="m-4 text-3xl text-indigo-500 ml-0 "> English course </h1>
+        <h1 className="m-4 text-3xl text-indigo-500 ml-0 "> English Course </h1>
       </div>
       <div className="overflow-y-auto scrollbar-hide h-full">
         <ul className="flex gap-14  flex-wrap p-1 overflow-y-auto md:justify-start justify-center">


### PR DESCRIPTION
解决以下问题：

1. 统一课程处标题大写
2. 普通模式下课程文字颜色不够明显
3. 原先的课程只能通过文字点击跳转，现在可以通过点击课程块来跳转

![image](https://github.com/cuixiaorui/earthworm/assets/48991003/313655a9-0c85-48af-b281-7bf46040a741)
