### PR TITLE
fix: correct course data

### DIFF
--- a/scripts/courses/06.json
+++ b/scripts/courses/06.json
@@ -1,912 +1,912 @@
 [
-	{
-		"chinese": "我们",
-		"english": "we",
-		"soundmark": "/wi/"
-	},
-	{
-		"chinese": "喜欢",
-		"english": "like",
-		"soundmark": "/laɪk/"
-	},
-	{
-		"chinese": "我们喜欢",
-		"english": "we like",
-		"soundmark": "/wi/ /laɪk/"
-	},
-	{
-		"chinese": "做",
-		"english": "to do",
-		"soundmark": "/tə/ /du/"
-	},
-	{
-		"chinese": "这件事",
-		"english": "it",
-		"soundmark": "/ɪt/"
-	},
-	{
-		"chinese": "做这件事",
-		"english": "to do it",
-		"soundmark": "/tə/ /du/ /ɪt/"
-	},
-	{
-		"chinese": "我们喜欢做这件事",
-		"english": "we like to do it",
-		"soundmark": "/wi/ /laɪk/ /tə/ /du/ /ɪt/"
-	},
-	{
-		"chinese": "现在",
-		"english": "now",
-		"soundmark": "/naʊ/"
-	},
-	{
-		"chinese": "我们喜欢现在做这件事",
-		"english": "we like to do it now",
-		"soundmark": "/wi/ /laɪk/ /tə/ /du/ /ɪt/ /naʊ/"
-	},
-	{
-		"chinese": "不",
-		"english": "don't",
-		"soundmark": "/dont/"
-	},
-	{
-		"chinese": "我们不喜欢现在做这件事",
-		"english": "we don't like to do it now",
-		"soundmark": "/wi/ /dont/ /laɪk/ /tə/ /du/ /ɪt/ /naʊ/"
-	},
-	{
-		"chinese": "跳舞",
-		"english": "to dance",
-		"soundmark": "/tə/ /dæns/"
-	},
-	{
-		"chinese": "我们喜欢跳舞",
-		"english": "we like to dance",
-		"soundmark": "/wi/ /laɪk/ /tə/ /dæns/"
-	},
-	{
-		"chinese": "我们喜欢现在跳舞",
-		"english": "we like to dance now",
-		"soundmark": "/wi/ /laɪk/ /tə/ /dæns/ /naʊ/"
-	},
-	{
-		"chinese": "街道",
-		"english": "the street",
-		"soundmark": "/ðə/ /strit/"
-	},
-	{
-		"chinese": "在街头",
-		"english": "in the street",
-		"soundmark": "/ɪn/ /ðə/ /strit/"
-	},
-	{
-		"chinese": "我们喜欢在街头跳舞",
-		"english": "we like to dance in the street",
-		"soundmark": "/wi/ /laɪk/ /tə/ /dæns/ /ɪn/ /ðə/ /strit/"
-	},
-	{
-		"chinese": "晚上",
-		"english": "night",
-		"soundmark": "/naɪt/"
-	},
-	{
-		"chinese": "在晚上",
-		"english": "at night",
-		"soundmark": "/ət/ /naɪt/"
-	},
-	{
-		"chinese": "我们喜欢在晚上在街头跳舞",
-		"english": "we like to dance in the street at night",
-		"soundmark": "/wi/ /laɪk/ /tə/ /dæns/ /ɪn/ /ðə/ /strit/ /ət/ /naɪt/"
-	},
-	{
-		"chinese": "我们不喜欢在晚上在街头跳舞",
-		"english": "we don't like to dance in the street at night",
-		"soundmark": "/wi/ /dont/ /laɪk/ /tə/ /dæns/ /ɪn/ /ðə/ /strit/ /ət/ /naɪt/"
-	},
-	{
-		"chinese": "睡觉",
-		"english": "to sleep",
-		"soundmark": "/tə/ /slip/"
-	},
-	{
-		"chinese": "你们",
-		"english": "you",
-		"soundmark": "/ju/"
-	},
-	{
-		"chinese": "你们喜欢",
-		"english": "you like",
-		"soundmark": "/ju/ /laɪk/"
-	},
-	{
-		"chinese": "你们喜欢睡觉",
-		"english": "you like to sleep",
-		"soundmark": "/ju/ /laɪk/ /tə/ /slip/"
-	},
-	{
-		"chinese": "在床上",
-		"english": "on the bed",
-		"soundmark": "/ɑn/ /ðə/ /bɛd/"
-	},
-	{
-		"chinese": "你们喜欢在床上睡觉",
-		"english": "you like to sleep on the bed",
-		"soundmark": "/ju/ /laɪk/ /tə/ /slip/ /ɑn/ /ðə/ /bɛd/"
-	},
-	{
-		"chinese": "不",
-		"english": "don't",
-		"soundmark": "/dont/"
-	},
-	{
-		"chinese": "你们不喜欢在床上睡觉",
-		"english": "you don't like to sleep on the bed",
-		"soundmark": "/ju/ /dont/ /laɪk/ /tə/ /slip/ /ɑn/ /ðə/ /bɛd/"
-	},
-	{
-		"chinese": "我",
-		"english": "me",
-		"soundmark": "/mi/"
-	},
-	{
-		"chinese": "和我一起",
-		"english": "with me",
-		"soundmark": "/wɪð/ /mi/"
-	},
-	{
-		"chinese": "和我一起跳舞",
-		"english": "to dance with me",
-		"soundmark": "/tə/ /dæns/ /wɪð/ /mi/"
-	},
-	{
-		"chinese": "你们喜欢和我一起跳舞",
-		"english": "you like to dance with me",
-		"soundmark": "/ju/ /laɪk/ /tə/ /dæns/ /wɪð/ /mi/"
-	},
-	{
-		"chinese": "你们不喜欢和我一起跳舞",
-		"english": "you don't like to dance with me",
-		"soundmark": "/ju/ /dont/ /laɪk/ /tə/ /dæns/ /wɪð/ /mi/"
-	},
-	{
-		"chinese": "在街头",
-		"english": "in the street",
-		"soundmark": "/ɪn/ /ðə/ /strit/"
-	},
-	{
-		"chinese": "你们不喜欢在街头和我一起跳舞",
-		"english": "you don't like to dance with me in the street",
-		"soundmark": "/ju/ /dont/ /laɪk/ /tə/ /dæns/ /wɪð/ /mi/ /ɪn/ /ðə/ /strit/"
-	},
-	{
-		"chinese": "在晚上",
-		"english": "at night",
-		"soundmark": "/ət/ /naɪt/"
-	},
-	{
-		"chinese": "你们不喜欢在晚上在街头和我一起跳舞",
-		"english": "you don't like to dance with me in the street at night",
-		"soundmark": "/ju/ /dont/ /laɪk/ /tə/ /dæns/ /wɪð/ /mi/ /ɪn/ /ðə/ /strit/ /ət/ /naɪt/"
-	},
-	{
-		"chinese": "说话",
-		"english": "to talk",
-		"soundmark": "/tə/ /tɔk/"
-	},
-	{
-		"chinese": "和我",
-		"english": "with me",
-		"soundmark": "/wɪð/ /mi/"
-	},
-	{
-		"chinese": "和我说话",
-		"english": "to talk with me",
-		"soundmark": "/tə/ /tɔk/ /wɪð/ /mi/"
-	},
-	{
-		"chinese": "他们",
-		"english": "they",
-		"soundmark": "/ðe/"
-	},
-	{
-		"chinese": "他们喜欢和我说话",
-		"english": "they like to talk with me",
-		"soundmark": "/ðe/ /laɪk/ /tə/ /tɔk/ /wɪð/ /mi/"
-	},
-	{
-		"chinese": "他们不喜欢和我说话",
-		"english": "they don't like to talk with me",
-		"soundmark": "/ðe/ /dont/ /laɪk/ /tə/ /tɔk/ /wɪð/ /mi/"
-	},
-	{
-		"chinese": "和你",
-		"english": "with you",
-		"soundmark": "/wɪð/ /ju/"
-	},
-	{
-		"chinese": "和你一起跳舞",
-		"english": "to dance with you",
-		"soundmark": "/tə/ /dæns/ /wɪð/ /ju/"
-	},
-	{
-		"chinese": "他们喜欢和你一起跳舞",
-		"english": "they like to dance with you",
-		"soundmark": "/ðe/ /laɪk/ /tə/ /dæns/ /wɪð/ /ju/"
-	},
-	{
-		"chinese": "他们不喜欢和你一起跳舞",
-		"english": "they don't like to dance with you",
-		"soundmark": "/ðe/ /dont/ /laɪk/ /tə/ /dæns/ /wɪð/ /ju/"
-	},
-	{
-		"chinese": "在街头",
-		"english": "in the street",
-		"soundmark": "/ɪn/ /ðə/ /strit/"
-	},
-	{
-		"chinese": "他们喜欢和你一起在街头跳舞",
-		"english": "they like to dance with you in the street",
-		"soundmark": "/ðe/ /laɪk/ /tə/ /dæns/ /wɪð/ /ju/ /ɪn/ /ðə/ /strit/"
-	},
-	{
-		"chinese": "在晚上",
-		"english": "at night",
-		"soundmark": "/ət/ /naɪt/"
-	},
-	{
-		"chinese": "他们喜欢在晚上和你一起在街头跳舞",
-		"english": "they like to dance with you in the street at night",
-		"soundmark": "/ðe/ /laɪk/ /tə/ /dæns/ /wɪð/ /ju/ /ɪn/ /ðə/ /strit/ /ət/ /naɪt/"
-	},
-	{
-		"chinese": "他们不喜欢在晚上和你一起在街头跳舞",
-		"english": "they don't like to dance with you in the street at night",
-		"soundmark": "/ðe/ /dont/ /laɪk/ /tə/ /dæns/ /wɪð/ /ju/ /ɪn/ /ðə/ /strit/ /ət/ /naɪt/"
-	},
-	{
-		"chinese": "知道",
-		"english": "to know",
-		"soundmark": "/tə/ /no/"
-	},
-	{
-		"chinese": "想要知道",
-		"english": "want to know",
-		"soundmark": "/wɑnt/ /tə/ /no/"
-	},
-	{
-		"chinese": "我们想要知道",
-		"english": "we want to know",
-		"soundmark": "/wi/ /wɑnt/ /tə/ /no/"
-	},
-	{
-		"chinese": "只是",
-		"english": "just",
-		"soundmark": "/dʒʌst/"
-	},
-	{
-		"chinese": "我们只是想要知道",
-		"english": "we just want to know",
-		"soundmark": "/wi/ /dʒʌst/ /wɑnt/ /tə/ /no/"
-	},
-	{
-		"chinese": "是否",
-		"english": "if",
-		"soundmark": "/ɪf/"
-	},
-	{
-		"chinese": "我们只是想要知道是否他们喜欢在晚上和你一起在街头跳舞",
-		"english": "we just want to know if they like to dance with you in the street at night",
-		"soundmark": "/wi/ /dʒʌst/ /wɑnt/ /tə/ /no/ /ɪf/ /ðe/ /laɪk/ /tə/ /dæns/ /wɪð/ /ju/ /ɪn/ /ðə/ /strit/ /ət/ /naɪt/"
-	},
-	{
-		"chinese": "答案",
-		"english": "the answer",
-		"soundmark": "/ði/ /'ænsɚ/"
-	},
-	{
-		"chinese": "我们想要知道答案",
-		"english": "we want to know the answer",
-		"soundmark": "/wi/ /wɑnt/ /tə/ /no/ /ði/ /'ænsɚ/"
-	},
-	{
-		"chinese": "问题",
-		"english": "the question",
-		"soundmark": "/ðə/ /'kwɛstʃən/"
-	},
-	{
-		"chinese": "问题的答案",
-		"english": "the answer to the question",
-		"soundmark": "/ði/ /'ænsɚ/ /tə/ /ðə/ /'kwɛstʃən/"
-	},
-	{
-		"chinese": "我们想要知道问题的答案",
-		"english": "we want to know the answer to the question",
-		"soundmark": "/wi/ /wɑnt/ /tə/ /no/ /ði/ /'ænsɚ/ /tə/ /ðə/ /'kwɛstʃən/"
-	},
-	{
-		"chinese": "我们不想知道问题的答案",
-		"english": "we don't want to know the answer to the question",
-		"soundmark": "/wi/ /dont/ /wɑnt/ /tə/ /no/ /ði/ /'ænsɚ/ /tə/ /ðə/ /'kwɛstʃən/"
-	},
-	{
-		"chinese": "很快",
-		"english": "soon",
-		"soundmark": "/sun/"
-	},
-	{
-		"chinese": "可能",
-		"english": "possible",
-		"soundmark": "/'pɑsəbl/"
-	},
-	{
-		"chinese": "尽快；尽可能地快",
-		"english": "as soon as possible",
-		"soundmark": "/əz/ /sun/ /əz/ /'pɑsəbl/"
-	},
-	{
-		"chinese": "我们想要尽快知道问题的答案",
-		"english": "we want to know the asnwer to the question as soon as possible",
-		"soundmark": "/wi/ /wɑnt/ /tə/ /no/ /ði/ /'ænsɚ/ /tə/ /ðə/ /'kwɛstʃən/ /əz/ /sun/ /əz/ /'pɑsəbl/"
-	},
-	{
-		"chinese": "散步",
-		"english": "to walk",
-		"soundmark": "/tə/ /wɔk/"
-	},
-	{
-		"chinese": "在公园里",
-		"english": "in the park",
-		"soundmark": "/ɪn/ /ðə/ /pɑrk/"
-	},
-	{
-		"chinese": "我们想要在公园里散步",
-		"english": "we want to walk in the park",
-		"soundmark": "/wi/ /wɑnt/ /tə/ /wɔk/ /ɪn/ /ðə/ /pɑrk/"
-	},
-	{
-		"chinese": "每天",
-		"english": "every day",
-		"soundmark": "/'ɛvri/ /de/"
-	},
-	{
-		"chinese": "我们想要每天在公园里散步",
-		"english": "we want to walk in the park every day",
-		"soundmark": "/wi/ /wɑnt/ /tə/ /wɔk/ /ɪn/ /ðə/ /pɑrk/ /'ɛvri/ /de/"
-	},
-	{
-		"chinese": "这个食物",
-		"english": "the food",
-		"soundmark": "/ðə/ /fud/"
-	},
-	{
-		"chinese": "这个餐厅",
-		"english": "the restaurant",
-		"soundmark": "/ðə/ /'rɛstrɑnt/"
-	},
-	{
-		"chinese": "来自这个餐厅",
-		"english": "from the restaurant",
-		"soundmark": "/frʌm/ /ðə/ /'rɛstrɑnt/"
-	},
-	{
-		"chinese": "来自这个餐厅的食物",
-		"english": "the food from the restaurant",
-		"soundmark": "/ðə/ /fud/ /frʌm/ /ðə/ /'rɛstrɑnt/"
-	},
-	{
-		"chinese": "吃",
-		"english": "to eat",
-		"soundmark": "/tə/ /it/"
-	},
-	{
-		"chinese": "吃来自这个餐厅的食物",
-		"english": "to eat the food from the restaurant",
-		"soundmark": "/tə/ /it/ /ðə/ /fud/ /frʌm/ /ðə/ /'rɛstrɑnt/"
-	},
-	{
-		"chinese": "我们想吃来自这个餐厅的食物",
-		"english": "we want to eat the food from the restaurant",
-		"soundmark": "/wi/ /wɑnt/ /tə/ /it/ /ðə/ /fud/ /frʌm/ /ðə/ /'rɛstrɑnt/"
-	},
-	{
-		"chinese": "我们不想吃来自这个餐厅的食物",
-		"english": "we don't want to eat the food from the restaurant",
-		"soundmark": "/wi/ /dont/ /wɑnt/ /tə/ /it/ /ðə/ /fud/ /frʌm/ /ðə/ /'rɛstrɑnt/"
-	},
-	{
-		"chinese": "工作",
-		"english": "to work",
-		"soundmark": "/tə/ /wɝk/"
-	},
-	{
-		"chinese": "这个餐厅",
-		"english": "the restaurant",
-		"soundmark": "/ðə/ /'rɛstrɑnt/"
-	},
-	{
-		"chinese": "在这个餐厅",
-		"english": "at the restaurant",
-		"soundmark": "/ət/ /ðə/ /'rɛstrɑnt/"
-	},
-	{
-		"chinese": "在这个餐厅工作",
-		"english": "to work at the restaurant",
-		"soundmark": "/tə/ /wɝk/ /ət/ /ðə/ /'rɛstrɑnt/"
-	},
-	{
-		"chinese": "我们想要在这个餐厅工作",
-		"english": "we want to work at the restaurant",
-		"soundmark": "/wi/ /wɑnt/ /tə/ /wɝk/ /ət/ /ðə/ /'rɛstrɑnt/"
-	},
-	{
-		"chinese": "我们不想在这个餐厅工作",
-		"english": "we don't want to work at the restaurant",
-		"soundmark": "/wi/ /dont/ /wɑnt/ /tə/ /wɝk/ /ət/ /ðə/ /'rɛstrɑnt/"
-	},
-	{
-		"chinese": "你们想要在这个餐厅工作",
-		"english": "you want to work at the restaurant",
-		"soundmark": "/ju/ /wɑnt/ /tə/ /wɝk/ /ət/ /ðə/ /'rɛstrɑnt/"
-	},
-	{
-		"chinese": "你们不想在这个餐厅工作",
-		"english": "you don't want to work at the restaurant",
-		"soundmark": "/ju/ /dont/ /wɑnt/ /tə/ /wɝk/ /ət/ /ðə/ /'rɛstrɑnt/"
-	},
-	{
-		"chinese": "他们想要在这个餐厅工作",
-		"english": "they want to work at the restaurant",
-		"soundmark": "/ðe/ /wɑnt/ /tə/ /wɝk/ /ət/ /ðə/ /'rɛstrɑnt/"
-	},
-	{
-		"chinese": "他们不想在这个餐厅工作",
-		"english": "they don't want to work at the restaurant",
-		"soundmark": "/ðe/ /dont/ /wɑnt/ /tə/ /wɝk/ /ət/ /ðə/ /'rɛstrɑnt/"
-	},
-	{
-		"chinese": "和你一起",
-		"english": "with you",
-		"soundmark": "/wɪð/ /ju/"
-	},
-	{
-		"chinese": "和你一起工作",
-		"english": "to work with you",
-		"soundmark": "/tə/ /wɝk/ /wɪð/ /ju/"
-	},
-	{
-		"chinese": "他们想要和你一起工作",
-		"english": "they want to work with you",
-		"soundmark": "/ðe/ /wɑnt/ /tə/ /wɝk/ /wɪð/ /ju/"
-	},
-	{
-		"chinese": "他们不想和你一起工作",
-		"english": "they don't want to work with you",
-		"soundmark": "/ðe/ /dont/ /wɑnt/ /tə/ /wɝk/ /wɪð/ /ju/"
-	},
-	{
-		"chinese": "认为",
-		"english": "think",
-		"soundmark": "/θɪŋk/"
-	},
-	{
-		"chinese": "我认为",
-		"english": "I think",
-		"soundmark": "/aɪ/ /θɪŋk/"
-	},
-	{
-		"chinese": "我认为他们想要和你一起工作",
-		"english": "I think they want to work with you",
-		"soundmark": "/aɪ/ /θɪŋk/ /ðe/ /wɑnt/ /tə/ /wɝk/ /wɪð/ /ju/"
-	},
-	{
-		"chinese": "我认为他们不想和你一起工作",
-		"english": "I don't think they want to work with you",
-		"soundmark": "/aɪ/ /dont/ /θɪŋk/ /ðe/ /wɑnt/ /tə/ /wɝk/ /wɪð/ /ju/"
-	},
-	{
-		"chinese": "问题",
-		"english": "the question",
-		"soundmark": "/ðə/ /'kwɛstʃən/"
-	},
-	{
-		"chinese": "问题（们）",
-		"english": "the questions",
-		"soundmark": "/ðə/ /'kwestʃənz/"
-	},
-	{
-		"chinese": "回答",
-		"english": "to answer",
-		"soundmark": "/tə/ /'ænsɚ/"
-	},
-	{
-		"chinese": "回答问题",
-		"english": "to answer the questions",
-		"soundmark": "/tə/ /'ænsɚ/ /ðə/ /'kwestʃənz/"
-	},
-	{
-		"chinese": "我们需要回答问题",
-		"english": "we need to answer the questions",
-		"soundmark": "/wi/ /nid/ /tə/ /'ænsɚ/ /ðə/ /'kwestʃənz/"
-	},
-	{
-		"chinese": "关于",
-		"english": "about",
-		"soundmark": "/ə'baʊt/"
-	},
-	{
-		"chinese": "关于工作",
-		"english": "about the work",
-		"soundmark": "/ə'baʊt/ /ðə/ /wɝk/"
-	},
-	{
-		"chinese": "我们需要回答关于工作的问题",
-		"english": "we need to answer the questions about the work",
-		"soundmark": "/wi/ /nid/ /tə/ /'ænsɚ/ /ðə/ /'kwestʃənz/ /ə'baʊt/ /ðə/ /wɝk/"
-	},
-	{
-		"chinese": "我们不需要回答关于工作的问题",
-		"english": "we don't need to answer the questions about the work",
-		"soundmark": "/wi/ /dont/ /nid/ /tə/ /'ænsɚ/ /ðə/ /'kwestʃənz/ /ə'baʊt/ /ðə/ /wɝk/"
-	},
-	{
-		"chinese": "你们需要回答关于工作的问题",
-		"english": "you need to answer the questions about the work",
-		"soundmark": "/ju/ /nid/ /tə/ /'ænsɚ/ /ðə/ /'kwestʃənz/ /ə'baʊt/ /ðə/ /wɝk/"
-	},
-	{
-		"chinese": "很快",
-		"english": "soon",
-		"soundmark": "/sun/"
-	},
-	{
-		"chinese": "可能",
-		"english": "possible",
-		"soundmark": "/'pɑsəbl/"
-	},
-	{
-		"chinese": "尽快；尽可能地快",
-		"english": "as soon as possible",
-		"soundmark": "/əz/ /sun/ /əz/ /'pɑsəbl/"
-	},
-	{
-		"chinese": "你们需要尽快回答关于工作的问题",
-		"english": "you need to answer the questions about the work as soon as possible",
-		"soundmark": "/ju/ /nid/ /tə/ /'ænsɚ/ /ðə/ /'kwestʃənz/ /ə'baʊt/ /ðə/ /wɝk/ /əz/ /sun/ /əz/ /'pɑsəbl/"
-	},
-	{
-		"chinese": "重要的",
-		"english": "important",
-		"soundmark": "/ɪm'pɔrtnt/"
-	},
-	{
-		"chinese": "它们是重要的",
-		"english": "they are important",
-		"soundmark": "/ðe/ /ɚ/ /ɪm'pɔrtnt/"
-	},
-	{
-		"chinese": "非常",
-		"english": "very",
-		"soundmark": "/ˈvɛri/"
-	},
-	{
-		"chinese": "它们是非常重要的",
-		"english": "they are very important",
-		"soundmark": "/ðe/ /ɚ/ /ˈvɛri/ /ɪm'pɔrtnt/"
-	},
-	{
-		"chinese": "因为",
-		"english": "because",
-		"soundmark": "/bɪ'kɔz/"
-	},
-	{
-		"chinese": "你们需要尽快回答关于工作的问题因为它们是非常重要的",
-		"english": "you need to answer the questions about the work as soon as possible because they are very important",
-		"soundmark": "/ju/ /nid/ /tə/ /'ænsɚ/ /ðə/ /'kwestʃənz/ /ə'baʊt/ /ðə/ /wɝk/ /əz/ /sun/ /əz/ /'pɑsəbl/ /bɪ'kɔz/ /ðe/ /ɚ/ /ˈvɛri/ /ɪm'pɔrtnt/"
-	},
-	{
-		"chinese": "离开",
-		"english": "to leave",
-		"soundmark": "/tə/ /liv/"
-	},
-	{
-		"chinese": "我们必须离开",
-		"english": "we have to leave",
-		"soundmark": "/wi/ /hæv/ /tə/ /liv/"
-	},
-	{
-		"chinese": "现在",
-		"english": "now",
-		"soundmark": "/naʊ/"
-	},
-	{
-		"chinese": "我们必须现在离开",
-		"english": "we have to leave now",
-		"soundmark": "/wi/ /hæv/ /tə/ /liv/ /naʊ/"
-	},
-	{
-		"chinese": "我们不必现在离开",
-		"english": "we don't have to leave now",
-		"soundmark": "/wi/ /dont/ /hæv/ /tə/ /liv/ /naʊ/"
-	},
-	{
-		"chinese": "你们必须现在离开",
-		"english": "you have to leave now",
-		"soundmark": "/ju/ /hæv/ /tə/ /liv/ /naʊ/"
-	},
-	{
-		"chinese": "你们不必现在离开",
-		"english": "you don't have to leave now",
-		"soundmark": "/ju/ /dont/ /hæv/ /tə/ /liv/ /naʊ/"
-	},
-	{
-		"chinese": "这个餐厅",
-		"english": "the restaurant",
-		"soundmark": "/ðə/ /'rɛstrɑnt/"
-	},
-	{
-		"chinese": "你们必须现在离开这个餐厅",
-		"english": "you have to leave the restaurant now",
-		"soundmark": "/ju/ /hæv/ /tə/ /liv/ /ðə/ /'rɛstrɑnt/ /naʊ/"
-	},
-	{
-		"chinese": "你们不必现在离开这个餐厅",
-		"english": "you don't have to leave the restaurant now",
-		"soundmark": "/ju/ /dont/ /hæv/ /tə/ /liv/ /ðə/ /'rɛstrɑnt/ /naʊ/"
-	},
-	{
-		"chinese": "跳舞",
-		"english": "to dance",
-		"soundmark": "/tə/ /dæns/"
-	},
-	{
-		"chinese": "可以",
-		"english": "can",
-		"soundmark": "/kæn/"
-	},
-	{
-		"chinese": "我们可以",
-		"english": "we can",
-		"soundmark": "/wi/ /kæn/"
-	},
-	{
-		"chinese": "我们可以跳舞",
-		"english": "we can dance",
-		"soundmark": "/wi/ /kæn/ /dæns/"
-	},
-	{
-		"chinese": "在街头",
-		"english": "in the street",
-		"soundmark": "/ɪn/ /ðə/ /strit/"
-	},
-	{
-		"chinese": "我们可以在街头跳舞",
-		"english": "we can dance in the street",
-		"soundmark": "/wi/ /kæn/ /dæns/ /ɪn/ /ðə/ /strit/"
-	},
-	{
-		"chinese": "在晚上",
-		"english": "at night",
-		"soundmark": "/ət/ /naɪt/"
-	},
-	{
-		"chinese": "我们可以晚上在街头跳舞",
-		"english": "we can dance in the street at night",
-		"soundmark": "/wi/ /kæn/ /dæns/ /ɪn/ /ðə/ /strit/ /ət/ /naɪt/"
-	},
-	{
-		"chinese": "我们不可以晚上在街头跳舞",
-		"english": "we can not dance in the street at night",
-		"soundmark": "/wi/ /kæn/ /nɑt/ /dæns/ /ɪn/ /ðə/ /strit/ /ət/ /naɪt/"
-	},
-	{
-		"chinese": "工作",
-		"english": "to work",
-		"soundmark": "/tə/ /wɝk/"
-	},
-	{
-		"chinese": "我们可以工作",
-		"english": "we can work",
-		"soundmark": "/wi/ /kæn/ /wɝk/"
-	},
-	{
-		"chinese": "这个餐厅",
-		"english": "the restaurant",
-		"soundmark": "/ðə/ /'rɛstrɑnt/"
-	},
-	{
-		"chinese": "在这个餐厅",
-		"english": "at the restaurant",
-		"soundmark": "/ət/ /ðə/ /'rɛstrɑnt/"
-	},
-	{
-		"chinese": "我们可以在这个餐厅工作",
-		"english": "we can work at the restaurant",
-		"soundmark": "/wi/ /kæn/ /wɝk/ /ət/ /ðə/ /'rɛstrɑnt/"
-	},
-	{
-		"chinese": "我们不可以在这个餐厅工作",
-		"english": "we can not work at the restaurant",
-		"soundmark": "/wi/ /kæn/ /nɑt/ /wɝk/ /ət/ /ðə/ /'rɛstrɑnt/"
-	},
-	{
-		"chinese": "散步",
-		"english": "to walk",
-		"soundmark": "/tə/ /wɔk/"
-	},
-	{
-		"chinese": "我们可以散步",
-		"english": "we can walk",
-		"soundmark": "/wi/ /kæn/ /wɔk/"
-	},
-	{
-		"chinese": "在公园里",
-		"english": "in the park",
-		"soundmark": "/ɪn/ /ðə/ /pɑrk/"
-	},
-	{
-		"chinese": "我们可以在公园里散步",
-		"english": "we can walk in the park",
-		"soundmark": "/wi/ /kæn/ /wɔk/ /ɪn/ /ðə/ /pɑrk/"
-	},
-	{
-		"chinese": "每天",
-		"english": "every day",
-		"soundmark": "/'ɛvri/ /de/"
-	},
-	{
-		"chinese": "我们可以每天在公园里散步",
-		"english": "we can walk in the park every day",
-		"soundmark": "/wi/ /kæn/ /wɔk/ /ɪn/ /ðə/ /pɑrk/ /'ɛvri/ /de/"
-	},
-	{
-		"chinese": "我们不可以每天在公园里散步",
-		"english": "we can not walk in the park every day",
-		"soundmark": "/wi/ /kæn/ /nɑt/ /wɔk/ /ɪn/ /ðə/ /pɑrk/ /'ɛvri/ /de/"
-	},
-	{
-		"chinese": "知道",
-		"english": "to know",
-		"soundmark": "/tə/ /no/"
-	},
-	{
-		"chinese": "应该",
-		"english": "should",
-		"soundmark": "/ʃʊd/"
-	},
-	{
-		"chinese": "我们应该",
-		"english": "we should",
-		"soundmark": "/wi/ /ʃʊd/"
-	},
-	{
-		"chinese": "我们应该知道",
-		"english": "we should know",
-		"soundmark": "/wi/ /ʃʊd/ /no/"
-	},
-	{
-		"chinese": "答案",
-		"english": "the answer",
-		"soundmark": "/ði/ /'ænsɚ/"
-	},
-	{
-		"chinese": "我们应该知道答案",
-		"english": "we should know the answer",
-		"soundmark": "/wi/ /ʃʊd/ /no/ /ði/ /'ænsɚ/"
-	},
-	{
-		"chinese": "这个问题",
-		"english": "the question",
-		"soundmark": "/ðə/ /'kwɛstʃən/"
-	},
-	{
-		"chinese": "这个问题的答案",
-		"english": "the answer to the question",
-		"soundmark": "/ði/ /'ænsɚ/ /tə/ /ðə/ /'kwɛstʃən/"
-	},
-	{
-		"chinese": "我们应该知道这个问题的答案",
-		"english": "we should know the answer to the question",
-		"soundmark": "/wi/ /ʃʊd/ /no/ /ði/ /'ænsɚ/ /tə/ /ðə/ /'kwɛstʃən/"
-	},
-	{
-		"chinese": "我们不应该知道这个问题的答案",
-		"english": "we should not know the answer to the question",
-		"soundmark": "/wi/ /ʃʊd/ /nɑt/ /no/ /ði/ /'ænsɚ/ /tə/ /ðə/ /'kwɛstʃən/"
-	},
-	{
-		"chinese": "我认为",
-		"english": "I think",
-		"soundmark": "/aɪ/ /θɪŋk/"
-	},
-	{
-		"chinese": "我认为我们应该知道这个问题的答案",
-		"english": "I think we should know the answer to the question",
-		"soundmark": "/aɪ/ /θɪŋk/ /wi/ /ʃʊd/ /no/ /ði/ /'ænsɚ/ /tə/ /ðə/ /'kwɛstʃən/"
-	},
-	{
-		"chinese": "我认为我们不应该知道这个问题的答案",
-		"english": "I don't think we should know the answer to the question",
-		"soundmark": "/aɪ/ /dont/ /θɪŋk/ /wi/ /ʃʊd/ /no/ /ði/ /'ænsɚ/ /tə/ /ðə/ /'kwɛstʃən/"
-	},
-	{
-		"chinese": "应该知道",
-		"english": "should know",
-		"soundmark": "/ʃʊd/ /no/"
-	},
-	{
-		"chinese": "你们应该知道",
-		"english": "you should know",
-		"soundmark": "/ju/ /ʃʊd/ /no/"
-	},
-	{
-		"chinese": "原因",
-		"english": "the reason",
-		"soundmark": "/ðə/ /ˈrizən/"
-	},
-	{
-		"chinese": "你们应该知道原因",
-		"english": "you should know the reason",
-		"soundmark": "/ju/ /ʃʊd/ /no/ /ðə/ /ˈrizən/"
-	},
-	{
-		"chinese": "食物",
-		"english": "the food",
-		"soundmark": "/ðə/ /fud/"
-	},
-	{
-		"chinese": "这个餐厅",
-		"english": "the restaurant",
-		"soundmark": "/ðə/ /'rɛstrɑnt/"
-	},
-	{
-		"chinese": "来自这个餐厅的食物",
-		"english": "the food from the restaurant",
-		"soundmark": "/ðə/ /fud/ /frʌm/ /ðə/ /'rɛstrɑnt/"
-	},
-	{
-		"chinese": "吃来自这个餐厅的食物",
-		"english": "to eat the food from the restaurant",
-		"soundmark": "/tə/ /it/ /ðə/ /fud/ /frʌm/ /ðə/ /'rɛstrɑnt/"
-	},
-	{
-		"chinese": "我们想要",
-		"english": "we want",
-		"soundmark": "/wi/ /wɑnt/"
-	},
-	{
-		"chinese": "吃",
-		"english": "to eat",
-		"soundmark": "/tə/ /it/"
-	},
-	{
-		"chinese": "我们想要吃来自这个餐厅的食物",
-		"english": "we want to eat the food from the restaurant",
-		"soundmark": "/wi/ /wɑnt/ /tə/ /it/ /ðə/ /fud/ /frʌm/ /ðə/ /'rɛstrɑnt/"
-	},
-	{
-		"chinese": "我们不想吃来自这个餐厅的食物",
-		"english": "we don't want to eat the food from the restaurant",
-		"soundmark": "/wi/ /dont/ /wɑnt/ /tə/ /it/ /ðə/ /fud/ /frʌm/ /ðə/ /'rɛstrɑnt/"
-	},
-	{
-		"chinese": "为什么",
-		"english": "why",
-		"soundmark": "/waɪ/"
-	},
-	{
-		"chinese": "你应该知道原因为什么我们不想吃来自这个餐厅的食物",
-		"english": "you should know the reason why we don't want to eat the food from the restaurant",
-		"soundmark": "/ju/ /ʃʊd/ /no/ /ðə/ /ˈrizən/ /waɪ/ /wi/ /dont/ /wɑnt/ /tə/ /it/ /ðə/ /fud/ /frʌm/ /ðə/ /'rɛstrɑnt/"
-	},
-	{
-		"chinese": "我认为",
-		"english": "I think",
-		"soundmark": "/aɪ/ /θɪŋk/"
-	},
-	{
-		"chinese": "我认为你应该知道原因为什么我们不想吃来自这个餐厅的食物",
-		"english": "I think you should know the reason why we don't want to eat the food from the restaurant",
-		"soundmark": "/aɪ/ /θɪŋk/ /ju/ /ʃʊd/ /no/ /ðə/ /ˈrizən/ /waɪ/ /wi/ /dont/ /wɑnt/ /tə/ /it/ /ðə/ /fud/ /frʌm/ /ðə/ /'rɛstrɑnt/"
-	}
+  {
+    "chinese": "我们",
+    "english": "we",
+    "soundmark": "/wi/"
+  },
+  {
+    "chinese": "喜欢",
+    "english": "like",
+    "soundmark": "/laɪk/"
+  },
+  {
+    "chinese": "我们喜欢",
+    "english": "we like",
+    "soundmark": "/wi/ /laɪk/"
+  },
+  {
+    "chinese": "做",
+    "english": "to do",
+    "soundmark": "/tə/ /du/"
+  },
+  {
+    "chinese": "这件事",
+    "english": "it",
+    "soundmark": "/ɪt/"
+  },
+  {
+    "chinese": "做这件事",
+    "english": "to do it",
+    "soundmark": "/tə/ /du/ /ɪt/"
+  },
+  {
+    "chinese": "我们喜欢做这件事",
+    "english": "we like to do it",
+    "soundmark": "/wi/ /laɪk/ /tə/ /du/ /ɪt/"
+  },
+  {
+    "chinese": "现在",
+    "english": "now",
+    "soundmark": "/naʊ/"
+  },
+  {
+    "chinese": "我们喜欢现在做这件事",
+    "english": "we like to do it now",
+    "soundmark": "/wi/ /laɪk/ /tə/ /du/ /ɪt/ /naʊ/"
+  },
+  {
+    "chinese": "不",
+    "english": "don't",
+    "soundmark": "/dont/"
+  },
+  {
+    "chinese": "我们不喜欢现在做这件事",
+    "english": "we don't like to do it now",
+    "soundmark": "/wi/ /dont/ /laɪk/ /tə/ /du/ /ɪt/ /naʊ/"
+  },
+  {
+    "chinese": "跳舞",
+    "english": "to dance",
+    "soundmark": "/tə/ /dæns/"
+  },
+  {
+    "chinese": "我们喜欢跳舞",
+    "english": "we like to dance",
+    "soundmark": "/wi/ /laɪk/ /tə/ /dæns/"
+  },
+  {
+    "chinese": "我们喜欢现在跳舞",
+    "english": "we like to dance now",
+    "soundmark": "/wi/ /laɪk/ /tə/ /dæns/ /naʊ/"
+  },
+  {
+    "chinese": "街道",
+    "english": "the street",
+    "soundmark": "/ðə/ /strit/"
+  },
+  {
+    "chinese": "在街头",
+    "english": "in the street",
+    "soundmark": "/ɪn/ /ðə/ /strit/"
+  },
+  {
+    "chinese": "我们喜欢在街头跳舞",
+    "english": "we like to dance in the street",
+    "soundmark": "/wi/ /laɪk/ /tə/ /dæns/ /ɪn/ /ðə/ /strit/"
+  },
+  {
+    "chinese": "晚上",
+    "english": "night",
+    "soundmark": "/naɪt/"
+  },
+  {
+    "chinese": "在晚上",
+    "english": "at night",
+    "soundmark": "/ət/ /naɪt/"
+  },
+  {
+    "chinese": "我们喜欢在晚上在街头跳舞",
+    "english": "we like to dance in the street at night",
+    "soundmark": "/wi/ /laɪk/ /tə/ /dæns/ /ɪn/ /ðə/ /strit/ /ət/ /naɪt/"
+  },
+  {
+    "chinese": "我们不喜欢在晚上在街头跳舞",
+    "english": "we don't like to dance in the street at night",
+    "soundmark": "/wi/ /dont/ /laɪk/ /tə/ /dæns/ /ɪn/ /ðə/ /strit/ /ət/ /naɪt/"
+  },
+  {
+    "chinese": "睡觉",
+    "english": "to sleep",
+    "soundmark": "/tə/ /slip/"
+  },
+  {
+    "chinese": "你们",
+    "english": "you",
+    "soundmark": "/ju/"
+  },
+  {
+    "chinese": "你们喜欢",
+    "english": "you like",
+    "soundmark": "/ju/ /laɪk/"
+  },
+  {
+    "chinese": "你们喜欢睡觉",
+    "english": "you like to sleep",
+    "soundmark": "/ju/ /laɪk/ /tə/ /slip/"
+  },
+  {
+    "chinese": "在床上",
+    "english": "on the bed",
+    "soundmark": "/ɑn/ /ðə/ /bɛd/"
+  },
+  {
+    "chinese": "你们喜欢在床上睡觉",
+    "english": "you like to sleep on the bed",
+    "soundmark": "/ju/ /laɪk/ /tə/ /slip/ /ɑn/ /ðə/ /bɛd/"
+  },
+  {
+    "chinese": "不",
+    "english": "don't",
+    "soundmark": "/dont/"
+  },
+  {
+    "chinese": "你们不喜欢在床上睡觉",
+    "english": "you don't like to sleep on the bed",
+    "soundmark": "/ju/ /dont/ /laɪk/ /tə/ /slip/ /ɑn/ /ðə/ /bɛd/"
+  },
+  {
+    "chinese": "我",
+    "english": "me",
+    "soundmark": "/mi/"
+  },
+  {
+    "chinese": "和我一起",
+    "english": "with me",
+    "soundmark": "/wɪð/ /mi/"
+  },
+  {
+    "chinese": "和我一起跳舞",
+    "english": "to dance with me",
+    "soundmark": "/tə/ /dæns/ /wɪð/ /mi/"
+  },
+  {
+    "chinese": "你们喜欢和我一起跳舞",
+    "english": "you like to dance with me",
+    "soundmark": "/ju/ /laɪk/ /tə/ /dæns/ /wɪð/ /mi/"
+  },
+  {
+    "chinese": "你们不喜欢和我一起跳舞",
+    "english": "you don't like to dance with me",
+    "soundmark": "/ju/ /dont/ /laɪk/ /tə/ /dæns/ /wɪð/ /mi/"
+  },
+  {
+    "chinese": "在街头",
+    "english": "in the street",
+    "soundmark": "/ɪn/ /ðə/ /strit/"
+  },
+  {
+    "chinese": "你们不喜欢在街头和我一起跳舞",
+    "english": "you don't like to dance with me in the street",
+    "soundmark": "/ju/ /dont/ /laɪk/ /tə/ /dæns/ /wɪð/ /mi/ /ɪn/ /ðə/ /strit/"
+  },
+  {
+    "chinese": "在晚上",
+    "english": "at night",
+    "soundmark": "/ət/ /naɪt/"
+  },
+  {
+    "chinese": "你们不喜欢在晚上在街头和我一起跳舞",
+    "english": "you don't like to dance with me in the street at night",
+    "soundmark": "/ju/ /dont/ /laɪk/ /tə/ /dæns/ /wɪð/ /mi/ /ɪn/ /ðə/ /strit/ /ət/ /naɪt/"
+  },
+  {
+    "chinese": "说话",
+    "english": "to talk",
+    "soundmark": "/tə/ /tɔk/"
+  },
+  {
+    "chinese": "和我",
+    "english": "with me",
+    "soundmark": "/wɪð/ /mi/"
+  },
+  {
+    "chinese": "和我说话",
+    "english": "to talk with me",
+    "soundmark": "/tə/ /tɔk/ /wɪð/ /mi/"
+  },
+  {
+    "chinese": "他们",
+    "english": "they",
+    "soundmark": "/ðe/"
+  },
+  {
+    "chinese": "他们喜欢和我说话",
+    "english": "they like to talk with me",
+    "soundmark": "/ðe/ /laɪk/ /tə/ /tɔk/ /wɪð/ /mi/"
+  },
+  {
+    "chinese": "他们不喜欢和我说话",
+    "english": "they don't like to talk with me",
+    "soundmark": "/ðe/ /dont/ /laɪk/ /tə/ /tɔk/ /wɪð/ /mi/"
+  },
+  {
+    "chinese": "和你",
+    "english": "with you",
+    "soundmark": "/wɪð/ /ju/"
+  },
+  {
+    "chinese": "和你一起跳舞",
+    "english": "to dance with you",
+    "soundmark": "/tə/ /dæns/ /wɪð/ /ju/"
+  },
+  {
+    "chinese": "他们喜欢和你一起跳舞",
+    "english": "they like to dance with you",
+    "soundmark": "/ðe/ /laɪk/ /tə/ /dæns/ /wɪð/ /ju/"
+  },
+  {
+    "chinese": "他们不喜欢和你一起跳舞",
+    "english": "they don't like to dance with you",
+    "soundmark": "/ðe/ /dont/ /laɪk/ /tə/ /dæns/ /wɪð/ /ju/"
+  },
+  {
+    "chinese": "在街头",
+    "english": "in the street",
+    "soundmark": "/ɪn/ /ðə/ /strit/"
+  },
+  {
+    "chinese": "他们喜欢和你一起在街头跳舞",
+    "english": "they like to dance with you in the street",
+    "soundmark": "/ðe/ /laɪk/ /tə/ /dæns/ /wɪð/ /ju/ /ɪn/ /ðə/ /strit/"
+  },
+  {
+    "chinese": "在晚上",
+    "english": "at night",
+    "soundmark": "/ət/ /naɪt/"
+  },
+  {
+    "chinese": "他们喜欢在晚上和你一起在街头跳舞",
+    "english": "they like to dance with you in the street at night",
+    "soundmark": "/ðe/ /laɪk/ /tə/ /dæns/ /wɪð/ /ju/ /ɪn/ /ðə/ /strit/ /ət/ /naɪt/"
+  },
+  {
+    "chinese": "他们不喜欢在晚上和你一起在街头跳舞",
+    "english": "they don't like to dance with you in the street at night",
+    "soundmark": "/ðe/ /dont/ /laɪk/ /tə/ /dæns/ /wɪð/ /ju/ /ɪn/ /ðə/ /strit/ /ət/ /naɪt/"
+  },
+  {
+    "chinese": "知道",
+    "english": "to know",
+    "soundmark": "/tə/ /no/"
+  },
+  {
+    "chinese": "想要知道",
+    "english": "want to know",
+    "soundmark": "/wɑnt/ /tə/ /no/"
+  },
+  {
+    "chinese": "我们想要知道",
+    "english": "we want to know",
+    "soundmark": "/wi/ /wɑnt/ /tə/ /no/"
+  },
+  {
+    "chinese": "只是",
+    "english": "just",
+    "soundmark": "/dʒʌst/"
+  },
+  {
+    "chinese": "我们只是想要知道",
+    "english": "we just want to know",
+    "soundmark": "/wi/ /dʒʌst/ /wɑnt/ /tə/ /no/"
+  },
+  {
+    "chinese": "是否",
+    "english": "if",
+    "soundmark": "/ɪf/"
+  },
+  {
+    "chinese": "我们只是想要知道是否他们喜欢在晚上和你一起在街头跳舞",
+    "english": "we just want to know if they like to dance with you in the street at night",
+    "soundmark": "/wi/ /dʒʌst/ /wɑnt/ /tə/ /no/ /ɪf/ /ðe/ /laɪk/ /tə/ /dæns/ /wɪð/ /ju/ /ɪn/ /ðə/ /strit/ /ət/ /naɪt/"
+  },
+  {
+    "chinese": "答案",
+    "english": "the answer",
+    "soundmark": "/ði/ /'ænsɚ/"
+  },
+  {
+    "chinese": "我们想要知道答案",
+    "english": "we want to know the answer",
+    "soundmark": "/wi/ /wɑnt/ /tə/ /no/ /ði/ /'ænsɚ/"
+  },
+  {
+    "chinese": "问题",
+    "english": "the question",
+    "soundmark": "/ðə/ /'kwɛstʃən/"
+  },
+  {
+    "chinese": "问题的答案",
+    "english": "the answer to the question",
+    "soundmark": "/ði/ /'ænsɚ/ /tə/ /ðə/ /'kwɛstʃən/"
+  },
+  {
+    "chinese": "我们想要知道问题的答案",
+    "english": "we want to know the answer to the question",
+    "soundmark": "/wi/ /wɑnt/ /tə/ /no/ /ði/ /'ænsɚ/ /tə/ /ðə/ /'kwɛstʃən/"
+  },
+  {
+    "chinese": "我们不想知道问题的答案",
+    "english": "we don't want to know the answer to the question",
+    "soundmark": "/wi/ /dont/ /wɑnt/ /tə/ /no/ /ði/ /'ænsɚ/ /tə/ /ðə/ /'kwɛstʃən/"
+  },
+  {
+    "chinese": "很快",
+    "english": "soon",
+    "soundmark": "/sun/"
+  },
+  {
+    "chinese": "可能",
+    "english": "possible",
+    "soundmark": "/'pɑsəbl/"
+  },
+  {
+    "chinese": "尽快；尽可能地快",
+    "english": "as soon as possible",
+    "soundmark": "/əz/ /sun/ /əz/ /'pɑsəbl/"
+  },
+  {
+    "chinese": "我们想要尽快知道问题的答案",
+    "english": "we want to know the answer to the question as soon as possible",
+    "soundmark": "/wi/ /wɑnt/ /tə/ /no/ /ði/ /'ænsɚ/ /tə/ /ðə/ /'kwɛstʃən/ /əz/ /sun/ /əz/ /'pɑsəbl/"
+  },
+  {
+    "chinese": "散步",
+    "english": "to walk",
+    "soundmark": "/tə/ /wɔk/"
+  },
+  {
+    "chinese": "在公园里",
+    "english": "in the park",
+    "soundmark": "/ɪn/ /ðə/ /pɑrk/"
+  },
+  {
+    "chinese": "我们想要在公园里散步",
+    "english": "we want to walk in the park",
+    "soundmark": "/wi/ /wɑnt/ /tə/ /wɔk/ /ɪn/ /ðə/ /pɑrk/"
+  },
+  {
+    "chinese": "每天",
+    "english": "every day",
+    "soundmark": "/'ɛvri/ /de/"
+  },
+  {
+    "chinese": "我们想要每天在公园里散步",
+    "english": "we want to walk in the park every day",
+    "soundmark": "/wi/ /wɑnt/ /tə/ /wɔk/ /ɪn/ /ðə/ /pɑrk/ /'ɛvri/ /de/"
+  },
+  {
+    "chinese": "这个食物",
+    "english": "the food",
+    "soundmark": "/ðə/ /fud/"
+  },
+  {
+    "chinese": "这个餐厅",
+    "english": "the restaurant",
+    "soundmark": "/ðə/ /'rɛstrɑnt/"
+  },
+  {
+    "chinese": "来自这个餐厅",
+    "english": "from the restaurant",
+    "soundmark": "/frʌm/ /ðə/ /'rɛstrɑnt/"
+  },
+  {
+    "chinese": "来自这个餐厅的食物",
+    "english": "the food from the restaurant",
+    "soundmark": "/ðə/ /fud/ /frʌm/ /ðə/ /'rɛstrɑnt/"
+  },
+  {
+    "chinese": "吃",
+    "english": "to eat",
+    "soundmark": "/tə/ /it/"
+  },
+  {
+    "chinese": "吃来自这个餐厅的食物",
+    "english": "to eat the food from the restaurant",
+    "soundmark": "/tə/ /it/ /ðə/ /fud/ /frʌm/ /ðə/ /'rɛstrɑnt/"
+  },
+  {
+    "chinese": "我们想吃来自这个餐厅的食物",
+    "english": "we want to eat the food from the restaurant",
+    "soundmark": "/wi/ /wɑnt/ /tə/ /it/ /ðə/ /fud/ /frʌm/ /ðə/ /'rɛstrɑnt/"
+  },
+  {
+    "chinese": "我们不想吃来自这个餐厅的食物",
+    "english": "we don't want to eat the food from the restaurant",
+    "soundmark": "/wi/ /dont/ /wɑnt/ /tə/ /it/ /ðə/ /fud/ /frʌm/ /ðə/ /'rɛstrɑnt/"
+  },
+  {
+    "chinese": "工作",
+    "english": "to work",
+    "soundmark": "/tə/ /wɝk/"
+  },
+  {
+    "chinese": "这个餐厅",
+    "english": "the restaurant",
+    "soundmark": "/ðə/ /'rɛstrɑnt/"
+  },
+  {
+    "chinese": "在这个餐厅",
+    "english": "at the restaurant",
+    "soundmark": "/ət/ /ðə/ /'rɛstrɑnt/"
+  },
+  {
+    "chinese": "在这个餐厅工作",
+    "english": "to work at the restaurant",
+    "soundmark": "/tə/ /wɝk/ /ət/ /ðə/ /'rɛstrɑnt/"
+  },
+  {
+    "chinese": "我们想要在这个餐厅工作",
+    "english": "we want to work at the restaurant",
+    "soundmark": "/wi/ /wɑnt/ /tə/ /wɝk/ /ət/ /ðə/ /'rɛstrɑnt/"
+  },
+  {
+    "chinese": "我们不想在这个餐厅工作",
+    "english": "we don't want to work at the restaurant",
+    "soundmark": "/wi/ /dont/ /wɑnt/ /tə/ /wɝk/ /ət/ /ðə/ /'rɛstrɑnt/"
+  },
+  {
+    "chinese": "你们想要在这个餐厅工作",
+    "english": "you want to work at the restaurant",
+    "soundmark": "/ju/ /wɑnt/ /tə/ /wɝk/ /ət/ /ðə/ /'rɛstrɑnt/"
+  },
+  {
+    "chinese": "你们不想在这个餐厅工作",
+    "english": "you don't want to work at the restaurant",
+    "soundmark": "/ju/ /dont/ /wɑnt/ /tə/ /wɝk/ /ət/ /ðə/ /'rɛstrɑnt/"
+  },
+  {
+    "chinese": "他们想要在这个餐厅工作",
+    "english": "they want to work at the restaurant",
+    "soundmark": "/ðe/ /wɑnt/ /tə/ /wɝk/ /ət/ /ðə/ /'rɛstrɑnt/"
+  },
+  {
+    "chinese": "他们不想在这个餐厅工作",
+    "english": "they don't want to work at the restaurant",
+    "soundmark": "/ðe/ /dont/ /wɑnt/ /tə/ /wɝk/ /ət/ /ðə/ /'rɛstrɑnt/"
+  },
+  {
+    "chinese": "和你一起",
+    "english": "with you",
+    "soundmark": "/wɪð/ /ju/"
+  },
+  {
+    "chinese": "和你一起工作",
+    "english": "to work with you",
+    "soundmark": "/tə/ /wɝk/ /wɪð/ /ju/"
+  },
+  {
+    "chinese": "他们想要和你一起工作",
+    "english": "they want to work with you",
+    "soundmark": "/ðe/ /wɑnt/ /tə/ /wɝk/ /wɪð/ /ju/"
+  },
+  {
+    "chinese": "他们不想和你一起工作",
+    "english": "they don't want to work with you",
+    "soundmark": "/ðe/ /dont/ /wɑnt/ /tə/ /wɝk/ /wɪð/ /ju/"
+  },
+  {
+    "chinese": "认为",
+    "english": "think",
+    "soundmark": "/θɪŋk/"
+  },
+  {
+    "chinese": "我认为",
+    "english": "I think",
+    "soundmark": "/aɪ/ /θɪŋk/"
+  },
+  {
+    "chinese": "我认为他们想要和你一起工作",
+    "english": "I think they want to work with you",
+    "soundmark": "/aɪ/ /θɪŋk/ /ðe/ /wɑnt/ /tə/ /wɝk/ /wɪð/ /ju/"
+  },
+  {
+    "chinese": "我认为他们不想和你一起工作",
+    "english": "I don't think they want to work with you",
+    "soundmark": "/aɪ/ /dont/ /θɪŋk/ /ðe/ /wɑnt/ /tə/ /wɝk/ /wɪð/ /ju/"
+  },
+  {
+    "chinese": "问题",
+    "english": "the question",
+    "soundmark": "/ðə/ /'kwɛstʃən/"
+  },
+  {
+    "chinese": "问题（们）",
+    "english": "the questions",
+    "soundmark": "/ðə/ /'kwestʃənz/"
+  },
+  {
+    "chinese": "回答",
+    "english": "to answer",
+    "soundmark": "/tə/ /'ænsɚ/"
+  },
+  {
+    "chinese": "回答问题",
+    "english": "to answer the questions",
+    "soundmark": "/tə/ /'ænsɚ/ /ðə/ /'kwestʃənz/"
+  },
+  {
+    "chinese": "我们需要回答问题",
+    "english": "we need to answer the questions",
+    "soundmark": "/wi/ /nid/ /tə/ /'ænsɚ/ /ðə/ /'kwestʃənz/"
+  },
+  {
+    "chinese": "关于",
+    "english": "about",
+    "soundmark": "/ə'baʊt/"
+  },
+  {
+    "chinese": "关于工作",
+    "english": "about the work",
+    "soundmark": "/ə'baʊt/ /ðə/ /wɝk/"
+  },
+  {
+    "chinese": "我们需要回答关于工作的问题",
+    "english": "we need to answer the questions about the work",
+    "soundmark": "/wi/ /nid/ /tə/ /'ænsɚ/ /ðə/ /'kwestʃənz/ /ə'baʊt/ /ðə/ /wɝk/"
+  },
+  {
+    "chinese": "我们不需要回答关于工作的问题",
+    "english": "we don't need to answer the questions about the work",
+    "soundmark": "/wi/ /dont/ /nid/ /tə/ /'ænsɚ/ /ðə/ /'kwestʃənz/ /ə'baʊt/ /ðə/ /wɝk/"
+  },
+  {
+    "chinese": "你们需要回答关于工作的问题",
+    "english": "you need to answer the questions about the work",
+    "soundmark": "/ju/ /nid/ /tə/ /'ænsɚ/ /ðə/ /'kwestʃənz/ /ə'baʊt/ /ðə/ /wɝk/"
+  },
+  {
+    "chinese": "很快",
+    "english": "soon",
+    "soundmark": "/sun/"
+  },
+  {
+    "chinese": "可能",
+    "english": "possible",
+    "soundmark": "/'pɑsəbl/"
+  },
+  {
+    "chinese": "尽快；尽可能地快",
+    "english": "as soon as possible",
+    "soundmark": "/əz/ /sun/ /əz/ /'pɑsəbl/"
+  },
+  {
+    "chinese": "你们需要尽快回答关于工作的问题",
+    "english": "you need to answer the questions about the work as soon as possible",
+    "soundmark": "/ju/ /nid/ /tə/ /'ænsɚ/ /ðə/ /'kwestʃənz/ /ə'baʊt/ /ðə/ /wɝk/ /əz/ /sun/ /əz/ /'pɑsəbl/"
+  },
+  {
+    "chinese": "重要的",
+    "english": "important",
+    "soundmark": "/ɪm'pɔrtnt/"
+  },
+  {
+    "chinese": "它们是重要的",
+    "english": "they are important",
+    "soundmark": "/ðe/ /ɚ/ /ɪm'pɔrtnt/"
+  },
+  {
+    "chinese": "非常",
+    "english": "very",
+    "soundmark": "/ˈvɛri/"
+  },
+  {
+    "chinese": "它们是非常重要的",
+    "english": "they are very important",
+    "soundmark": "/ðe/ /ɚ/ /ˈvɛri/ /ɪm'pɔrtnt/"
+  },
+  {
+    "chinese": "因为",
+    "english": "because",
+    "soundmark": "/bɪ'kɔz/"
+  },
+  {
+    "chinese": "你们需要尽快回答关于工作的问题因为它们是非常重要的",
+    "english": "you need to answer the questions about the work as soon as possible because they are very important",
+    "soundmark": "/ju/ /nid/ /tə/ /'ænsɚ/ /ðə/ /'kwestʃənz/ /ə'baʊt/ /ðə/ /wɝk/ /əz/ /sun/ /əz/ /'pɑsəbl/ /bɪ'kɔz/ /ðe/ /ɚ/ /ˈvɛri/ /ɪm'pɔrtnt/"
+  },
+  {
+    "chinese": "离开",
+    "english": "to leave",
+    "soundmark": "/tə/ /liv/"
+  },
+  {
+    "chinese": "我们必须离开",
+    "english": "we have to leave",
+    "soundmark": "/wi/ /hæv/ /tə/ /liv/"
+  },
+  {
+    "chinese": "现在",
+    "english": "now",
+    "soundmark": "/naʊ/"
+  },
+  {
+    "chinese": "我们必须现在离开",
+    "english": "we have to leave now",
+    "soundmark": "/wi/ /hæv/ /tə/ /liv/ /naʊ/"
+  },
+  {
+    "chinese": "我们不必现在离开",
+    "english": "we don't have to leave now",
+    "soundmark": "/wi/ /dont/ /hæv/ /tə/ /liv/ /naʊ/"
+  },
+  {
+    "chinese": "你们必须现在离开",
+    "english": "you have to leave now",
+    "soundmark": "/ju/ /hæv/ /tə/ /liv/ /naʊ/"
+  },
+  {
+    "chinese": "你们不必现在离开",
+    "english": "you don't have to leave now",
+    "soundmark": "/ju/ /dont/ /hæv/ /tə/ /liv/ /naʊ/"
+  },
+  {
+    "chinese": "这个餐厅",
+    "english": "the restaurant",
+    "soundmark": "/ðə/ /'rɛstrɑnt/"
+  },
+  {
+    "chinese": "你们必须现在离开这个餐厅",
+    "english": "you have to leave the restaurant now",
+    "soundmark": "/ju/ /hæv/ /tə/ /liv/ /ðə/ /'rɛstrɑnt/ /naʊ/"
+  },
+  {
+    "chinese": "你们不必现在离开这个餐厅",
+    "english": "you don't have to leave the restaurant now",
+    "soundmark": "/ju/ /dont/ /hæv/ /tə/ /liv/ /ðə/ /'rɛstrɑnt/ /naʊ/"
+  },
+  {
+    "chinese": "跳舞",
+    "english": "to dance",
+    "soundmark": "/tə/ /dæns/"
+  },
+  {
+    "chinese": "可以",
+    "english": "can",
+    "soundmark": "/kæn/"
+  },
+  {
+    "chinese": "我们可以",
+    "english": "we can",
+    "soundmark": "/wi/ /kæn/"
+  },
+  {
+    "chinese": "我们可以跳舞",
+    "english": "we can dance",
+    "soundmark": "/wi/ /kæn/ /dæns/"
+  },
+  {
+    "chinese": "在街头",
+    "english": "in the street",
+    "soundmark": "/ɪn/ /ðə/ /strit/"
+  },
+  {
+    "chinese": "我们可以在街头跳舞",
+    "english": "we can dance in the street",
+    "soundmark": "/wi/ /kæn/ /dæns/ /ɪn/ /ðə/ /strit/"
+  },
+  {
+    "chinese": "在晚上",
+    "english": "at night",
+    "soundmark": "/ət/ /naɪt/"
+  },
+  {
+    "chinese": "我们可以晚上在街头跳舞",
+    "english": "we can dance in the street at night",
+    "soundmark": "/wi/ /kæn/ /dæns/ /ɪn/ /ðə/ /strit/ /ət/ /naɪt/"
+  },
+  {
+    "chinese": "我们不可以晚上在街头跳舞",
+    "english": "we can not dance in the street at night",
+    "soundmark": "/wi/ /kæn/ /nɑt/ /dæns/ /ɪn/ /ðə/ /strit/ /ət/ /naɪt/"
+  },
+  {
+    "chinese": "工作",
+    "english": "to work",
+    "soundmark": "/tə/ /wɝk/"
+  },
+  {
+    "chinese": "我们可以工作",
+    "english": "we can work",
+    "soundmark": "/wi/ /kæn/ /wɝk/"
+  },
+  {
+    "chinese": "这个餐厅",
+    "english": "the restaurant",
+    "soundmark": "/ðə/ /'rɛstrɑnt/"
+  },
+  {
+    "chinese": "在这个餐厅",
+    "english": "at the restaurant",
+    "soundmark": "/ət/ /ðə/ /'rɛstrɑnt/"
+  },
+  {
+    "chinese": "我们可以在这个餐厅工作",
+    "english": "we can work at the restaurant",
+    "soundmark": "/wi/ /kæn/ /wɝk/ /ət/ /ðə/ /'rɛstrɑnt/"
+  },
+  {
+    "chinese": "我们不可以在这个餐厅工作",
+    "english": "we can not work at the restaurant",
+    "soundmark": "/wi/ /kæn/ /nɑt/ /wɝk/ /ət/ /ðə/ /'rɛstrɑnt/"
+  },
+  {
+    "chinese": "散步",
+    "english": "to walk",
+    "soundmark": "/tə/ /wɔk/"
+  },
+  {
+    "chinese": "我们可以散步",
+    "english": "we can walk",
+    "soundmark": "/wi/ /kæn/ /wɔk/"
+  },
+  {
+    "chinese": "在公园里",
+    "english": "in the park",
+    "soundmark": "/ɪn/ /ðə/ /pɑrk/"
+  },
+  {
+    "chinese": "我们可以在公园里散步",
+    "english": "we can walk in the park",
+    "soundmark": "/wi/ /kæn/ /wɔk/ /ɪn/ /ðə/ /pɑrk/"
+  },
+  {
+    "chinese": "每天",
+    "english": "every day",
+    "soundmark": "/'ɛvri/ /de/"
+  },
+  {
+    "chinese": "我们可以每天在公园里散步",
+    "english": "we can walk in the park every day",
+    "soundmark": "/wi/ /kæn/ /wɔk/ /ɪn/ /ðə/ /pɑrk/ /'ɛvri/ /de/"
+  },
+  {
+    "chinese": "我们不可以每天在公园里散步",
+    "english": "we can not walk in the park every day",
+    "soundmark": "/wi/ /kæn/ /nɑt/ /wɔk/ /ɪn/ /ðə/ /pɑrk/ /'ɛvri/ /de/"
+  },
+  {
+    "chinese": "知道",
+    "english": "to know",
+    "soundmark": "/tə/ /no/"
+  },
+  {
+    "chinese": "应该",
+    "english": "should",
+    "soundmark": "/ʃʊd/"
+  },
+  {
+    "chinese": "我们应该",
+    "english": "we should",
+    "soundmark": "/wi/ /ʃʊd/"
+  },
+  {
+    "chinese": "我们应该知道",
+    "english": "we should know",
+    "soundmark": "/wi/ /ʃʊd/ /no/"
+  },
+  {
+    "chinese": "答案",
+    "english": "the answer",
+    "soundmark": "/ði/ /'ænsɚ/"
+  },
+  {
+    "chinese": "我们应该知道答案",
+    "english": "we should know the answer",
+    "soundmark": "/wi/ /ʃʊd/ /no/ /ði/ /'ænsɚ/"
+  },
+  {
+    "chinese": "这个问题",
+    "english": "the question",
+    "soundmark": "/ðə/ /'kwɛstʃən/"
+  },
+  {
+    "chinese": "这个问题的答案",
+    "english": "the answer to the question",
+    "soundmark": "/ði/ /'ænsɚ/ /tə/ /ðə/ /'kwɛstʃən/"
+  },
+  {
+    "chinese": "我们应该知道这个问题的答案",
+    "english": "we should know the answer to the question",
+    "soundmark": "/wi/ /ʃʊd/ /no/ /ði/ /'ænsɚ/ /tə/ /ðə/ /'kwɛstʃən/"
+  },
+  {
+    "chinese": "我们不应该知道这个问题的答案",
+    "english": "we should not know the answer to the question",
+    "soundmark": "/wi/ /ʃʊd/ /nɑt/ /no/ /ði/ /'ænsɚ/ /tə/ /ðə/ /'kwɛstʃən/"
+  },
+  {
+    "chinese": "我认为",
+    "english": "I think",
+    "soundmark": "/aɪ/ /θɪŋk/"
+  },
+  {
+    "chinese": "我认为我们应该知道这个问题的答案",
+    "english": "I think we should know the answer to the question",
+    "soundmark": "/aɪ/ /θɪŋk/ /wi/ /ʃʊd/ /no/ /ði/ /'ænsɚ/ /tə/ /ðə/ /'kwɛstʃən/"
+  },
+  {
+    "chinese": "我认为我们不应该知道这个问题的答案",
+    "english": "I don't think we should know the answer to the question",
+    "soundmark": "/aɪ/ /dont/ /θɪŋk/ /wi/ /ʃʊd/ /no/ /ði/ /'ænsɚ/ /tə/ /ðə/ /'kwɛstʃən/"
+  },
+  {
+    "chinese": "应该知道",
+    "english": "should know",
+    "soundmark": "/ʃʊd/ /no/"
+  },
+  {
+    "chinese": "你们应该知道",
+    "english": "you should know",
+    "soundmark": "/ju/ /ʃʊd/ /no/"
+  },
+  {
+    "chinese": "原因",
+    "english": "the reason",
+    "soundmark": "/ðə/ /ˈrizən/"
+  },
+  {
+    "chinese": "你们应该知道原因",
+    "english": "you should know the reason",
+    "soundmark": "/ju/ /ʃʊd/ /no/ /ðə/ /ˈrizən/"
+  },
+  {
+    "chinese": "食物",
+    "english": "the food",
+    "soundmark": "/ðə/ /fud/"
+  },
+  {
+    "chinese": "这个餐厅",
+    "english": "the restaurant",
+    "soundmark": "/ðə/ /'rɛstrɑnt/"
+  },
+  {
+    "chinese": "来自这个餐厅的食物",
+    "english": "the food from the restaurant",
+    "soundmark": "/ðə/ /fud/ /frʌm/ /ðə/ /'rɛstrɑnt/"
+  },
+  {
+    "chinese": "吃来自这个餐厅的食物",
+    "english": "to eat the food from the restaurant",
+    "soundmark": "/tə/ /it/ /ðə/ /fud/ /frʌm/ /ðə/ /'rɛstrɑnt/"
+  },
+  {
+    "chinese": "我们想要",
+    "english": "we want",
+    "soundmark": "/wi/ /wɑnt/"
+  },
+  {
+    "chinese": "吃",
+    "english": "to eat",
+    "soundmark": "/tə/ /it/"
+  },
+  {
+    "chinese": "我们想要吃来自这个餐厅的食物",
+    "english": "we want to eat the food from the restaurant",
+    "soundmark": "/wi/ /wɑnt/ /tə/ /it/ /ðə/ /fud/ /frʌm/ /ðə/ /'rɛstrɑnt/"
+  },
+  {
+    "chinese": "我们不想吃来自这个餐厅的食物",
+    "english": "we don't want to eat the food from the restaurant",
+    "soundmark": "/wi/ /dont/ /wɑnt/ /tə/ /it/ /ðə/ /fud/ /frʌm/ /ðə/ /'rɛstrɑnt/"
+  },
+  {
+    "chinese": "为什么",
+    "english": "why",
+    "soundmark": "/waɪ/"
+  },
+  {
+    "chinese": "你应该知道原因为什么我们不想吃来自这个餐厅的食物",
+    "english": "you should know the reason why we don't want to eat the food from the restaurant",
+    "soundmark": "/ju/ /ʃʊd/ /no/ /ðə/ /ˈrizən/ /waɪ/ /wi/ /dont/ /wɑnt/ /tə/ /it/ /ðə/ /fud/ /frʌm/ /ðə/ /'rɛstrɑnt/"
+  },
+  {
+    "chinese": "我认为",
+    "english": "I think",
+    "soundmark": "/aɪ/ /θɪŋk/"
+  },
+  {
+    "chinese": "我认为你应该知道原因为什么我们不想吃来自这个餐厅的食物",
+    "english": "I think you should know the reason why we don't want to eat the food from the restaurant",
+    "soundmark": "/aɪ/ /θɪŋk/ /ju/ /ʃʊd/ /no/ /ðə/ /ˈrizən/ /waɪ/ /wi/ /dont/ /wɑnt/ /tə/ /it/ /ðə/ /fud/ /frʌm/ /ðə/ /'rɛstrɑnt/"
+  }
 ]

--- a/scripts/courses/10.json
+++ b/scripts/courses/10.json
@@ -1,957 +1,957 @@
 [
-	{
-		"chinese": "告诉",
-		"english": "to tell",
-		"soundmark": "/tə/ /tɛl/"
-	},
-	{
-		"chinese": "你",
-		"english": "you",
-		"soundmark": "/ju/"
-	},
-	{
-		"chinese": "告诉你",
-		"english": "to tell you",
-		"soundmark": "/tə/ /tɛl/ /ju/"
-	},
-	{
-		"chinese": "某些事情；某些东西",
-		"english": "something",
-		"soundmark": "/'sʌmθɪŋ/"
-	},
-	{
-		"chinese": "重要的",
-		"english": "important",
-		"soundmark": "/ɪm'pɔrtnt/"
-	},
-	{
-		"chinese": "重要的某些事情",
-		"english": "something important",
-		"soundmark": "/'sʌmθɪŋ/ /ɪm'pɔrtnt/"
-	},
-	{
-		"chinese": "告诉你重要的某些事情",
-		"english": "to tell you something important",
-		"soundmark": "/tə/ /tɛl/ /ju/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/"
-	},
-	{
-		"chinese": "想要",
-		"english": "want",
-		"soundmark": "/wɑnt/"
-	},
-	{
-		"chinese": "我想要告诉你重要的某些事情",
-		"english": "I want to tell you something important",
-		"soundmark": "/aɪ/ /wɑnt/ /tə/ /tɛl/ /ju/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/"
-	},
-	{
-		"chinese": "教",
-		"english": "to teach",
-		"soundmark": "/tə/ /titʃ/"
-	},
-	{
-		"chinese": "某些事情；某些东西",
-		"english": "something",
-		"soundmark": "/'sʌmθɪŋ/"
-	},
-	{
-		"chinese": "重要的某些东西",
-		"english": "something important",
-		"soundmark": "/'sʌmθɪŋ/ /ɪm'pɔrtnt/"
-	},
-	{
-		"chinese": "我想要教你重要的某些东西",
-		"english": "I want to teach you something important",
-		"soundmark": "/aɪ/ /wɑnt/ /tə/ /titʃ/ /ju/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/"
-	},
-	{
-		"chinese": "任何东西",
-		"english": "anything",
-		"soundmark": "/'ɛnɪθɪŋ/"
-	},
-	{
-		"chinese": "任何重要的东西",
-		"english": "anything important",
-		"soundmark": "/'ɛnɪθɪŋ/ /ɪm'pɔrtnt/"
-	},
-	{
-		"chinese": "我不想教你任何重要的东西",
-		"english": "I don't want to teach you anything important",
-		"soundmark": "/aɪ/ /wɑnt/ /tə/ /titʃ/ /ju/ /'ɛnɪθɪŋ/ /ɪm'pɔrtnt/"
-	},
-	{
-		"chinese": "一堂课",
-		"english": "a lesson",
-		"soundmark": "/ə/ /'lɛsn/"
-	},
-	{
-		"chinese": "我想要教你一堂课",
-		"english": "（我想要给你上一课） I want to teach you a lesson",
-		"soundmark": "/aɪ/ /wɑnt/ /tə/ /titʃ/ /ju/ /ə/ /'lɛsn/"
-	},
-	{
-		"chinese": "我必须给你上一课",
-		"english": "I have to teach you a lesson",
-		"soundmark": "/aɪ/ /hæv/ /tə/ /titʃ/ /ju/ /ə/ /'lɛsn/"
-	},
-	{
-		"chinese": "我将会给你上一课",
-		"english": "I will teach you a lesson",
-		"soundmark": "/aɪ/ /wɪl/ /tə/ /titʃ/ /ju/ /ə/ /'lɛsn/"
-	},
-	{
-		"chinese": "教他",
-		"english": "to teach him",
-		"soundmark": "/tə/ /titʃ/ /hɪm/"
-	},
-	{
-		"chinese": "你必须教他一堂课",
-		"english": "（你必须给他上一课） you have to teach him a lesson",
-		"soundmark": "/ju/ /hæv/ /tə/ /titʃ/ /hɪm/ /ə/ /'lɛsn/"
-	},
-	{
-		"chinese": "使用",
-		"english": "to use",
-		"soundmark": "/tə/ /juz/"
-	},
-	{
-		"chinese": "字典",
-		"english": "the dictionary",
-		"soundmark": "/ðə/ /'dɪkʃənɛri/"
-	},
-	{
-		"chinese": "使用字典",
-		"english": "to use the dictionary",
-		"soundmark": "/tə/ /juz/ /ðə/ /'dɪkʃənɛri/"
-	},
-	{
-		"chinese": "如何",
-		"english": "how",
-		"soundmark": "/haʊ/"
-	},
-	{
-		"chinese": "如何使用字典",
-		"english": "how to use the dictionary",
-		"soundmark": "/haʊ/ /tə/ /juz/ /ðə/ /'dɪkʃənɛri/"
-	},
-	{
-		"chinese": "你必须教我",
-		"english": "you have to teach me",
-		"soundmark": "/ju/ /hæv/ /tə/ /titʃ/ /mi/"
-	},
-	{
-		"chinese": "你必须教我如何使用字典",
-		"english": "you have to teach me how to use the dictionary",
-		"soundmark": "/ju/ /hæv/ /tə/ /titʃ/ /mi/ /haʊ/ /tə/ /juz/ /ðə/ /'dɪkʃənɛri/"
-	},
-	{
-		"chinese": "你不必教我如何使用字典",
-		"english": "you don't have to teach me how to use the dictionary",
-		"soundmark": "/ju/ /dont/ /hæv/ /tə/ /titʃ/ /mi/ /haʊ/ /tə/ /juz/ /ðə/ /'dɪkʃənɛri/"
-	},
-	{
-		"chinese": "网络",
-		"english": "the internet",
-		"soundmark": "/ði/ /ˈɪntərnɛt/"
-	},
-	{
-		"chinese": "使用网络",
-		"english": "to use the internet",
-		"soundmark": "/tə/ /juz/ /ði/ /ˈɪntərnɛt/"
-	},
-	{
-		"chinese": "如何使用网络",
-		"english": "how to use the internet",
-		"soundmark": "/haʊ/ /tə/ /juz/ /ði/ /ˈɪntərnɛt/"
-	},
-	{
-		"chinese": "你必须教我如何使用网络",
-		"english": "you have to teach me how to use the internet",
-		"soundmark": "/ju/ /hæv/ /tə/ /titʃ/ /mi/ /haʊ/ /tə/ /juz/ /ði/ /ˈɪntərnɛt/"
-	},
-	{
-		"chinese": "你不必教我如何使用网络",
-		"english": "you don't have to teach me how to use the internet",
-		"soundmark": "/ju/ /dont/ /hæv/ /tə/ /titʃ/ /mi/ /haʊ/ /tə/ /juz/ /ði/ /ˈɪntərnɛt/"
-	},
-	{
-		"chinese": "做饭",
-		"english": "to cook",
-		"soundmark": "/tə/ /kʊk/"
-	},
-	{
-		"chinese": "如何做饭",
-		"english": "how to cook",
-		"soundmark": "/haʊ/ /tə/ /kʊk/"
-	},
-	{
-		"chinese": "你需要教我如何做饭",
-		"english": "you need to teach me how to cook",
-		"soundmark": "/ju/ /nid/ /tə/ /titʃ/ /mi/ /haʊ/ /tə/ /kʊk/"
-	},
-	{
-		"chinese": "不需要",
-		"english": "don't need",
-		"soundmark": "/dont/ /nid/"
-	},
-	{
-		"chinese": "你不需要教我如何做饭",
-		"english": "you don't need to teach me how to cook",
-		"soundmark": "/ju/ /dont/ /nid/ /tə/ /titʃ/ /mi/ /haʊ/ /tə/ /kʊk/"
-	},
-	{
-		"chinese": "我想要你",
-		"english": "I want you",
-		"soundmark": "/aɪ/ /wɑnt/ /ju/"
-	},
-	{
-		"chinese": "教我如何做饭",
-		"english": "to teach me how to cook",
-		"soundmark": "/tə/ /titʃ/ /mi/ /haʊ/ /tə/ /kʊk/"
-	},
-	{
-		"chinese": "我想要你教我如何做饭",
-		"english": "I want you to teach me how to cook",
-		"soundmark": "/aɪ/ /wɑnt/ /ju/ /tə/ /titʃ/ /mi/ /haʊ/ /tə/ /kʊk/"
-	},
-	{
-		"chinese": "到达",
-		"english": "to get",
-		"soundmark": "/tə/ /ɡɛt/"
-	},
-	{
-		"chinese": "那里",
-		"english": "there",
-		"soundmark": "/ðɛr/"
-	},
-	{
-		"chinese": "到达那里",
-		"english": "to get there",
-		"soundmark": "/tə/ /ɡɛt/ /ðɛr/"
-	},
-	{
-		"chinese": "如何到达那里",
-		"english": "how to get there",
-		"soundmark": "/haʊ/ /tə/ /ɡɛt/ /ðɛr/"
-	},
-	{
-		"chinese": "我想要你",
-		"english": "I want you",
-		"soundmark": "/aɪ/ /wɑnt/ /ju/"
-	},
-	{
-		"chinese": "教我",
-		"english": "to teach me",
-		"soundmark": "/tə/ /titʃ/ /mi/"
-	},
-	{
-		"chinese": "我想要你教我如何到达那里",
-		"english": "I want you to teach me how to get there",
-		"soundmark": "/aɪ/ /wɑnt/ /ju/ /tə/ /titʃ/ /mi/ /haʊ/ /tə/ /ɡɛt/ /ðɛr/"
-	},
-	{
-		"chinese": "展示",
-		"english": "to show",
-		"soundmark": "/tə/ /ʃo/"
-	},
-	{
-		"chinese": "展示给你",
-		"english": "to show you",
-		"soundmark": "/tə/ /ʃo/ /ju/"
-	},
-	{
-		"chinese": "某些东西",
-		"english": "something",
-		"soundmark": "/'sʌmθɪŋ/"
-	},
-	{
-		"chinese": "展示给你某些东西",
-		"english": "to show you something",
-		"soundmark": "/tə/ /ʃo/ /ju/ /'sʌmθɪŋ/"
-	},
-	{
-		"chinese": "我想要展示给你某些东西",
-		"english": "I want to show you something",
-		"soundmark": "/aɪ/ /wɑnt/ /tə/ /ʃo/ /ju/ /'sʌmθɪŋ/"
-	},
-	{
-		"chinese": "重要的",
-		"english": "important",
-		"soundmark": "/ɪm'pɔrtnt/"
-	},
-	{
-		"chinese": "我想要展示给你重要的某些东西",
-		"english": "I want to show you something important",
-		"soundmark": "/aɪ/ /wɑnt/ /tə/ /ʃo/ /ju/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/"
-	},
-	{
-		"chinese": "任何东西",
-		"english": "anything",
-		"soundmark": "/'ɛnɪθɪŋ/"
-	},
-	{
-		"chinese": "我不想展示给你任何东西",
-		"english": "I don't want to show you anything",
-		"soundmark": "/aɪ/ /dont/ /wɑnt/ /tə/ /ʃo/ /ju/ /'ɛnɪθɪŋ/"
-	},
-	{
-		"chinese": "我",
-		"english": "me",
-		"soundmark": "/mi/"
-	},
-	{
-		"chinese": "展示给我",
-		"english": "to show me",
-		"soundmark": "/tə/ /ʃo/ /mi/"
-	},
-	{
-		"chinese": "你必须展示给我",
-		"english": "you have to show me",
-		"soundmark": "/ju/ /hæv/ /tə/ /ʃo/ /mi/"
-	},
-	{
-		"chinese": "如何",
-		"english": "how",
-		"soundmark": "/haʊ/"
-	},
-	{
-		"chinese": "使用字典",
-		"english": "to use the dictionary",
-		"soundmark": "/tə/ /juz/ /ðə/ /'dɪkʃənɛri/"
-	},
-	{
-		"chinese": "如何使用字典",
-		"english": "how to use the dictionary",
-		"soundmark": "/haʊ/ /tə/ /juz/ /ðə/ /'dɪkʃənɛri/"
-	},
-	{
-		"chinese": "你必须展示给我如何使用字典",
-		"english": "you have to show me how to use the dictionary",
-		"soundmark": "/ju/ /hæv/ /tə/ /ʃo/ /mi/ /haʊ/ /tə/ /juz/ /ðə/ /'dɪkʃənɛri/"
-	},
-	{
-		"chinese": "使用网络",
-		"english": "to use the internet",
-		"soundmark": "/tə/ /juz/ /ði/ /ˈɪntərnɛt/"
-	},
-	{
-		"chinese": "如何使用网络",
-		"english": "how to use the internet",
-		"soundmark": "/haʊ/ /tə/ /juz/ /ði/ /ˈɪntərnɛt/"
-	},
-	{
-		"chinese": "你必须展示给我如何使用网络",
-		"english": "you have to show me how to use the internet",
-		"soundmark": "/ju/ /hæv/ /tə/ /ʃo/ /mi/ /haʊ/ /tə/ /juz/ /ði/ /ˈɪntərnɛt/"
-	},
-	{
-		"chinese": "做这件事",
-		"english": "to do it",
-		"soundmark": "/tə/ /du/ /ɪt/"
-	},
-	{
-		"chinese": "如何做这件事",
-		"english": "how to do it",
-		"soundmark": "/haʊ/ /tə/ /du/ /ɪt/"
-	},
-	{
-		"chinese": "展示给我们",
-		"english": "to show us",
-		"soundmark": "/tə/ /ʃo/ /ʌs/"
-	},
-	{
-		"chinese": "你需要展示给我们如何做这件事",
-		"english": "you need to show us how to do it",
-		"soundmark": "/ju/ /nid/ /tə/ /ʃo/ /ʌs/ /haʊ/ /tə/ /du/ /ɪt/"
-	},
-	{
-		"chinese": "你不必展示给我们如何做这件事",
-		"english": "you don't need to show us how to do it",
-		"soundmark": "/ju/ /dont/ /nid/ /tə/ /ʃo/ /ʌs/ /haʊ/ /tə/ /du/ /ɪt/"
-	},
-	{
-		"chinese": "房子",
-		"english": "house",
-		"soundmark": "/haʊs/"
-	},
-	{
-		"chinese": "新的",
-		"english": "new",
-		"soundmark": "/nu/"
-	},
-	{
-		"chinese": "新房子",
-		"english": "new house",
-		"soundmark": "/nu/ /haʊs/"
-	},
-	{
-		"chinese": "你的",
-		"english": "your",
-		"soundmark": "/jʊr/"
-	},
-	{
-		"chinese": "你的新房子",
-		"english": "your new house",
-		"soundmark": "/jʊr/ /nu/ /haʊs/"
-	},
-	{
-		"chinese": "你必须展示给我",
-		"english": "you have to show me",
-		"soundmark": "/ju/ /hæv/ /tə/ /ʃo/ /mi/"
-	},
-	{
-		"chinese": "你必须展示给我你的新房子",
-		"english": "you have to show me your new house",
-		"soundmark": "/ju/ /hæv/ /tə/ /ʃo/ /mi/ /jʊr/ /nu/ /haʊs/"
-	},
-	{
-		"chinese": "你不必展示给我你的新房子",
-		"english": "you don't have to show me your new house",
-		"soundmark": "/ju/ /dont/ /hæv/ /tə/ /ʃo/ /mi/ /jʊr/ /nu/ /haʊs/"
-	},
-	{
-		"chinese": "手（复数）",
-		"english": "hands",
-		"soundmark": "/hændz/"
-	},
-	{
-		"chinese": "你的手",
-		"english": "your hands",
-		"soundmark": "/jʊr/ /hændz/"
-	},
-	{
-		"chinese": "展示给我你的手",
-		"english": "to show me your hands",
-		"soundmark": "/tə/ /ʃo/ /mi/ /jʊr/ /hændz/"
-	},
-	{
-		"chinese": "你必须展示给我你的手",
-		"english": "you have to show me your hands",
-		"soundmark": "/ju/ /hæv/ /tə/ /ʃo/ /mi/ /jʊr/ /hændz/"
-	},
-	{
-		"chinese": "让",
-		"english": "to let",
-		"soundmark": "/tə/ /lɛt/"
-	},
-	{
-		"chinese": "你",
-		"english": "you",
-		"soundmark": "/ju/"
-	},
-	{
-		"chinese": "让你",
-		"english": "to let you",
-		"soundmark": "/tə/ /lɛt/ /ju/"
-	},
-	{
-		"chinese": "知道",
-		"english": "to know",
-		"soundmark": "/tə/ /no/"
-	},
-	{
-		"chinese": "让你知道",
-		"english": "to let you know",
-		"soundmark": "/tə/ /lɛt/ /ju/ /no/"
-	},
-	{
-		"chinese": "我想要让你知道",
-		"english": "I want to let you know",
-		"soundmark": "/aɪ/ /wɑnt/ /tə/ /lɛt/ /ju/ /no/"
-	},
-	{
-		"chinese": "事实",
-		"english": "the truth",
-		"soundmark": "/ðə/ /trʊθ/"
-	},
-	{
-		"chinese": "我想要让你知道事实",
-		"english": "I want to let you know the truth",
-		"soundmark": "/aɪ/ /wɑnt/ /tə/ /lɛt/ /ju/ /no/ /ðə/ /trʊθ/"
-	},
-	{
-		"chinese": "关于",
-		"english": "about",
-		"soundmark": "/ə'baʊt/"
-	},
-	{
-		"chinese": "关于我",
-		"english": "about me",
-		"soundmark": "/ə'baʊt/ /mi/"
-	},
-	{
-		"chinese": "我想要让你知道关于我的事实",
-		"english": "I want to let you know the truth about me",
-		"soundmark": "/aɪ/ /wɑnt/ /tə/ /lɛt/ /ju/ /no/ /ðə/ /trʊθ/ /ə'baʊt/ /mi/"
-	},
-	{
-		"chinese": "我将会",
-		"english": "I will",
-		"soundmark": "/aɪ/ /wɪl/"
-	},
-	{
-		"chinese": "让你知道",
-		"english": "to let you know",
-		"soundmark": "/tə/ /lɛt/ /ju/ /no/"
-	},
-	{
-		"chinese": "我将会让你知道",
-		"english": "I will let you know",
-		"soundmark": "/aɪ/ /wɪl/ /lɛt/ /ju/ /no/"
-	},
-	{
-		"chinese": "我将会让你知道关于我的事实",
-		"english": "I will let you know the truth about me",
-		"soundmark": "/aɪ/ /wɪl/ /lɛt/ /ju/ /no/ /ðə/ /trʊθ/ /ə'baʊt/ /mi/"
-	},
-	{
-		"chinese": "下一个",
-		"english": "next",
-		"soundmark": "/nɛkst/"
-	},
-	{
-		"chinese": "周",
-		"english": "week",
-		"soundmark": "/wik/"
-	},
-	{
-		"chinese": "下周",
-		"english": "next week",
-		"soundmark": "/nɛkst/ /wik/"
-	},
-	{
-		"chinese": "我下周将会让你知道关于我的事实",
-		"english": "I will let you know the truth about me next week",
-		"soundmark": "/aɪ/ /wɪl/ /lɛt/ /ju/ /no/ /ðə/ /trʊθ/ /ə'baʊt/ /mi/ /nɛkst/ /wik/"
-	},
-	{
-		"chinese": "去",
-		"english": "to go",
-		"soundmark": "/tə/ /ɡo/"
-	},
-	{
-		"chinese": "外面",
-		"english": "out",
-		"soundmark": "/aʊt/"
-	},
-	{
-		"chinese": "去外面",
-		"english": "to go out",
-		"soundmark": "/tə/ /ɡo/ /aʊt/"
-	},
-	{
-		"chinese": "我想要去外面",
-		"english": "I want to go out",
-		"soundmark": "/aɪ/ /wɑnt/ /tə/ /ɡo/ /aʊt/"
-	},
-	{
-		"chinese": "让你",
-		"english": "to let you",
-		"soundmark": "/tə/ /lɛt/ /ju/"
-	},
-	{
-		"chinese": "让你去外面",
-		"english": "to let you go out",
-		"soundmark": "/tə/ /lɛt/ /ju/ /ɡo/ /aʊt/"
-	},
-	{
-		"chinese": "我想要让你去外面",
-		"english": "I want to let you go out",
-		"soundmark": "/aɪ/ /wɑnt/ /tə/ /lɛt/ /ju/ /ɡo/ /aʊt/"
-	},
-	{
-		"chinese": "我不想让你去外面",
-		"english": "I don't want to let you go out",
-		"soundmark": "/aɪ/ /dont/ /wɑnt/ /tə/ /lɛt/ /ju/ /ɡo/ /aʊt/"
-	},
-	{
-		"chinese": "在晚上",
-		"english": "at night",
-		"soundmark": "/ət/ /naɪt/"
-	},
-	{
-		"chinese": "我不想让你在晚上去外面",
-		"english": "I don't want to let you go out at night",
-		"soundmark": "/aɪ/ /dont/ /wɑnt/ /tə/ /lɛt/ /ju/ /ɡo/ /aʊt/ /ət/ /naɪt/"
-	},
-	{
-		"chinese": "因为",
-		"english": "because",
-		"soundmark": "/bɪ'kɔz/"
-	},
-	{
-		"chinese": "危险的",
-		"english": "dangerous",
-		"soundmark": "/'dendʒərəs/"
-	},
-	{
-		"chinese": "非常",
-		"english": "very",
-		"soundmark": "/ˈvɛri/"
-	},
-	{
-		"chinese": "这件事是非常危险的",
-		"english": "it is very dangerous",
-		"soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /'dendʒərəs/"
-	},
-	{
-		"chinese": "因为这件事是非常危险的",
-		"english": "because it is very dangerous",
-		"soundmark": "/bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /'dendʒərəs/"
-	},
-	{
-		"chinese": "我不想让你在晚上去外面因为这件事是非常危险的",
-		"english": "I don't want to let you go out at night because it is very dangerous",
-		"soundmark": "/aɪ/ /dont/ /wɑnt/ /tə/ /lɛt/ /ju/ /ɡo/ /aʊt/ /ət/ /naɪt/ /bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /'dendʒərəs/"
-	},
-	{
-		"chinese": "待在",
-		"english": "to stay",
-		"soundmark": "/tə/ /ste/"
-	},
-	{
-		"chinese": "这里",
-		"english": "here",
-		"soundmark": "/hɪr/"
-	},
-	{
-		"chinese": "待在这里",
-		"english": "to stay here",
-		"soundmark": "/tə/ /ste/ /hɪr/"
-	},
-	{
-		"chinese": "需要",
-		"english": "need",
-		"soundmark": "/nid/"
-	},
-	{
-		"chinese": "我需要你待在这里",
-		"english": "I need you to stay here",
-		"soundmark": "/aɪ/ /nid/ /tə/ /ste/ /hɪr/"
-	},
-	{
-		"chinese": "而且",
-		"english": "and",
-		"soundmark": "/ənd/"
-	},
-	{
-		"chinese": "而且我需要你待在这里",
-		"english": "and I need you to stay here",
-		"soundmark": "/ənd/ /aɪ/ /nid/ /tə/ /ste/ /hɪr/"
-	},
-	{
-		"chinese": "我不想让你在晚上去外面因为这件事是非常危险的而且我需要你待在这里",
-		"english": "I don't want to let you go out at night because it is very dangerous and I need you to stay here",
-		"soundmark": "/aɪ/ /dont/ /wɑnt/ /tə/ /lɛt/ /ju/ /ɡo/ /aʊt/ /ət/ /naɪt/ /bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /'dendʒərəs/ /ənd/ /aɪ/ /nid/ /tə/ /ste/ /hɪr/"
-	},
-	{
-		"chinese": "父亲",
-		"english": "father",
-		"soundmark": "/'fɑðɚ/"
-	},
-	{
-		"chinese": "我的",
-		"english": "my",
-		"soundmark": "/maɪ/"
-	},
-	{
-		"chinese": "我的父亲",
-		"english": "my father",
-		"soundmark": "/maɪ/ /'fɑðɚ/"
-	},
-	{
-		"chinese": "打电话给",
-		"english": "to call",
-		"soundmark": "/tə/ /kɔl/"
-	},
-	{
-		"chinese": "打电话给我的父亲",
-		"english": "to call my father",
-		"soundmark": "/tə/ /kɔl/ /maɪ/ /'fɑðɚ/"
-	},
-	{
-		"chinese": "让我",
-		"english": "to let me",
-		"soundmark": "/tə/ /lɛt/ /mi/"
-	},
-	{
-		"chinese": "让我打电话给我的父亲",
-		"english": "to let me call my father",
-		"soundmark": "/tə/ /lɛt/ /mi/ /kɔl/ /maɪ/ /'fɑðɚ/"
-	},
-	{
-		"chinese": "记得",
-		"english": "to remember",
-		"soundmark": "/tə/ /rɪ'mɛmbɚ/"
-	},
-	{
-		"chinese": "你必须记得",
-		"english": "you have to remember",
-		"soundmark": "/ju/ /hæv/ /tə/ /rɪ'mɛmbɚ/"
-	},
-	{
-		"chinese": "你必须记得让我打电话给我的父亲",
-		"english": "you have to remember to let me call my father",
-		"soundmark": "/ju/ /hæv/ /tə/ /rɪ'mɛmbɚ/ /tə/ /lɛt/ /mi/ /kɔl/ /maɪ/ /'fɑðɚ/"
-	},
-	{
-		"chinese": "到达",
-		"english": "to get",
-		"soundmark": "/tə/ /ɡɛt/"
-	},
-	{
-		"chinese": "那里",
-		"english": "there",
-		"soundmark": "/ðɛr/"
-	},
-	{
-		"chinese": "到达那里",
-		"english": "to get there",
-		"soundmark": "/tə/ /ɡɛt/ /ðɛr/"
-	},
-	{
-		"chinese": "我们到达那里",
-		"english": "we get there",
-		"soundmark": "/wi/ /ɡɛt/ /ðɛr/"
-	},
-	{
-		"chinese": "当......时候",
-		"english": "when",
-		"soundmark": "/wɛn/"
-	},
-	{
-		"chinese": "当我们到达那里的时候",
-		"english": "when we get there",
-		"soundmark": "/wɛn/ /wi/ /ɡɛt/ /ðɛr/"
-	},
-	{
-		"chinese": "你必须记得当我们到达那里的时候让我打电话给我的父亲",
-		"english": "you have to remember to let me call my father when we get there",
-		"soundmark": "/ju/ /hæv/ /tə/ /rɪ'mɛmbɚ/ /tə/ /lɛt/ /mi/ /kɔl/ /maɪ/ /'fɑðɚ/ /wɛn/ /wi/ /ɡɛt/ /ðɛr/"
-	},
-	{
-		"chinese": "让",
-		"english": "to let",
-		"soundmark": "/tə/ /lɛt/"
-	},
-	{
-		"chinese": "我们",
-		"english": "us",
-		"soundmark": "/ʌs/"
-	},
-	{
-		"chinese": "让我们",
-		"english": "to let us",
-		"soundmark": "/tə/ /lɛt/ /ʌs/"
-	},
-	{
-		"chinese": "去",
-		"english": "to go",
-		"soundmark": "/tə/ /ɡo/"
-	},
-	{
-		"chinese": "让我们去",
-		"english": "to let us go",
-		"soundmark": "/tə/ /lɛt/ /ʌs/ /ɡo/"
-	},
-	{
-		"chinese": "你必须让我们去",
-		"english": "you have to let us go",
-		"soundmark": "/ju/ /hæv/ /tə/ /lɛt/ /ʌs/ /ɡo/"
-	},
-	{
-		"chinese": "让我们去",
-		"english": "let us go",
-		"soundmark": "/lɛt/ /ʌs/ /ɡo/"
-	},
-	{
-		"chinese": "里面；进去",
-		"english": "in",
-		"soundmark": "/ɪn/"
-	},
-	{
-		"chinese": "让我们进去",
-		"english": "let us in",
-		"soundmark": "/lɛt/ /ʌs/ /ɪn/"
-	},
-	{
-		"chinese": "我",
-		"english": "me",
-		"soundmark": "/mi/"
-	},
-	{
-		"chinese": "让我进去",
-		"english": "let me in",
-		"soundmark": "/lɛt/ /mi/ /ɪn/"
-	},
-	{
-		"chinese": "门",
-		"english": "the door",
-		"soundmark": "/ðə/ /dɔr/"
-	},
-	{
-		"chinese": "开门",
-		"english": "open the door",
-		"soundmark": "/'opən/ /ðə/ /dɔr/"
-	},
-	{
-		"chinese": "开门  让我进去",
-		"english": "open the door let me in",
-		"soundmark": "/'opən/ /ðə/ /dɔr/ /lɛt/ /mi/ /ɪn/"
-	},
-	{
-		"chinese": "外面；出去",
-		"english": "out",
-		"soundmark": "/aʊt/"
-	},
-	{
-		"chinese": "让我出去",
-		"english": "let me out",
-		"soundmark": "/lɛt/ /mi/ /aʊt/"
-	},
-	{
-		"chinese": "开门  让我出去",
-		"english": "open the door let me out",
-		"soundmark": "/'opən/ /ðə/ /dɔr/ /lɛt/ /mi/ /aʊt/"
-	},
-	{
-		"chinese": "告诉你",
-		"english": "to tell you",
-		"soundmark": "/tə/ /tɛl/ /ju/"
-	},
-	{
-		"chinese": "让我",
-		"english": "let me",
-		"soundmark": "/lɛt/ /mi/"
-	},
-	{
-		"chinese": "让我告诉你",
-		"english": "let me tell you",
-		"soundmark": "/lɛt/ /mi/ /tɛl/ /ju/"
-	},
-	{
-		"chinese": "某些事情；某些东西",
-		"english": "something",
-		"soundmark": "/'sʌmθɪŋ/"
-	},
-	{
-		"chinese": "让我告诉你某些事情",
-		"english": "let me tell you something",
-		"soundmark": "/lɛt/ /mi/ /tɛl/ /ju/ /'sʌmθɪŋ/"
-	},
-	{
-		"chinese": "关于",
-		"english": "about",
-		"soundmark": "/ə'baʊt/"
-	},
-	{
-		"chinese": "你的工作",
-		"english": "your work",
-		"soundmark": "/jʊr/ /wɝk/"
-	},
-	{
-		"chinese": "关于你的工作",
-		"english": "about your work",
-		"soundmark": "/ə'baʊt/ /jʊr/ /wɝk/"
-	},
-	{
-		"chinese": "让我告诉你关于你的工作的某些事情",
-		"english": "let me tell you something about your work",
-		"soundmark": "/lɛt/ /mi/ /tɛl/ /ju/ /'sʌmθɪŋ/ /ə'baʊt/ /jʊr/ /wɝk/"
-	},
-	{
-		"chinese": "一个问题",
-		"english": "a question",
-		"soundmark": "/ə/ /'kwɛstʃən/"
-	},
-	{
-		"chinese": "问",
-		"english": "to ask",
-		"soundmark": "/tə/ /æsk/"
-	},
-	{
-		"chinese": "问你一个问题",
-		"english": "to ask you a question",
-		"soundmark": "/tə/ /æsk/ /ju/ /ə/ /'kwɛstʃən/"
-	},
-	{
-		"chinese": "让我",
-		"english": "let me",
-		"soundmark": "/lɛt/ /mi/"
-	},
-	{
-		"chinese": "让我问你一个问题",
-		"english": "let me ask you a question",
-		"soundmark": "/lɛt/ /mi/ /æsk/ /ju/ /ə/ /'kwɛstʃən/"
-	},
-	{
-		"chinese": "事实",
-		"english": "the truth",
-		"soundmark": "/ðə/ /trʊθ/"
-	},
-	{
-		"chinese": "告诉你事实",
-		"english": "to tell you the truth",
-		"soundmark": "/tə/ /tɛl/ /ju/ /ðə/ /trʊθ/"
-	},
-	{
-		"chinese": "让我",
-		"english": "let me",
-		"soundmark": "/lɛt/ /mi/"
-	},
-	{
-		"chinese": "让我告诉你事实",
-		"english": "let me tell you the truth",
-		"soundmark": "/lɛt/ /mi/ /tɛl/ /ju/ /ðə/ /trʊθ/"
-	},
-	{
-		"chinese": "一个故事",
-		"english": "a story",
-		"soundmark": "/ə/ /'stɔri/"
-	},
-	{
-		"chinese": "让我告诉你一个故事",
-		"english": "let me tell you a story",
-		"soundmark": "/lɛt/ /mi/ /tɛl/ /ju/ /ə/ /'stɔri/"
-	},
-	{
-		"chinese": "解释",
-		"english": "to explain",
-		"soundmark": "/tə/ /ɪk'splen/"
-	},
-	{
-		"chinese": "让我",
-		"english": "let me",
-		"soundmark": "/lɛt/ /mi/"
-	},
-	{
-		"chinese": "让我解释",
-		"english": "let me explain",
-		"soundmark": "/lɛt/ /mi/ /ɪk'splen/"
-	},
-	{
-		"chinese": "你的手",
-		"english": "your hands",
-		"soundmark": "/jʊr/ /hændz/"
-	},
-	{
-		"chinese": "看到",
-		"english": "to see",
-		"soundmark": "/tə/ /si/"
-	},
-	{
-		"chinese": "看到你的手",
-		"english": "to see your hands",
-		"soundmark": "/tə/ /si/ /jʊr/ /hændz/"
-	},
-	{
-		"chinese": "让我",
-		"english": "let me",
-		"soundmark": "/lɛt/ /mi/"
-	},
-	{
-		"chinese": "让我看到你的手",
-		"english": "let me see your hands",
-		"soundmark": "/lɛt/ /mi/ /si/ /jʊr/ /hændz/"
-	}
+  {
+    "chinese": "告诉",
+    "english": "to tell",
+    "soundmark": "/tə/ /tɛl/"
+  },
+  {
+    "chinese": "你",
+    "english": "you",
+    "soundmark": "/ju/"
+  },
+  {
+    "chinese": "告诉你",
+    "english": "to tell you",
+    "soundmark": "/tə/ /tɛl/ /ju/"
+  },
+  {
+    "chinese": "某些事情；某些东西",
+    "english": "something",
+    "soundmark": "/'sʌmθɪŋ/"
+  },
+  {
+    "chinese": "重要的",
+    "english": "important",
+    "soundmark": "/ɪm'pɔrtnt/"
+  },
+  {
+    "chinese": "重要的某些事情",
+    "english": "something important",
+    "soundmark": "/'sʌmθɪŋ/ /ɪm'pɔrtnt/"
+  },
+  {
+    "chinese": "告诉你重要的某些事情",
+    "english": "to tell you something important",
+    "soundmark": "/tə/ /tɛl/ /ju/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/"
+  },
+  {
+    "chinese": "想要",
+    "english": "want",
+    "soundmark": "/wɑnt/"
+  },
+  {
+    "chinese": "我想要告诉你重要的某些事情",
+    "english": "I want to tell you something important",
+    "soundmark": "/aɪ/ /wɑnt/ /tə/ /tɛl/ /ju/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/"
+  },
+  {
+    "chinese": "教",
+    "english": "to teach",
+    "soundmark": "/tə/ /titʃ/"
+  },
+  {
+    "chinese": "某些事情；某些东西",
+    "english": "something",
+    "soundmark": "/'sʌmθɪŋ/"
+  },
+  {
+    "chinese": "重要的某些东西",
+    "english": "something important",
+    "soundmark": "/'sʌmθɪŋ/ /ɪm'pɔrtnt/"
+  },
+  {
+    "chinese": "我想要教你重要的某些东西",
+    "english": "I want to teach you something important",
+    "soundmark": "/aɪ/ /wɑnt/ /tə/ /titʃ/ /ju/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/"
+  },
+  {
+    "chinese": "任何东西",
+    "english": "anything",
+    "soundmark": "/'ɛnɪθɪŋ/"
+  },
+  {
+    "chinese": "任何重要的东西",
+    "english": "anything important",
+    "soundmark": "/'ɛnɪθɪŋ/ /ɪm'pɔrtnt/"
+  },
+  {
+    "chinese": "我不想教你任何重要的东西",
+    "english": "I don't want to teach you anything important",
+    "soundmark": "/aɪ/ /wɑnt/ /tə/ /titʃ/ /ju/ /'ɛnɪθɪŋ/ /ɪm'pɔrtnt/"
+  },
+  {
+    "chinese": "一堂课",
+    "english": "a lesson",
+    "soundmark": "/ə/ /'lɛsn/"
+  },
+  {
+    "chinese": "我想要教你一堂课",
+    "english": "I want to teach you a lesson",
+    "soundmark": "/aɪ/ /wɑnt/ /tə/ /titʃ/ /ju/ /ə/ /'lɛsn/"
+  },
+  {
+    "chinese": "我必须给你上一课",
+    "english": "I have to teach you a lesson",
+    "soundmark": "/aɪ/ /hæv/ /tə/ /titʃ/ /ju/ /ə/ /'lɛsn/"
+  },
+  {
+    "chinese": "我将会给你上一课",
+    "english": "I will teach you a lesson",
+    "soundmark": "/aɪ/ /wɪl/ /tə/ /titʃ/ /ju/ /ə/ /'lɛsn/"
+  },
+  {
+    "chinese": "教他",
+    "english": "to teach him",
+    "soundmark": "/tə/ /titʃ/ /hɪm/"
+  },
+  {
+    "chinese": "你必须教他一堂课",
+    "english": "you have to teach him a lesson",
+    "soundmark": "/ju/ /hæv/ /tə/ /titʃ/ /hɪm/ /ə/ /'lɛsn/"
+  },
+  {
+    "chinese": "使用",
+    "english": "to use",
+    "soundmark": "/tə/ /juz/"
+  },
+  {
+    "chinese": "字典",
+    "english": "the dictionary",
+    "soundmark": "/ðə/ /'dɪkʃənɛri/"
+  },
+  {
+    "chinese": "使用字典",
+    "english": "to use the dictionary",
+    "soundmark": "/tə/ /juz/ /ðə/ /'dɪkʃənɛri/"
+  },
+  {
+    "chinese": "如何",
+    "english": "how",
+    "soundmark": "/haʊ/"
+  },
+  {
+    "chinese": "如何使用字典",
+    "english": "how to use the dictionary",
+    "soundmark": "/haʊ/ /tə/ /juz/ /ðə/ /'dɪkʃənɛri/"
+  },
+  {
+    "chinese": "你必须教我",
+    "english": "you have to teach me",
+    "soundmark": "/ju/ /hæv/ /tə/ /titʃ/ /mi/"
+  },
+  {
+    "chinese": "你必须教我如何使用字典",
+    "english": "you have to teach me how to use the dictionary",
+    "soundmark": "/ju/ /hæv/ /tə/ /titʃ/ /mi/ /haʊ/ /tə/ /juz/ /ðə/ /'dɪkʃənɛri/"
+  },
+  {
+    "chinese": "你不必教我如何使用字典",
+    "english": "you don't have to teach me how to use the dictionary",
+    "soundmark": "/ju/ /dont/ /hæv/ /tə/ /titʃ/ /mi/ /haʊ/ /tə/ /juz/ /ðə/ /'dɪkʃənɛri/"
+  },
+  {
+    "chinese": "网络",
+    "english": "the internet",
+    "soundmark": "/ði/ /ˈɪntərnɛt/"
+  },
+  {
+    "chinese": "使用网络",
+    "english": "to use the internet",
+    "soundmark": "/tə/ /juz/ /ði/ /ˈɪntərnɛt/"
+  },
+  {
+    "chinese": "如何使用网络",
+    "english": "how to use the internet",
+    "soundmark": "/haʊ/ /tə/ /juz/ /ði/ /ˈɪntərnɛt/"
+  },
+  {
+    "chinese": "你必须教我如何使用网络",
+    "english": "you have to teach me how to use the internet",
+    "soundmark": "/ju/ /hæv/ /tə/ /titʃ/ /mi/ /haʊ/ /tə/ /juz/ /ði/ /ˈɪntərnɛt/"
+  },
+  {
+    "chinese": "你不必教我如何使用网络",
+    "english": "you don't have to teach me how to use the internet",
+    "soundmark": "/ju/ /dont/ /hæv/ /tə/ /titʃ/ /mi/ /haʊ/ /tə/ /juz/ /ði/ /ˈɪntərnɛt/"
+  },
+  {
+    "chinese": "做饭",
+    "english": "to cook",
+    "soundmark": "/tə/ /kʊk/"
+  },
+  {
+    "chinese": "如何做饭",
+    "english": "how to cook",
+    "soundmark": "/haʊ/ /tə/ /kʊk/"
+  },
+  {
+    "chinese": "你需要教我如何做饭",
+    "english": "you need to teach me how to cook",
+    "soundmark": "/ju/ /nid/ /tə/ /titʃ/ /mi/ /haʊ/ /tə/ /kʊk/"
+  },
+  {
+    "chinese": "不需要",
+    "english": "don't need",
+    "soundmark": "/dont/ /nid/"
+  },
+  {
+    "chinese": "你不需要教我如何做饭",
+    "english": "you don't need to teach me how to cook",
+    "soundmark": "/ju/ /dont/ /nid/ /tə/ /titʃ/ /mi/ /haʊ/ /tə/ /kʊk/"
+  },
+  {
+    "chinese": "我想要你",
+    "english": "I want you",
+    "soundmark": "/aɪ/ /wɑnt/ /ju/"
+  },
+  {
+    "chinese": "教我如何做饭",
+    "english": "to teach me how to cook",
+    "soundmark": "/tə/ /titʃ/ /mi/ /haʊ/ /tə/ /kʊk/"
+  },
+  {
+    "chinese": "我想要你教我如何做饭",
+    "english": "I want you to teach me how to cook",
+    "soundmark": "/aɪ/ /wɑnt/ /ju/ /tə/ /titʃ/ /mi/ /haʊ/ /tə/ /kʊk/"
+  },
+  {
+    "chinese": "到达",
+    "english": "to get",
+    "soundmark": "/tə/ /ɡɛt/"
+  },
+  {
+    "chinese": "那里",
+    "english": "there",
+    "soundmark": "/ðɛr/"
+  },
+  {
+    "chinese": "到达那里",
+    "english": "to get there",
+    "soundmark": "/tə/ /ɡɛt/ /ðɛr/"
+  },
+  {
+    "chinese": "如何到达那里",
+    "english": "how to get there",
+    "soundmark": "/haʊ/ /tə/ /ɡɛt/ /ðɛr/"
+  },
+  {
+    "chinese": "我想要你",
+    "english": "I want you",
+    "soundmark": "/aɪ/ /wɑnt/ /ju/"
+  },
+  {
+    "chinese": "教我",
+    "english": "to teach me",
+    "soundmark": "/tə/ /titʃ/ /mi/"
+  },
+  {
+    "chinese": "我想要你教我如何到达那里",
+    "english": "I want you to teach me how to get there",
+    "soundmark": "/aɪ/ /wɑnt/ /ju/ /tə/ /titʃ/ /mi/ /haʊ/ /tə/ /ɡɛt/ /ðɛr/"
+  },
+  {
+    "chinese": "展示",
+    "english": "to show",
+    "soundmark": "/tə/ /ʃo/"
+  },
+  {
+    "chinese": "展示给你",
+    "english": "to show you",
+    "soundmark": "/tə/ /ʃo/ /ju/"
+  },
+  {
+    "chinese": "某些东西",
+    "english": "something",
+    "soundmark": "/'sʌmθɪŋ/"
+  },
+  {
+    "chinese": "展示给你某些东西",
+    "english": "to show you something",
+    "soundmark": "/tə/ /ʃo/ /ju/ /'sʌmθɪŋ/"
+  },
+  {
+    "chinese": "我想要展示给你某些东西",
+    "english": "I want to show you something",
+    "soundmark": "/aɪ/ /wɑnt/ /tə/ /ʃo/ /ju/ /'sʌmθɪŋ/"
+  },
+  {
+    "chinese": "重要的",
+    "english": "important",
+    "soundmark": "/ɪm'pɔrtnt/"
+  },
+  {
+    "chinese": "我想要展示给你重要的某些东西",
+    "english": "I want to show you something important",
+    "soundmark": "/aɪ/ /wɑnt/ /tə/ /ʃo/ /ju/ /'sʌmθɪŋ/ /ɪm'pɔrtnt/"
+  },
+  {
+    "chinese": "任何东西",
+    "english": "anything",
+    "soundmark": "/'ɛnɪθɪŋ/"
+  },
+  {
+    "chinese": "我不想展示给你任何东西",
+    "english": "I don't want to show you anything",
+    "soundmark": "/aɪ/ /dont/ /wɑnt/ /tə/ /ʃo/ /ju/ /'ɛnɪθɪŋ/"
+  },
+  {
+    "chinese": "我",
+    "english": "me",
+    "soundmark": "/mi/"
+  },
+  {
+    "chinese": "展示给我",
+    "english": "to show me",
+    "soundmark": "/tə/ /ʃo/ /mi/"
+  },
+  {
+    "chinese": "你必须展示给我",
+    "english": "you have to show me",
+    "soundmark": "/ju/ /hæv/ /tə/ /ʃo/ /mi/"
+  },
+  {
+    "chinese": "如何",
+    "english": "how",
+    "soundmark": "/haʊ/"
+  },
+  {
+    "chinese": "使用字典",
+    "english": "to use the dictionary",
+    "soundmark": "/tə/ /juz/ /ðə/ /'dɪkʃənɛri/"
+  },
+  {
+    "chinese": "如何使用字典",
+    "english": "how to use the dictionary",
+    "soundmark": "/haʊ/ /tə/ /juz/ /ðə/ /'dɪkʃənɛri/"
+  },
+  {
+    "chinese": "你必须展示给我如何使用字典",
+    "english": "you have to show me how to use the dictionary",
+    "soundmark": "/ju/ /hæv/ /tə/ /ʃo/ /mi/ /haʊ/ /tə/ /juz/ /ðə/ /'dɪkʃənɛri/"
+  },
+  {
+    "chinese": "使用网络",
+    "english": "to use the internet",
+    "soundmark": "/tə/ /juz/ /ði/ /ˈɪntərnɛt/"
+  },
+  {
+    "chinese": "如何使用网络",
+    "english": "how to use the internet",
+    "soundmark": "/haʊ/ /tə/ /juz/ /ði/ /ˈɪntərnɛt/"
+  },
+  {
+    "chinese": "你必须展示给我如何使用网络",
+    "english": "you have to show me how to use the internet",
+    "soundmark": "/ju/ /hæv/ /tə/ /ʃo/ /mi/ /haʊ/ /tə/ /juz/ /ði/ /ˈɪntərnɛt/"
+  },
+  {
+    "chinese": "做这件事",
+    "english": "to do it",
+    "soundmark": "/tə/ /du/ /ɪt/"
+  },
+  {
+    "chinese": "如何做这件事",
+    "english": "how to do it",
+    "soundmark": "/haʊ/ /tə/ /du/ /ɪt/"
+  },
+  {
+    "chinese": "展示给我们",
+    "english": "to show us",
+    "soundmark": "/tə/ /ʃo/ /ʌs/"
+  },
+  {
+    "chinese": "你需要展示给我们如何做这件事",
+    "english": "you need to show us how to do it",
+    "soundmark": "/ju/ /nid/ /tə/ /ʃo/ /ʌs/ /haʊ/ /tə/ /du/ /ɪt/"
+  },
+  {
+    "chinese": "你不必展示给我们如何做这件事",
+    "english": "you don't need to show us how to do it",
+    "soundmark": "/ju/ /dont/ /nid/ /tə/ /ʃo/ /ʌs/ /haʊ/ /tə/ /du/ /ɪt/"
+  },
+  {
+    "chinese": "房子",
+    "english": "house",
+    "soundmark": "/haʊs/"
+  },
+  {
+    "chinese": "新的",
+    "english": "new",
+    "soundmark": "/nu/"
+  },
+  {
+    "chinese": "新房子",
+    "english": "new house",
+    "soundmark": "/nu/ /haʊs/"
+  },
+  {
+    "chinese": "你的",
+    "english": "your",
+    "soundmark": "/jʊr/"
+  },
+  {
+    "chinese": "你的新房子",
+    "english": "your new house",
+    "soundmark": "/jʊr/ /nu/ /haʊs/"
+  },
+  {
+    "chinese": "你必须展示给我",
+    "english": "you have to show me",
+    "soundmark": "/ju/ /hæv/ /tə/ /ʃo/ /mi/"
+  },
+  {
+    "chinese": "你必须展示给我你的新房子",
+    "english": "you have to show me your new house",
+    "soundmark": "/ju/ /hæv/ /tə/ /ʃo/ /mi/ /jʊr/ /nu/ /haʊs/"
+  },
+  {
+    "chinese": "你不必展示给我你的新房子",
+    "english": "you don't have to show me your new house",
+    "soundmark": "/ju/ /dont/ /hæv/ /tə/ /ʃo/ /mi/ /jʊr/ /nu/ /haʊs/"
+  },
+  {
+    "chinese": "手（复数）",
+    "english": "hands",
+    "soundmark": "/hændz/"
+  },
+  {
+    "chinese": "你的手",
+    "english": "your hands",
+    "soundmark": "/jʊr/ /hændz/"
+  },
+  {
+    "chinese": "展示给我你的手",
+    "english": "to show me your hands",
+    "soundmark": "/tə/ /ʃo/ /mi/ /jʊr/ /hændz/"
+  },
+  {
+    "chinese": "你必须展示给我你的手",
+    "english": "you have to show me your hands",
+    "soundmark": "/ju/ /hæv/ /tə/ /ʃo/ /mi/ /jʊr/ /hændz/"
+  },
+  {
+    "chinese": "让",
+    "english": "to let",
+    "soundmark": "/tə/ /lɛt/"
+  },
+  {
+    "chinese": "你",
+    "english": "you",
+    "soundmark": "/ju/"
+  },
+  {
+    "chinese": "让你",
+    "english": "to let you",
+    "soundmark": "/tə/ /lɛt/ /ju/"
+  },
+  {
+    "chinese": "知道",
+    "english": "to know",
+    "soundmark": "/tə/ /no/"
+  },
+  {
+    "chinese": "让你知道",
+    "english": "to let you know",
+    "soundmark": "/tə/ /lɛt/ /ju/ /no/"
+  },
+  {
+    "chinese": "我想要让你知道",
+    "english": "I want to let you know",
+    "soundmark": "/aɪ/ /wɑnt/ /tə/ /lɛt/ /ju/ /no/"
+  },
+  {
+    "chinese": "事实",
+    "english": "the truth",
+    "soundmark": "/ðə/ /trʊθ/"
+  },
+  {
+    "chinese": "我想要让你知道事实",
+    "english": "I want to let you know the truth",
+    "soundmark": "/aɪ/ /wɑnt/ /tə/ /lɛt/ /ju/ /no/ /ðə/ /trʊθ/"
+  },
+  {
+    "chinese": "关于",
+    "english": "about",
+    "soundmark": "/ə'baʊt/"
+  },
+  {
+    "chinese": "关于我",
+    "english": "about me",
+    "soundmark": "/ə'baʊt/ /mi/"
+  },
+  {
+    "chinese": "我想要让你知道关于我的事实",
+    "english": "I want to let you know the truth about me",
+    "soundmark": "/aɪ/ /wɑnt/ /tə/ /lɛt/ /ju/ /no/ /ðə/ /trʊθ/ /ə'baʊt/ /mi/"
+  },
+  {
+    "chinese": "我将会",
+    "english": "I will",
+    "soundmark": "/aɪ/ /wɪl/"
+  },
+  {
+    "chinese": "让你知道",
+    "english": "to let you know",
+    "soundmark": "/tə/ /lɛt/ /ju/ /no/"
+  },
+  {
+    "chinese": "我将会让你知道",
+    "english": "I will let you know",
+    "soundmark": "/aɪ/ /wɪl/ /lɛt/ /ju/ /no/"
+  },
+  {
+    "chinese": "我将会让你知道关于我的事实",
+    "english": "I will let you know the truth about me",
+    "soundmark": "/aɪ/ /wɪl/ /lɛt/ /ju/ /no/ /ðə/ /trʊθ/ /ə'baʊt/ /mi/"
+  },
+  {
+    "chinese": "下一个",
+    "english": "next",
+    "soundmark": "/nɛkst/"
+  },
+  {
+    "chinese": "周",
+    "english": "week",
+    "soundmark": "/wik/"
+  },
+  {
+    "chinese": "下周",
+    "english": "next week",
+    "soundmark": "/nɛkst/ /wik/"
+  },
+  {
+    "chinese": "我下周将会让你知道关于我的事实",
+    "english": "I will let you know the truth about me next week",
+    "soundmark": "/aɪ/ /wɪl/ /lɛt/ /ju/ /no/ /ðə/ /trʊθ/ /ə'baʊt/ /mi/ /nɛkst/ /wik/"
+  },
+  {
+    "chinese": "去",
+    "english": "to go",
+    "soundmark": "/tə/ /ɡo/"
+  },
+  {
+    "chinese": "外面",
+    "english": "out",
+    "soundmark": "/aʊt/"
+  },
+  {
+    "chinese": "去外面",
+    "english": "to go out",
+    "soundmark": "/tə/ /ɡo/ /aʊt/"
+  },
+  {
+    "chinese": "我想要去外面",
+    "english": "I want to go out",
+    "soundmark": "/aɪ/ /wɑnt/ /tə/ /ɡo/ /aʊt/"
+  },
+  {
+    "chinese": "让你",
+    "english": "to let you",
+    "soundmark": "/tə/ /lɛt/ /ju/"
+  },
+  {
+    "chinese": "让你去外面",
+    "english": "to let you go out",
+    "soundmark": "/tə/ /lɛt/ /ju/ /ɡo/ /aʊt/"
+  },
+  {
+    "chinese": "我想要让你去外面",
+    "english": "I want to let you go out",
+    "soundmark": "/aɪ/ /wɑnt/ /tə/ /lɛt/ /ju/ /ɡo/ /aʊt/"
+  },
+  {
+    "chinese": "我不想让你去外面",
+    "english": "I don't want to let you go out",
+    "soundmark": "/aɪ/ /dont/ /wɑnt/ /tə/ /lɛt/ /ju/ /ɡo/ /aʊt/"
+  },
+  {
+    "chinese": "在晚上",
+    "english": "at night",
+    "soundmark": "/ət/ /naɪt/"
+  },
+  {
+    "chinese": "我不想让你在晚上去外面",
+    "english": "I don't want to let you go out at night",
+    "soundmark": "/aɪ/ /dont/ /wɑnt/ /tə/ /lɛt/ /ju/ /ɡo/ /aʊt/ /ət/ /naɪt/"
+  },
+  {
+    "chinese": "因为",
+    "english": "because",
+    "soundmark": "/bɪ'kɔz/"
+  },
+  {
+    "chinese": "危险的",
+    "english": "dangerous",
+    "soundmark": "/'dendʒərəs/"
+  },
+  {
+    "chinese": "非常",
+    "english": "very",
+    "soundmark": "/ˈvɛri/"
+  },
+  {
+    "chinese": "这件事是非常危险的",
+    "english": "it is very dangerous",
+    "soundmark": "/ɪt/ /ɪz/ /ˈvɛri/ /'dendʒərəs/"
+  },
+  {
+    "chinese": "因为这件事是非常危险的",
+    "english": "because it is very dangerous",
+    "soundmark": "/bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /'dendʒərəs/"
+  },
+  {
+    "chinese": "我不想让你在晚上去外面因为这件事是非常危险的",
+    "english": "I don't want to let you go out at night because it is very dangerous",
+    "soundmark": "/aɪ/ /dont/ /wɑnt/ /tə/ /lɛt/ /ju/ /ɡo/ /aʊt/ /ət/ /naɪt/ /bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /'dendʒərəs/"
+  },
+  {
+    "chinese": "待在",
+    "english": "to stay",
+    "soundmark": "/tə/ /ste/"
+  },
+  {
+    "chinese": "这里",
+    "english": "here",
+    "soundmark": "/hɪr/"
+  },
+  {
+    "chinese": "待在这里",
+    "english": "to stay here",
+    "soundmark": "/tə/ /ste/ /hɪr/"
+  },
+  {
+    "chinese": "需要",
+    "english": "need",
+    "soundmark": "/nid/"
+  },
+  {
+    "chinese": "我需要你待在这里",
+    "english": "I need you to stay here",
+    "soundmark": "/aɪ/ /nid/ /tə/ /ste/ /hɪr/"
+  },
+  {
+    "chinese": "而且",
+    "english": "and",
+    "soundmark": "/ənd/"
+  },
+  {
+    "chinese": "而且我需要你待在这里",
+    "english": "and I need you to stay here",
+    "soundmark": "/ənd/ /aɪ/ /nid/ /tə/ /ste/ /hɪr/"
+  },
+  {
+    "chinese": "我不想让你在晚上去外面因为这件事是非常危险的而且我需要你待在这里",
+    "english": "I don't want to let you go out at night because it is very dangerous and I need you to stay here",
+    "soundmark": "/aɪ/ /dont/ /wɑnt/ /tə/ /lɛt/ /ju/ /ɡo/ /aʊt/ /ət/ /naɪt/ /bɪ'kɔz/ /ɪt/ /ɪz/ /ˈvɛri/ /'dendʒərəs/ /ənd/ /aɪ/ /nid/ /tə/ /ste/ /hɪr/"
+  },
+  {
+    "chinese": "父亲",
+    "english": "father",
+    "soundmark": "/'fɑðɚ/"
+  },
+  {
+    "chinese": "我的",
+    "english": "my",
+    "soundmark": "/maɪ/"
+  },
+  {
+    "chinese": "我的父亲",
+    "english": "my father",
+    "soundmark": "/maɪ/ /'fɑðɚ/"
+  },
+  {
+    "chinese": "打电话给",
+    "english": "to call",
+    "soundmark": "/tə/ /kɔl/"
+  },
+  {
+    "chinese": "打电话给我的父亲",
+    "english": "to call my father",
+    "soundmark": "/tə/ /kɔl/ /maɪ/ /'fɑðɚ/"
+  },
+  {
+    "chinese": "让我",
+    "english": "to let me",
+    "soundmark": "/tə/ /lɛt/ /mi/"
+  },
+  {
+    "chinese": "让我打电话给我的父亲",
+    "english": "to let me call my father",
+    "soundmark": "/tə/ /lɛt/ /mi/ /kɔl/ /maɪ/ /'fɑðɚ/"
+  },
+  {
+    "chinese": "记得",
+    "english": "to remember",
+    "soundmark": "/tə/ /rɪ'mɛmbɚ/"
+  },
+  {
+    "chinese": "你必须记得",
+    "english": "you have to remember",
+    "soundmark": "/ju/ /hæv/ /tə/ /rɪ'mɛmbɚ/"
+  },
+  {
+    "chinese": "你必须记得让我打电话给我的父亲",
+    "english": "you have to remember to let me call my father",
+    "soundmark": "/ju/ /hæv/ /tə/ /rɪ'mɛmbɚ/ /tə/ /lɛt/ /mi/ /kɔl/ /maɪ/ /'fɑðɚ/"
+  },
+  {
+    "chinese": "到达",
+    "english": "to get",
+    "soundmark": "/tə/ /ɡɛt/"
+  },
+  {
+    "chinese": "那里",
+    "english": "there",
+    "soundmark": "/ðɛr/"
+  },
+  {
+    "chinese": "到达那里",
+    "english": "to get there",
+    "soundmark": "/tə/ /ɡɛt/ /ðɛr/"
+  },
+  {
+    "chinese": "我们到达那里",
+    "english": "we get there",
+    "soundmark": "/wi/ /ɡɛt/ /ðɛr/"
+  },
+  {
+    "chinese": "当......时候",
+    "english": "when",
+    "soundmark": "/wɛn/"
+  },
+  {
+    "chinese": "当我们到达那里的时候",
+    "english": "when we get there",
+    "soundmark": "/wɛn/ /wi/ /ɡɛt/ /ðɛr/"
+  },
+  {
+    "chinese": "你必须记得当我们到达那里的时候让我打电话给我的父亲",
+    "english": "you have to remember to let me call my father when we get there",
+    "soundmark": "/ju/ /hæv/ /tə/ /rɪ'mɛmbɚ/ /tə/ /lɛt/ /mi/ /kɔl/ /maɪ/ /'fɑðɚ/ /wɛn/ /wi/ /ɡɛt/ /ðɛr/"
+  },
+  {
+    "chinese": "让",
+    "english": "to let",
+    "soundmark": "/tə/ /lɛt/"
+  },
+  {
+    "chinese": "我们",
+    "english": "us",
+    "soundmark": "/ʌs/"
+  },
+  {
+    "chinese": "让我们",
+    "english": "to let us",
+    "soundmark": "/tə/ /lɛt/ /ʌs/"
+  },
+  {
+    "chinese": "去",
+    "english": "to go",
+    "soundmark": "/tə/ /ɡo/"
+  },
+  {
+    "chinese": "让我们去",
+    "english": "to let us go",
+    "soundmark": "/tə/ /lɛt/ /ʌs/ /ɡo/"
+  },
+  {
+    "chinese": "你必须让我们去",
+    "english": "you have to let us go",
+    "soundmark": "/ju/ /hæv/ /tə/ /lɛt/ /ʌs/ /ɡo/"
+  },
+  {
+    "chinese": "让我们去",
+    "english": "let us go",
+    "soundmark": "/lɛt/ /ʌs/ /ɡo/"
+  },
+  {
+    "chinese": "里面；进去",
+    "english": "in",
+    "soundmark": "/ɪn/"
+  },
+  {
+    "chinese": "让我们进去",
+    "english": "let us in",
+    "soundmark": "/lɛt/ /ʌs/ /ɪn/"
+  },
+  {
+    "chinese": "我",
+    "english": "me",
+    "soundmark": "/mi/"
+  },
+  {
+    "chinese": "让我进去",
+    "english": "let me in",
+    "soundmark": "/lɛt/ /mi/ /ɪn/"
+  },
+  {
+    "chinese": "门",
+    "english": "the door",
+    "soundmark": "/ðə/ /dɔr/"
+  },
+  {
+    "chinese": "开门",
+    "english": "open the door",
+    "soundmark": "/'opən/ /ðə/ /dɔr/"
+  },
+  {
+    "chinese": "开门  让我进去",
+    "english": "open the door let me in",
+    "soundmark": "/'opən/ /ðə/ /dɔr/ /lɛt/ /mi/ /ɪn/"
+  },
+  {
+    "chinese": "外面；出去",
+    "english": "out",
+    "soundmark": "/aʊt/"
+  },
+  {
+    "chinese": "让我出去",
+    "english": "let me out",
+    "soundmark": "/lɛt/ /mi/ /aʊt/"
+  },
+  {
+    "chinese": "开门  让我出去",
+    "english": "open the door let me out",
+    "soundmark": "/'opən/ /ðə/ /dɔr/ /lɛt/ /mi/ /aʊt/"
+  },
+  {
+    "chinese": "告诉你",
+    "english": "to tell you",
+    "soundmark": "/tə/ /tɛl/ /ju/"
+  },
+  {
+    "chinese": "让我",
+    "english": "let me",
+    "soundmark": "/lɛt/ /mi/"
+  },
+  {
+    "chinese": "让我告诉你",
+    "english": "let me tell you",
+    "soundmark": "/lɛt/ /mi/ /tɛl/ /ju/"
+  },
+  {
+    "chinese": "某些事情；某些东西",
+    "english": "something",
+    "soundmark": "/'sʌmθɪŋ/"
+  },
+  {
+    "chinese": "让我告诉你某些事情",
+    "english": "let me tell you something",
+    "soundmark": "/lɛt/ /mi/ /tɛl/ /ju/ /'sʌmθɪŋ/"
+  },
+  {
+    "chinese": "关于",
+    "english": "about",
+    "soundmark": "/ə'baʊt/"
+  },
+  {
+    "chinese": "你的工作",
+    "english": "your work",
+    "soundmark": "/jʊr/ /wɝk/"
+  },
+  {
+    "chinese": "关于你的工作",
+    "english": "about your work",
+    "soundmark": "/ə'baʊt/ /jʊr/ /wɝk/"
+  },
+  {
+    "chinese": "让我告诉你关于你的工作的某些事情",
+    "english": "let me tell you something about your work",
+    "soundmark": "/lɛt/ /mi/ /tɛl/ /ju/ /'sʌmθɪŋ/ /ə'baʊt/ /jʊr/ /wɝk/"
+  },
+  {
+    "chinese": "一个问题",
+    "english": "a question",
+    "soundmark": "/ə/ /'kwɛstʃən/"
+  },
+  {
+    "chinese": "问",
+    "english": "to ask",
+    "soundmark": "/tə/ /æsk/"
+  },
+  {
+    "chinese": "问你一个问题",
+    "english": "to ask you a question",
+    "soundmark": "/tə/ /æsk/ /ju/ /ə/ /'kwɛstʃən/"
+  },
+  {
+    "chinese": "让我",
+    "english": "let me",
+    "soundmark": "/lɛt/ /mi/"
+  },
+  {
+    "chinese": "让我问你一个问题",
+    "english": "let me ask you a question",
+    "soundmark": "/lɛt/ /mi/ /æsk/ /ju/ /ə/ /'kwɛstʃən/"
+  },
+  {
+    "chinese": "事实",
+    "english": "the truth",
+    "soundmark": "/ðə/ /trʊθ/"
+  },
+  {
+    "chinese": "告诉你事实",
+    "english": "to tell you the truth",
+    "soundmark": "/tə/ /tɛl/ /ju/ /ðə/ /trʊθ/"
+  },
+  {
+    "chinese": "让我",
+    "english": "let me",
+    "soundmark": "/lɛt/ /mi/"
+  },
+  {
+    "chinese": "让我告诉你事实",
+    "english": "let me tell you the truth",
+    "soundmark": "/lɛt/ /mi/ /tɛl/ /ju/ /ðə/ /trʊθ/"
+  },
+  {
+    "chinese": "一个故事",
+    "english": "a story",
+    "soundmark": "/ə/ /'stɔri/"
+  },
+  {
+    "chinese": "让我告诉你一个故事",
+    "english": "let me tell you a story",
+    "soundmark": "/lɛt/ /mi/ /tɛl/ /ju/ /ə/ /'stɔri/"
+  },
+  {
+    "chinese": "解释",
+    "english": "to explain",
+    "soundmark": "/tə/ /ɪk'splen/"
+  },
+  {
+    "chinese": "让我",
+    "english": "let me",
+    "soundmark": "/lɛt/ /mi/"
+  },
+  {
+    "chinese": "让我解释",
+    "english": "let me explain",
+    "soundmark": "/lɛt/ /mi/ /ɪk'splen/"
+  },
+  {
+    "chinese": "你的手",
+    "english": "your hands",
+    "soundmark": "/jʊr/ /hændz/"
+  },
+  {
+    "chinese": "看到",
+    "english": "to see",
+    "soundmark": "/tə/ /si/"
+  },
+  {
+    "chinese": "看到你的手",
+    "english": "to see your hands",
+    "soundmark": "/tə/ /si/ /jʊr/ /hændz/"
+  },
+  {
+    "chinese": "让我",
+    "english": "let me",
+    "soundmark": "/lɛt/ /mi/"
+  },
+  {
+    "chinese": "让我看到你的手",
+    "english": "let me see your hands",
+    "soundmark": "/lɛt/ /mi/ /si/ /jʊr/ /hændz/"
+  }
 ]

--- a/scripts/courses/11.json
+++ b/scripts/courses/11.json
@@ -1,687 +1,687 @@
 [
-	{
-		"chinese": "做",
-		"english": "to do",
-		"soundmark": "/tə/ /du/"
-	},
-	{
-		"chinese": "这件事情",
-		"english": "it",
-		"soundmark": "/ɪt/"
-	},
-	{
-		"chinese": "做这件事情",
-		"english": "to do it",
-		"soundmark": "/tə/ /du/ /ɪt/"
-	},
-	{
-		"chinese": "想要",
-		"english": "want",
-		"soundmark": "/wɑnt/"
-	},
-	{
-		"chinese": "我想要做这件事情",
-		"english": "I want to do it",
-		"soundmark": "/aɪ/ /wɑnt/ /tə/ /du/ /ɪt/"
-	},
-	{
-		"chinese": "现在",
-		"english": "now",
-		"soundmark": "/naʊ/"
-	},
-	{
-		"chinese": "我现在想要做这件事情",
-		"english": "I want to do it now",
-		"soundmark": "/aɪ/ /wɑnt/ /tə/ /du/ /ɪt/ /naʊ/"
-	},
-	{
-		"chinese": "不",
-		"english": "don't",
-		"soundmark": "/dont/"
-	},
-	{
-		"chinese": "我现在不想做这件事情",
-		"english": "I don't want to do it now",
-		"soundmark": "/aɪ/ /dont/ /wɑnt/ /tə/ /du/ /ɪt/ /naʊ/"
-	},
-	{
-		"chinese": "她现在想要做这件事",
-		"english": "she wants to do it now",
-		"soundmark": "/ʃi/ /wɑnts/ /tə/ /du/ /ɪt/ /naʊ/ /（第三人称单数）不 doesn't/ /ˈdʌznt/"
-	},
-	{
-		"chinese": "她现在不想做这件事",
-		"english": "she doesn't want to do it now",
-		"soundmark": "/ʃi/ /ˈdʌznt/ /wɑnt/ /tə/ /du/ /ɪt/ /naʊ/ /（过去）想要 wanted/ /wɑntɪd/"
-	},
-	{
-		"chinese": "我（过去）想要做这件事情",
-		"english": "I wanted to do it",
-		"soundmark": "/aɪ/ /wɑntɪd/ /tə/ /du/ /ɪt/"
-	},
-	{
-		"chinese": "昨天",
-		"english": "yesterday",
-		"soundmark": "/'jɛstɚde/"
-	},
-	{
-		"chinese": "我昨天想要做这件事情",
-		"english": "I wanted to do it yesterday",
-		"soundmark": "/aɪ/ /wɑntɪd/ /tə/ /du/ /ɪt/ /'jɛstɚde/ /（过去）不 didn't/ /ˈdɪdnt/"
-	},
-	{
-		"chinese": "我昨天不想做这件事情",
-		"english": "I didn't want to do it yesterday",
-		"soundmark": "/aɪ/ /ˈdɪdnt/ /wɑnt/ /tə/ /du/ /ɪt/"
-	},
-	{
-		"chinese": "留；待在",
-		"english": "to stay",
-		"soundmark": "/tə/ /ste/"
-	},
-	{
-		"chinese": "那里",
-		"english": "there",
-		"soundmark": "/ðɛr/"
-	},
-	{
-		"chinese": "待在那里",
-		"english": "to stay there",
-		"soundmark": "/tə/ /ste/ /ðɛr/"
-	},
-	{
-		"chinese": "喜欢",
-		"english": "like",
-		"soundmark": "/laɪk/"
-	},
-	{
-		"chinese": "我喜欢待在那里",
-		"english": "I like to stay there",
-		"soundmark": "/aɪ/ /laɪk/ /tə/ /ste/ /ðɛr/"
-	},
-	{
-		"chinese": "每天",
-		"english": "every day",
-		"soundmark": "/'ɛvri/ /de/"
-	},
-	{
-		"chinese": "我喜欢每天待在那里",
-		"english": "I like to stay there every day",
-		"soundmark": "/aɪ/ /laɪk/ /tə/ /ste/ /ðɛr/ /'ɛvri/ /de/"
-	},
-	{
-		"chinese": "不",
-		"english": "don't",
-		"soundmark": "/dont/"
-	},
-	{
-		"chinese": "我不喜欢每天待在那里",
-		"english": "I don't like to stay there every day",
-		"soundmark": "/aɪ/ /dont/ /laɪk/ /tə/ /ste/ /ðɛr/ /'ɛvri/ /de/ /（过去）喜欢 liked/ /laikt/"
-	},
-	{
-		"chinese": "我（过去）喜欢待在那里",
-		"english": "I liked to stay there",
-		"soundmark": "/aɪ/ /laikt/ /tə/ /ste/ /ðɛr/ /（过去）不 didn't/ /ˈdɪdnt/"
-	},
-	{
-		"chinese": "我（过去）不喜欢待在那里",
-		"english": "I didn't like to stay there",
-		"soundmark": "/aɪ/ /ˈdɪdnt/ /laɪk/ /tə/ /ste/ /ðɛr/"
-	},
-	{
-		"chinese": "离开",
-		"english": "to leave",
-		"soundmark": "/tə/ /liv/"
-	},
-	{
-		"chinese": "这座城市",
-		"english": "the city",
-		"soundmark": "/ðə/ /'sɪti/"
-	},
-	{
-		"chinese": "我必须离开这座城市",
-		"english": "I have to leave the city",
-		"soundmark": "/aɪ/ /hæv/ /tə/ /liv/ /ðə/ /'sɪti/"
-	},
-	{
-		"chinese": "今天",
-		"english": "today",
-		"soundmark": "/tə'de/"
-	},
-	{
-		"chinese": "我今天必须离开这座城市",
-		"english": "I have to leave the city today",
-		"soundmark": "/aɪ/ /hæv/ /tə/ /liv/ /ðə/ /'sɪti/ /tə'de/"
-	},
-	{
-		"chinese": "不",
-		"english": "don't",
-		"soundmark": "/dont/"
-	},
-	{
-		"chinese": "我今天不必离开这座城市",
-		"english": "I don't have to leave the city today",
-		"soundmark": "/aɪ/ /dont/ /hæv/ /tə/ /liv/ /ðə/ /'sɪti/ /tə'de/"
-	},
-	{
-		"chinese": "我（过去）必须",
-		"english": "I had to",
-		"soundmark": "/aɪ/ /hæd/ /tə/"
-	},
-	{
-		"chinese": "我（过去）必须离开这座城市",
-		"english": "I had to leave the city",
-		"soundmark": "/aɪ/ /hæd/ /tə/ /liv/ /ðə/ /'sɪti/"
-	},
-	{
-		"chinese": "时间",
-		"english": "time",
-		"soundmark": "/taɪm/"
-	},
-	{
-		"chinese": "那个",
-		"english": "that",
-		"soundmark": "/ðæt/"
-	},
-	{
-		"chinese": "在那时",
-		"english": "at that time",
-		"soundmark": "/ət/ /ðæt/ /taɪm/"
-	},
-	{
-		"chinese": "我必须在那时离开这座城市",
-		"english": "I had to leave the city at that time",
-		"soundmark": "/aɪ/ /hæd/ /tə/ /liv/ /ðə/ /'sɪti/ /ət/ /ðæt/ /taɪm/ /（过去）不 didn't/ /ˈdɪdnt/"
-	},
-	{
-		"chinese": "我不必在那时离开这座城市",
-		"english": "I didn't have to leave the city at that time",
-		"soundmark": "/aɪ/ /ˈdɪdnt/ /hæv/ /tə/ /liv/ /ðə/ /'sɪti/ /ət/ /ðæt/ /taɪm/"
-	},
-	{
-		"chinese": "计划；打算",
-		"english": "plan",
-		"soundmark": "/plæn/"
-	},
-	{
-		"chinese": "去；达到",
-		"english": "to get",
-		"soundmark": "/tə/ /ɡɛt/"
-	},
-	{
-		"chinese": "去那里",
-		"english": "to get there",
-		"soundmark": "/tə/ /ɡɛt/ /ðɛr/"
-	},
-	{
-		"chinese": "我打算去那里",
-		"english": "I plan to get there",
-		"soundmark": "/aɪ/ /plæn/ /tə/ /ɡɛt/ /ðɛr/"
-	},
-	{
-		"chinese": "不",
-		"english": "don't",
-		"soundmark": "/dont/"
-	},
-	{
-		"chinese": "我不打算去那里",
-		"english": "I don't plan to get there",
-		"soundmark": "/aɪ/ /dont/ /plæn/ /tə/ /ɡɛt/ /ðɛr/ /（过去）打算 planned/ /plænd/"
-	},
-	{
-		"chinese": "我（过去）打算去那里",
-		"english": "I planned to get there",
-		"soundmark": "/aɪ/ /plænd/ /tə/ /ɡɛt/ /ðɛr/ /（过去）不 didn't/ /ˈdɪdnt/"
-	},
-	{
-		"chinese": "我（过去）不打算去那里",
-		"english": "I didn't plan to get there",
-		"soundmark": "/aɪ/ /ˈdɪdnt/ /plæn/ /tə/ /ɡɛt/ /ðɛr/"
-	},
-	{
-		"chinese": "知道",
-		"english": "to know",
-		"soundmark": "/tə/ /no/"
-	},
-	{
-		"chinese": "事实；真相",
-		"english": "the truth",
-		"soundmark": "/ðə/ /trʊθ/"
-	},
-	{
-		"chinese": "需要",
-		"english": "need",
-		"soundmark": "/nid/"
-	},
-	{
-		"chinese": "我需要知道真相",
-		"english": "I need to know the truth",
-		"soundmark": "/aɪ/ /nid/ /tə/ /no/ /ðə/ /trʊθ/"
-	},
-	{
-		"chinese": "尽快；尽可能地快",
-		"english": "as soon as possible",
-		"soundmark": "/əz/ /sun/ /əz/ /'pɑsəbl/"
-	},
-	{
-		"chinese": "我需要尽快知道真相",
-		"english": "I need to know the truth as soon as possible",
-		"soundmark": "/aɪ/ /nid/ /tə/ /no/ /ðə/ /trʊθ/ /əz/ /sun/ /əz/ /'pɑsəbl/"
-	},
-	{
-		"chinese": "不",
-		"english": "don't",
-		"soundmark": "/dont/"
-	},
-	{
-		"chinese": "我不需要知道真相",
-		"english": "I don't need to know the truth",
-		"soundmark": "/aɪ/ /dont/ /nid/ /tə/ /no/ /ðə/ /trʊθ/ /（过去）需要 needed/ /nidɪd/"
-	},
-	{
-		"chinese": "我（过去）需要知道真相",
-		"english": "I needed to know the truth",
-		"soundmark": "/aɪ/ /nidɪd/ /tə/ /no/ /ðə/ /trʊθ/ /（过去）不 didn't/ /ˈdɪdnt/"
-	},
-	{
-		"chinese": "我（过去）不需要知道真相",
-		"english": "I didn't need to know the truth",
-		"soundmark": "/aɪ/ /ˈdɪdnt/ /nid/ /tə/ /no/ /ðə/ /trʊθ/"
-	},
-	{
-		"chinese": "她（过去）需要知道真相",
-		"english": "she needed to know the truth",
-		"soundmark": "/ʃi/ /nidɪd/ /tə/ /no/ /ðə/ /trʊθ/ /（过去）不 didn't/ /ˈdɪdnt/"
-	},
-	{
-		"chinese": "她（过去）不需要知道真相",
-		"english": "she didn't need to know the truth",
-		"soundmark": "/ʃi/ /ˈdɪdnt/ /nid/ /tə/ /no/ /ðə/ /trʊθ/"
-	},
-	{
-		"chinese": "做这件事情",
-		"english": "to do it",
-		"soundmark": "/tə/ /du/ /ɪt/"
-	},
-	{
-		"chinese": "你做这件事情",
-		"english": "you do it",
-		"soundmark": "/ju/ /du/ /ɪt/"
-	},
-	{
-		"chinese": "你现在做这件事情",
-		"english": "you do it now",
-		"soundmark": "/ju/ /du/ /ɪt/ /naʊ/"
-	},
-	{
-		"chinese": "不",
-		"english": "don't",
-		"soundmark": "/dont/"
-	},
-	{
-		"chinese": "你现在不做这件事情",
-		"english": "you don't do it now",
-		"soundmark": "/ju/ /dont/ /du/ /ɪt/ /naʊ/ /（过去）做 did/ /dɪd/"
-	},
-	{
-		"chinese": "你（过去）做这件事情",
-		"english": "you did it",
-		"soundmark": "/ju/ /dɪd/ /ɪt/"
-	},
-	{
-		"chinese": "年",
-		"english": "year",
-		"soundmark": "/jɪr/"
-	},
-	{
-		"chinese": "上一个",
-		"english": "last",
-		"soundmark": "/læst/"
-	},
-	{
-		"chinese": "去年",
-		"english": "last year",
-		"soundmark": "/læst/ /jɪr/"
-	},
-	{
-		"chinese": "你去年做这件事情",
-		"english": "you did it last year",
-		"soundmark": "/ju/ /dɪd/ /ɪt/ /læst/ /jɪr/ /（过去）不 didn't/ /ˈdɪdnt/"
-	},
-	{
-		"chinese": "你去年没做这件事情",
-		"english": "you didn't do it last year",
-		"soundmark": "/ju/ /ˈdɪdnt/ /du/ /ɪt/ /læst/ /jɪr/"
-	},
-	{
-		"chinese": "告诉",
-		"english": "to tell",
-		"soundmark": "/tə/ /tɛl/"
-	},
-	{
-		"chinese": "告诉我",
-		"english": "to tell me",
-		"soundmark": "/tə/ /tɛl/ /mi/"
-	},
-	{
-		"chinese": "你告诉我",
-		"english": "you tell me",
-		"soundmark": "/ju/ /tɛl/ /mi/"
-	},
-	{
-		"chinese": "不",
-		"english": "don't",
-		"soundmark": "/dont/"
-	},
-	{
-		"chinese": "你不告诉我",
-		"english": "you don't tell me",
-		"soundmark": "/ju/ /dont/ /tɛl/ /mi/"
-	},
-	{
-		"chinese": "她告诉我",
-		"english": "she tells me",
-		"soundmark": "/ʃi/ /tɛlz/ /mi/ /（第三人称单数）不 doesn't/ /ˈdʌznt/"
-	},
-	{
-		"chinese": "她不告诉我",
-		"english": "she doesn't tell me",
-		"soundmark": "/ʃi/ /ˈdʌznt/ /tɛl/ /mi/ /（过去）告诉 told/ /told/ /（过去）告诉我 told me/ /told/ /mi/"
-	},
-	{
-		"chinese": "他（过去）告诉我",
-		"english": "he told me",
-		"soundmark": "/hi/ /told/ /mi/ /（过去）不 didn't/ /ˈdɪdnt/"
-	},
-	{
-		"chinese": "他（过去）没告诉我",
-		"english": "he didn't tell me",
-		"soundmark": "/hi/ /ˈdɪdnt/ /tɛl/ /mi/"
-	},
-	{
-		"chinese": "事实；真相",
-		"english": "the truth",
-		"soundmark": "/ðə/ /trʊθ/"
-	},
-	{
-		"chinese": "他（过去）没告诉我真相",
-		"english": "he didn't tell me the truth",
-		"soundmark": "/hi/ /ˈdɪdnt/ /tɛl/ /mi/ /ðə/ /trʊθ/ /（过去）需要 needed/ /nidɪd/"
-	},
-	{
-		"chinese": "知道",
-		"english": "to know",
-		"soundmark": "/tə/ /no/"
-	},
-	{
-		"chinese": "知道真相",
-		"english": "to know the truth",
-		"soundmark": "/tə/ /no/ /ðə/ /trʊθ/"
-	},
-	{
-		"chinese": "他（过去）需要知道真相",
-		"english": "he needed to know the truth",
-		"soundmark": "/hi/ /nidɪd/ /tə/ /no/ /ðə/ /trʊθ/"
-	},
-	{
-		"chinese": "他（过去）告诉我",
-		"english": "he told me",
-		"soundmark": "/hi/ /told/ /mi/"
-	},
-	{
-		"chinese": "他（过去）告诉我他（过去）需要知道真相",
-		"english": "he told me he needed to know the truth",
-		"soundmark": "/hi/ /told/ /mi/ /hi/ /nidɪd/ /tə/ /no/ /ðə/ /trʊθ/"
-	},
-	{
-		"chinese": "重要的",
-		"english": "important",
-		"soundmark": "/ɪm'pɔrtnt/"
-	},
-	{
-		"chinese": "它是重要的",
-		"english": "it is important",
-		"soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/"
-	},
-	{
-		"chinese": "它（过去）是重要的",
-		"english": "it was important",
-		"soundmark": "/ɪt/ /wəz/ /ɪm'pɔrtnt/"
-	},
-	{
-		"chinese": "因为",
-		"english": "because",
-		"soundmark": "/bɪ'kɔz/"
-	},
-	{
-		"chinese": "因为它（过去）是重要的",
-		"english": "because it was important",
-		"soundmark": "/bɪ'kɔz/ /ɪt/ /wəz/ /ɪm'pɔrtnt/"
-	},
-	{
-		"chinese": "他（过去）告诉我他（过去）需要知道真相",
-		"english": "he told me he needed to know the truth",
-		"soundmark": "/hi/ /told/ /mi/ /hi/ /nidɪd/ /tə/ /no/ /ðə/ /trʊθ/"
-	},
-	{
-		"chinese": "他（过去）告诉我他（过去）需要知道真相因为它（过去）是重要的",
-		"english": "he told me he needed to know the truth because it was important",
-		"soundmark": "/hi/ /told/ /mi/ /hi/ /nidɪd/ /tə/ /no/ /ðə/ /trʊθ/ /bɪ'kɔz/ /ɪt/ /wəz/ /ɪm'pɔrtnt/"
-	},
-	{
-		"chinese": "存在；成为",
-		"english": "to be",
-		"soundmark": "/tə/ /bi/"
-	},
-	{
-		"chinese": "一个老师",
-		"english": "a teacher",
-		"soundmark": "/ə/ /'titʃɚ/"
-	},
-	{
-		"chinese": "成为一个老师",
-		"english": "to be a teacher",
-		"soundmark": "/tə/ /bi/ /ə/ /'titʃɚ/ /（过去）想要 wanted/ /wɑntɪd/"
-	},
-	{
-		"chinese": "我（过去）想要成为一个老师",
-		"english": "I wanted to be a teacher",
-		"soundmark": "/aɪ/ /wɑntɪd/ /tə/ /bi/ /ə/ /'titʃɚ/"
-	},
-	{
-		"chinese": "重要的",
-		"english": "important",
-		"soundmark": "/ɪm'pɔrtnt/"
-	},
-	{
-		"chinese": "我是重要的",
-		"english": "I am important",
-		"soundmark": "/aɪ/ /æm/ /ɪm'pɔrtnt/"
-	},
-	{
-		"chinese": "我（过去）是重要的",
-		"english": "I was important",
-		"soundmark": "/aɪ/ /wəz/ /ɪm'pɔrtnt/"
-	},
-	{
-		"chinese": "年轻的",
-		"english": "young",
-		"soundmark": "/jʌŋ/"
-	},
-	{
-		"chinese": "我是年轻的",
-		"english": "I am young",
-		"soundmark": "/aɪ/ /æm/ /jʌŋ/"
-	},
-	{
-		"chinese": "我（过去）是年轻的",
-		"english": "I was young",
-		"soundmark": "/aɪ/ /wəz/ /jʌŋ/"
-	},
-	{
-		"chinese": "当......的时候",
-		"english": "when",
-		"soundmark": "/wɛn/"
-	},
-	{
-		"chinese": "当我（过去）是年轻的时候",
-		"english": "when I was young",
-		"soundmark": "/wɛn/ /aɪ/ /wəz/ /jʌŋ/"
-	},
-	{
-		"chinese": "我（过去）想要成为一个老师",
-		"english": "I wanted to be a teacher",
-		"soundmark": "/aɪ/ /wɑntɪd/ /tə/ /bi/ /ə/ /'titʃɚ/"
-	},
-	{
-		"chinese": "我（过去）想要成为一个老师当我（过去）是年轻的时候",
-		"english": "I wanted to be a teacher when I was young",
-		"soundmark": "/aɪ/ /wɑntɪd/ /tə/ /bi/ /ə/ /'titʃɚ/ /wɛn/ /aɪ/ /wəz/ /jʌŋ/"
-	},
-	{
-		"chinese": "交谈；聊天",
-		"english": "to talk",
-		"soundmark": "/tə/ /tɔk/ /（过去）聊天 talked/ /tɔkt/"
-	},
-	{
-		"chinese": "我们（过去）聊天",
-		"english": "we talked",
-		"soundmark": "/wi/ /tɔkt/"
-	},
-	{
-		"chinese": "在......之前；以前",
-		"english": "before",
-		"soundmark": "/bɪ'fɔr/"
-	},
-	{
-		"chinese": "我们以前聊过天",
-		"english": "we talked before",
-		"soundmark": "/wi/ /tɔkt/ /bɪ'fɔr/"
-	},
-	{
-		"chinese": "和她（过去）聊天",
-		"english": "talked with her",
-		"soundmark": "/tɔkt/ /wɪð/ /hɚ/"
-	},
-	{
-		"chinese": "我和她聊过天",
-		"english": "I talked with her",
-		"soundmark": "/aɪ/ /tɔkt/ /wɪð/ /hɚ/"
-	},
-	{
-		"chinese": "我以前和她聊过天",
-		"english": "I talked with her before",
-		"soundmark": "/aɪ/ /tɔkt/ /wɪð/ /hɚ/ /bɪ'fɔr/"
-	},
-	{
-		"chinese": "昨天",
-		"english": "yesterday",
-		"soundmark": "/'jɛstɚde/"
-	},
-	{
-		"chinese": "那一天",
-		"english": "the day",
-		"soundmark": "/ðə/ /de/"
-	},
-	{
-		"chinese": "在......之前；以前",
-		"english": "before",
-		"soundmark": "/bɪ'fɔr/ /（在昨天之前的那一天）前天 the day before yesterday/ /ðə/ /de/ /bɪ'fɔr/ /'jɛstɚde/"
-	},
-	{
-		"chinese": "我前天和她聊过天",
-		"english": "I talked with her the day before yesterday",
-		"soundmark": "/aɪ/ /tɔkt/ /wɪð/ /hɚ/ /ðə/ /de/ /bɪ'fɔr/ /'jɛstɚde/"
-	},
-	{
-		"chinese": "上一个",
-		"english": "last",
-		"soundmark": "/læst/"
-	},
-	{
-		"chinese": "星期；周",
-		"english": "week",
-		"soundmark": "/wik/"
-	},
-	{
-		"chinese": "周末",
-		"english": "weekend",
-		"soundmark": "/'wikɛnd/"
-	},
-	{
-		"chinese": "上周末",
-		"english": "last weekend",
-		"soundmark": "/læst/ /'wikɛnd/"
-	},
-	{
-		"chinese": "我上周末和她聊过天",
-		"english": "I talked with her last weekend",
-		"soundmark": "/aɪ/ /tɔkt/ /wɪð/ /hɚ/ /læst/ /'wikɛnd/"
-	},
-	{
-		"chinese": "改变",
-		"english": "to change",
-		"soundmark": "/tə/ /tʃendʒ/"
-	},
-	{
-		"chinese": "世界",
-		"english": "the world",
-		"soundmark": "/ðə/ /wɝld/"
-	},
-	{
-		"chinese": "改变世界",
-		"english": "to change the world",
-		"soundmark": "/tə/ /tʃendʒ/ /ðə/ /wɝld/"
-	},
-	{
-		"chinese": "她想要改变世界",
-		"english": "she wants to change the world",
-		"soundmark": "/ʃi/ /wɑnts/ /tə/ /tʃendʒ/ /ðə/ /wɝld/"
-	},
-	{
-		"chinese": "她（过去）想要改变世界",
-		"english": "she wanted to change the world",
-		"soundmark": "/ʃi/ /wɑntɪd/ /tə/ /tʃendʒ/ /ðə/ /wɝld/"
-	},
-	{
-		"chinese": "年轻的",
-		"english": "young",
-		"soundmark": "/jʌŋ/"
-	},
-	{
-		"chinese": "她（过去）是年轻的",
-		"english": "she was young",
-		"soundmark": "/ʃi/ /wəz/ /jʌŋ/"
-	},
-	{
-		"chinese": "当......的时候",
-		"english": "when",
-		"soundmark": "/wɛn/"
-	},
-	{
-		"chinese": "当她（过去）是年轻的时候",
-		"english": "when she was young",
-		"soundmark": "/wɛn/ /ʃi/ /wəz/ /jʌŋ/"
-	},
-	{
-		"chinese": "她（过去）想要改变世界当她",
-		"english": "（过去）是年轻的时候 she wanted to change the world when she was young",
-		"soundmark": "/ʃi/ /wɑntɪd/ /tə/ /tʃendʒ/ /ðə/ /wɝld/ /wɛn/ /ʃi/ /wəz/ /jʌŋ/"
-	},
-	{
-		"chinese": "她（过去）告诉我",
-		"english": "she told me",
-		"soundmark": "/ʃi/ /told/ /mi/"
-	},
-	{
-		"chinese": "她（过去）告诉我她（过去）想要改变世界当她（过去）是年轻的时候",
-		"english": "she told me she wanted to change the world when she was young",
-		"soundmark": "/ʃi/ /told/ /mi/ /ʃi/ /wɑntɪd/ /tə/ /tʃendʒ/ /ðə/ /wɝld/ /wɛn/ /ʃi/ /wəz/ /jʌŋ/"
-	},
-	{
-		"chinese": "我上周末和她聊过天而且她告诉我她（想要）改变世界当她",
-		"english": "（过去）是年轻的时候 I talked with her last weekend and she told me she wanted to change the world when she was young",
-		"soundmark": "/aɪ/ /tɔkt/ /wɪð/ /hɚ/ /læst/ /'wikɛnd/ /ənd/ /ʃi/ /told/ /mi/ /ʃi/ /wɑntɪd/ /tə/ /tʃendʒ/ /ðə/ /wɝld/ /wɛn/ /ʃi/ /wəz/ /jʌŋ/"
-	}
+  {
+    "chinese": "做",
+    "english": "to do",
+    "soundmark": "/tə/ /du/"
+  },
+  {
+    "chinese": "这件事情",
+    "english": "it",
+    "soundmark": "/ɪt/"
+  },
+  {
+    "chinese": "做这件事情",
+    "english": "to do it",
+    "soundmark": "/tə/ /du/ /ɪt/"
+  },
+  {
+    "chinese": "想要",
+    "english": "want",
+    "soundmark": "/wɑnt/"
+  },
+  {
+    "chinese": "我想要做这件事情",
+    "english": "I want to do it",
+    "soundmark": "/aɪ/ /wɑnt/ /tə/ /du/ /ɪt/"
+  },
+  {
+    "chinese": "现在",
+    "english": "now",
+    "soundmark": "/naʊ/"
+  },
+  {
+    "chinese": "我现在想要做这件事情",
+    "english": "I want to do it now",
+    "soundmark": "/aɪ/ /wɑnt/ /tə/ /du/ /ɪt/ /naʊ/"
+  },
+  {
+    "chinese": "不",
+    "english": "don't",
+    "soundmark": "/dont/"
+  },
+  {
+    "chinese": "我现在不想做这件事情",
+    "english": "I don't want to do it now",
+    "soundmark": "/aɪ/ /dont/ /wɑnt/ /tə/ /du/ /ɪt/ /naʊ/"
+  },
+  {
+    "chinese": "她现在想要做这件事",
+    "english": "she wants to do it now",
+    "soundmark": "/ʃi/ /wɑnts/ /tə/ /du/ /ɪt/ /naʊ/ /（第三人称单数）不 doesn't/ /ˈdʌznt/"
+  },
+  {
+    "chinese": "她现在不想做这件事",
+    "english": "she doesn't want to do it now",
+    "soundmark": "/ʃi/ /ˈdʌznt/ /wɑnt/ /tə/ /du/ /ɪt/ /naʊ/ /（过去）想要 wanted/ /wɑntɪd/"
+  },
+  {
+    "chinese": "我（过去）想要做这件事情",
+    "english": "I wanted to do it",
+    "soundmark": "/aɪ/ /wɑntɪd/ /tə/ /du/ /ɪt/"
+  },
+  {
+    "chinese": "昨天",
+    "english": "yesterday",
+    "soundmark": "/'jɛstɚde/"
+  },
+  {
+    "chinese": "我昨天想要做这件事情",
+    "english": "I wanted to do it yesterday",
+    "soundmark": "/aɪ/ /wɑntɪd/ /tə/ /du/ /ɪt/ /'jɛstɚde/ /（过去）不 didn't/ /ˈdɪdnt/"
+  },
+  {
+    "chinese": "我昨天不想做这件事情",
+    "english": "I didn't want to do it yesterday",
+    "soundmark": "/aɪ/ /ˈdɪdnt/ /wɑnt/ /tə/ /du/ /ɪt/"
+  },
+  {
+    "chinese": "留；待在",
+    "english": "to stay",
+    "soundmark": "/tə/ /ste/"
+  },
+  {
+    "chinese": "那里",
+    "english": "there",
+    "soundmark": "/ðɛr/"
+  },
+  {
+    "chinese": "待在那里",
+    "english": "to stay there",
+    "soundmark": "/tə/ /ste/ /ðɛr/"
+  },
+  {
+    "chinese": "喜欢",
+    "english": "like",
+    "soundmark": "/laɪk/"
+  },
+  {
+    "chinese": "我喜欢待在那里",
+    "english": "I like to stay there",
+    "soundmark": "/aɪ/ /laɪk/ /tə/ /ste/ /ðɛr/"
+  },
+  {
+    "chinese": "每天",
+    "english": "every day",
+    "soundmark": "/'ɛvri/ /de/"
+  },
+  {
+    "chinese": "我喜欢每天待在那里",
+    "english": "I like to stay there every day",
+    "soundmark": "/aɪ/ /laɪk/ /tə/ /ste/ /ðɛr/ /'ɛvri/ /de/"
+  },
+  {
+    "chinese": "不",
+    "english": "don't",
+    "soundmark": "/dont/"
+  },
+  {
+    "chinese": "我不喜欢每天待在那里",
+    "english": "I don't like to stay there every day",
+    "soundmark": "/aɪ/ /dont/ /laɪk/ /tə/ /ste/ /ðɛr/ /'ɛvri/ /de/ /（过去）喜欢 liked/ /laikt/"
+  },
+  {
+    "chinese": "我（过去）喜欢待在那里",
+    "english": "I liked to stay there",
+    "soundmark": "/aɪ/ /laikt/ /tə/ /ste/ /ðɛr/ /（过去）不 didn't/ /ˈdɪdnt/"
+  },
+  {
+    "chinese": "我（过去）不喜欢待在那里",
+    "english": "I didn't like to stay there",
+    "soundmark": "/aɪ/ /ˈdɪdnt/ /laɪk/ /tə/ /ste/ /ðɛr/"
+  },
+  {
+    "chinese": "离开",
+    "english": "to leave",
+    "soundmark": "/tə/ /liv/"
+  },
+  {
+    "chinese": "这座城市",
+    "english": "the city",
+    "soundmark": "/ðə/ /'sɪti/"
+  },
+  {
+    "chinese": "我必须离开这座城市",
+    "english": "I have to leave the city",
+    "soundmark": "/aɪ/ /hæv/ /tə/ /liv/ /ðə/ /'sɪti/"
+  },
+  {
+    "chinese": "今天",
+    "english": "today",
+    "soundmark": "/tə'de/"
+  },
+  {
+    "chinese": "我今天必须离开这座城市",
+    "english": "I have to leave the city today",
+    "soundmark": "/aɪ/ /hæv/ /tə/ /liv/ /ðə/ /'sɪti/ /tə'de/"
+  },
+  {
+    "chinese": "不",
+    "english": "don't",
+    "soundmark": "/dont/"
+  },
+  {
+    "chinese": "我今天不必离开这座城市",
+    "english": "I don't have to leave the city today",
+    "soundmark": "/aɪ/ /dont/ /hæv/ /tə/ /liv/ /ðə/ /'sɪti/ /tə'de/"
+  },
+  {
+    "chinese": "我（过去）必须",
+    "english": "I had to",
+    "soundmark": "/aɪ/ /hæd/ /tə/"
+  },
+  {
+    "chinese": "我（过去）必须离开这座城市",
+    "english": "I had to leave the city",
+    "soundmark": "/aɪ/ /hæd/ /tə/ /liv/ /ðə/ /'sɪti/"
+  },
+  {
+    "chinese": "时间",
+    "english": "time",
+    "soundmark": "/taɪm/"
+  },
+  {
+    "chinese": "那个",
+    "english": "that",
+    "soundmark": "/ðæt/"
+  },
+  {
+    "chinese": "在那时",
+    "english": "at that time",
+    "soundmark": "/ət/ /ðæt/ /taɪm/"
+  },
+  {
+    "chinese": "我必须在那时离开这座城市",
+    "english": "I had to leave the city at that time",
+    "soundmark": "/aɪ/ /hæd/ /tə/ /liv/ /ðə/ /'sɪti/ /ət/ /ðæt/ /taɪm/ /（过去）不 didn't/ /ˈdɪdnt/"
+  },
+  {
+    "chinese": "我不必在那时离开这座城市",
+    "english": "I didn't have to leave the city at that time",
+    "soundmark": "/aɪ/ /ˈdɪdnt/ /hæv/ /tə/ /liv/ /ðə/ /'sɪti/ /ət/ /ðæt/ /taɪm/"
+  },
+  {
+    "chinese": "计划；打算",
+    "english": "plan",
+    "soundmark": "/plæn/"
+  },
+  {
+    "chinese": "去；达到",
+    "english": "to get",
+    "soundmark": "/tə/ /ɡɛt/"
+  },
+  {
+    "chinese": "去那里",
+    "english": "to get there",
+    "soundmark": "/tə/ /ɡɛt/ /ðɛr/"
+  },
+  {
+    "chinese": "我打算去那里",
+    "english": "I plan to get there",
+    "soundmark": "/aɪ/ /plæn/ /tə/ /ɡɛt/ /ðɛr/"
+  },
+  {
+    "chinese": "不",
+    "english": "don't",
+    "soundmark": "/dont/"
+  },
+  {
+    "chinese": "我不打算去那里",
+    "english": "I don't plan to get there",
+    "soundmark": "/aɪ/ /dont/ /plæn/ /tə/ /ɡɛt/ /ðɛr/ /（过去）打算 planned/ /plænd/"
+  },
+  {
+    "chinese": "我（过去）打算去那里",
+    "english": "I planned to get there",
+    "soundmark": "/aɪ/ /plænd/ /tə/ /ɡɛt/ /ðɛr/ /（过去）不 didn't/ /ˈdɪdnt/"
+  },
+  {
+    "chinese": "我（过去）不打算去那里",
+    "english": "I didn't plan to get there",
+    "soundmark": "/aɪ/ /ˈdɪdnt/ /plæn/ /tə/ /ɡɛt/ /ðɛr/"
+  },
+  {
+    "chinese": "知道",
+    "english": "to know",
+    "soundmark": "/tə/ /no/"
+  },
+  {
+    "chinese": "事实；真相",
+    "english": "the truth",
+    "soundmark": "/ðə/ /trʊθ/"
+  },
+  {
+    "chinese": "需要",
+    "english": "need",
+    "soundmark": "/nid/"
+  },
+  {
+    "chinese": "我需要知道真相",
+    "english": "I need to know the truth",
+    "soundmark": "/aɪ/ /nid/ /tə/ /no/ /ðə/ /trʊθ/"
+  },
+  {
+    "chinese": "尽快；尽可能地快",
+    "english": "as soon as possible",
+    "soundmark": "/əz/ /sun/ /əz/ /'pɑsəbl/"
+  },
+  {
+    "chinese": "我需要尽快知道真相",
+    "english": "I need to know the truth as soon as possible",
+    "soundmark": "/aɪ/ /nid/ /tə/ /no/ /ðə/ /trʊθ/ /əz/ /sun/ /əz/ /'pɑsəbl/"
+  },
+  {
+    "chinese": "不",
+    "english": "don't",
+    "soundmark": "/dont/"
+  },
+  {
+    "chinese": "我不需要知道真相",
+    "english": "I don't need to know the truth",
+    "soundmark": "/aɪ/ /dont/ /nid/ /tə/ /no/ /ðə/ /trʊθ/ /（过去）需要 needed/ /nidɪd/"
+  },
+  {
+    "chinese": "我（过去）需要知道真相",
+    "english": "I needed to know the truth",
+    "soundmark": "/aɪ/ /nidɪd/ /tə/ /no/ /ðə/ /trʊθ/ /（过去）不 didn't/ /ˈdɪdnt/"
+  },
+  {
+    "chinese": "我（过去）不需要知道真相",
+    "english": "I didn't need to know the truth",
+    "soundmark": "/aɪ/ /ˈdɪdnt/ /nid/ /tə/ /no/ /ðə/ /trʊθ/"
+  },
+  {
+    "chinese": "她（过去）需要知道真相",
+    "english": "she needed to know the truth",
+    "soundmark": "/ʃi/ /nidɪd/ /tə/ /no/ /ðə/ /trʊθ/ /（过去）不 didn't/ /ˈdɪdnt/"
+  },
+  {
+    "chinese": "她（过去）不需要知道真相",
+    "english": "she didn't need to know the truth",
+    "soundmark": "/ʃi/ /ˈdɪdnt/ /nid/ /tə/ /no/ /ðə/ /trʊθ/"
+  },
+  {
+    "chinese": "做这件事情",
+    "english": "to do it",
+    "soundmark": "/tə/ /du/ /ɪt/"
+  },
+  {
+    "chinese": "你做这件事情",
+    "english": "you do it",
+    "soundmark": "/ju/ /du/ /ɪt/"
+  },
+  {
+    "chinese": "你现在做这件事情",
+    "english": "you do it now",
+    "soundmark": "/ju/ /du/ /ɪt/ /naʊ/"
+  },
+  {
+    "chinese": "不",
+    "english": "don't",
+    "soundmark": "/dont/"
+  },
+  {
+    "chinese": "你现在不做这件事情",
+    "english": "you don't do it now",
+    "soundmark": "/ju/ /dont/ /du/ /ɪt/ /naʊ/ /（过去）做 did/ /dɪd/"
+  },
+  {
+    "chinese": "你（过去）做这件事情",
+    "english": "you did it",
+    "soundmark": "/ju/ /dɪd/ /ɪt/"
+  },
+  {
+    "chinese": "年",
+    "english": "year",
+    "soundmark": "/jɪr/"
+  },
+  {
+    "chinese": "上一个",
+    "english": "last",
+    "soundmark": "/læst/"
+  },
+  {
+    "chinese": "去年",
+    "english": "last year",
+    "soundmark": "/læst/ /jɪr/"
+  },
+  {
+    "chinese": "你去年做这件事情",
+    "english": "you did it last year",
+    "soundmark": "/ju/ /dɪd/ /ɪt/ /læst/ /jɪr/ /（过去）不 didn't/ /ˈdɪdnt/"
+  },
+  {
+    "chinese": "你去年没做这件事情",
+    "english": "you didn't do it last year",
+    "soundmark": "/ju/ /ˈdɪdnt/ /du/ /ɪt/ /læst/ /jɪr/"
+  },
+  {
+    "chinese": "告诉",
+    "english": "to tell",
+    "soundmark": "/tə/ /tɛl/"
+  },
+  {
+    "chinese": "告诉我",
+    "english": "to tell me",
+    "soundmark": "/tə/ /tɛl/ /mi/"
+  },
+  {
+    "chinese": "你告诉我",
+    "english": "you tell me",
+    "soundmark": "/ju/ /tɛl/ /mi/"
+  },
+  {
+    "chinese": "不",
+    "english": "don't",
+    "soundmark": "/dont/"
+  },
+  {
+    "chinese": "你不告诉我",
+    "english": "you don't tell me",
+    "soundmark": "/ju/ /dont/ /tɛl/ /mi/"
+  },
+  {
+    "chinese": "她告诉我",
+    "english": "she tells me",
+    "soundmark": "/ʃi/ /tɛlz/ /mi/ /（第三人称单数）不 doesn't/ /ˈdʌznt/"
+  },
+  {
+    "chinese": "她不告诉我",
+    "english": "she doesn't tell me",
+    "soundmark": "/ʃi/ /ˈdʌznt/ /tɛl/ /mi/ /（过去）告诉 told/ /told/ /（过去）告诉我 told me/ /told/ /mi/"
+  },
+  {
+    "chinese": "他（过去）告诉我",
+    "english": "he told me",
+    "soundmark": "/hi/ /told/ /mi/ /（过去）不 didn't/ /ˈdɪdnt/"
+  },
+  {
+    "chinese": "他（过去）没告诉我",
+    "english": "he didn't tell me",
+    "soundmark": "/hi/ /ˈdɪdnt/ /tɛl/ /mi/"
+  },
+  {
+    "chinese": "事实；真相",
+    "english": "the truth",
+    "soundmark": "/ðə/ /trʊθ/"
+  },
+  {
+    "chinese": "他（过去）没告诉我真相",
+    "english": "he didn't tell me the truth",
+    "soundmark": "/hi/ /ˈdɪdnt/ /tɛl/ /mi/ /ðə/ /trʊθ/ /（过去）需要 needed/ /nidɪd/"
+  },
+  {
+    "chinese": "知道",
+    "english": "to know",
+    "soundmark": "/tə/ /no/"
+  },
+  {
+    "chinese": "知道真相",
+    "english": "to know the truth",
+    "soundmark": "/tə/ /no/ /ðə/ /trʊθ/"
+  },
+  {
+    "chinese": "他（过去）需要知道真相",
+    "english": "he needed to know the truth",
+    "soundmark": "/hi/ /nidɪd/ /tə/ /no/ /ðə/ /trʊθ/"
+  },
+  {
+    "chinese": "他（过去）告诉我",
+    "english": "he told me",
+    "soundmark": "/hi/ /told/ /mi/"
+  },
+  {
+    "chinese": "他（过去）告诉我他（过去）需要知道真相",
+    "english": "he told me he needed to know the truth",
+    "soundmark": "/hi/ /told/ /mi/ /hi/ /nidɪd/ /tə/ /no/ /ðə/ /trʊθ/"
+  },
+  {
+    "chinese": "重要的",
+    "english": "important",
+    "soundmark": "/ɪm'pɔrtnt/"
+  },
+  {
+    "chinese": "它是重要的",
+    "english": "it is important",
+    "soundmark": "/ɪt/ /ɪz/ /ɪm'pɔrtnt/"
+  },
+  {
+    "chinese": "它（过去）是重要的",
+    "english": "it was important",
+    "soundmark": "/ɪt/ /wəz/ /ɪm'pɔrtnt/"
+  },
+  {
+    "chinese": "因为",
+    "english": "because",
+    "soundmark": "/bɪ'kɔz/"
+  },
+  {
+    "chinese": "因为它（过去）是重要的",
+    "english": "because it was important",
+    "soundmark": "/bɪ'kɔz/ /ɪt/ /wəz/ /ɪm'pɔrtnt/"
+  },
+  {
+    "chinese": "他（过去）告诉我他（过去）需要知道真相",
+    "english": "he told me he needed to know the truth",
+    "soundmark": "/hi/ /told/ /mi/ /hi/ /nidɪd/ /tə/ /no/ /ðə/ /trʊθ/"
+  },
+  {
+    "chinese": "他（过去）告诉我他（过去）需要知道真相因为它（过去）是重要的",
+    "english": "he told me he needed to know the truth because it was important",
+    "soundmark": "/hi/ /told/ /mi/ /hi/ /nidɪd/ /tə/ /no/ /ðə/ /trʊθ/ /bɪ'kɔz/ /ɪt/ /wəz/ /ɪm'pɔrtnt/"
+  },
+  {
+    "chinese": "存在；成为",
+    "english": "to be",
+    "soundmark": "/tə/ /bi/"
+  },
+  {
+    "chinese": "一个老师",
+    "english": "a teacher",
+    "soundmark": "/ə/ /'titʃɚ/"
+  },
+  {
+    "chinese": "成为一个老师",
+    "english": "to be a teacher",
+    "soundmark": "/tə/ /bi/ /ə/ /'titʃɚ/ /（过去）想要 wanted/ /wɑntɪd/"
+  },
+  {
+    "chinese": "我（过去）想要成为一个老师",
+    "english": "I wanted to be a teacher",
+    "soundmark": "/aɪ/ /wɑntɪd/ /tə/ /bi/ /ə/ /'titʃɚ/"
+  },
+  {
+    "chinese": "重要的",
+    "english": "important",
+    "soundmark": "/ɪm'pɔrtnt/"
+  },
+  {
+    "chinese": "我是重要的",
+    "english": "I am important",
+    "soundmark": "/aɪ/ /æm/ /ɪm'pɔrtnt/"
+  },
+  {
+    "chinese": "我（过去）是重要的",
+    "english": "I was important",
+    "soundmark": "/aɪ/ /wəz/ /ɪm'pɔrtnt/"
+  },
+  {
+    "chinese": "年轻的",
+    "english": "young",
+    "soundmark": "/jʌŋ/"
+  },
+  {
+    "chinese": "我是年轻的",
+    "english": "I am young",
+    "soundmark": "/aɪ/ /æm/ /jʌŋ/"
+  },
+  {
+    "chinese": "我（过去）是年轻的",
+    "english": "I was young",
+    "soundmark": "/aɪ/ /wəz/ /jʌŋ/"
+  },
+  {
+    "chinese": "当......的时候",
+    "english": "when",
+    "soundmark": "/wɛn/"
+  },
+  {
+    "chinese": "当我（过去）是年轻的时候",
+    "english": "when I was young",
+    "soundmark": "/wɛn/ /aɪ/ /wəz/ /jʌŋ/"
+  },
+  {
+    "chinese": "我（过去）想要成为一个老师",
+    "english": "I wanted to be a teacher",
+    "soundmark": "/aɪ/ /wɑntɪd/ /tə/ /bi/ /ə/ /'titʃɚ/"
+  },
+  {
+    "chinese": "我（过去）想要成为一个老师当我（过去）是年轻的时候",
+    "english": "I wanted to be a teacher when I was young",
+    "soundmark": "/aɪ/ /wɑntɪd/ /tə/ /bi/ /ə/ /'titʃɚ/ /wɛn/ /aɪ/ /wəz/ /jʌŋ/"
+  },
+  {
+    "chinese": "交谈；聊天",
+    "english": "to talk",
+    "soundmark": "/tə/ /tɔk/ /（过去）聊天 talked/ /tɔkt/"
+  },
+  {
+    "chinese": "我们（过去）聊天",
+    "english": "we talked",
+    "soundmark": "/wi/ /tɔkt/"
+  },
+  {
+    "chinese": "在......之前；以前",
+    "english": "before",
+    "soundmark": "/bɪ'fɔr/"
+  },
+  {
+    "chinese": "我们以前聊过天",
+    "english": "we talked before",
+    "soundmark": "/wi/ /tɔkt/ /bɪ'fɔr/"
+  },
+  {
+    "chinese": "和她（过去）聊天",
+    "english": "talked with her",
+    "soundmark": "/tɔkt/ /wɪð/ /hɚ/"
+  },
+  {
+    "chinese": "我和她聊过天",
+    "english": "I talked with her",
+    "soundmark": "/aɪ/ /tɔkt/ /wɪð/ /hɚ/"
+  },
+  {
+    "chinese": "我以前和她聊过天",
+    "english": "I talked with her before",
+    "soundmark": "/aɪ/ /tɔkt/ /wɪð/ /hɚ/ /bɪ'fɔr/"
+  },
+  {
+    "chinese": "昨天",
+    "english": "yesterday",
+    "soundmark": "/'jɛstɚde/"
+  },
+  {
+    "chinese": "那一天",
+    "english": "the day",
+    "soundmark": "/ðə/ /de/"
+  },
+  {
+    "chinese": "在......之前；以前",
+    "english": "before",
+    "soundmark": "/bɪ'fɔr/ /（在昨天之前的那一天）前天 the day before yesterday/ /ðə/ /de/ /bɪ'fɔr/ /'jɛstɚde/"
+  },
+  {
+    "chinese": "我前天和她聊过天",
+    "english": "I talked with her the day before yesterday",
+    "soundmark": "/aɪ/ /tɔkt/ /wɪð/ /hɚ/ /ðə/ /de/ /bɪ'fɔr/ /'jɛstɚde/"
+  },
+  {
+    "chinese": "上一个",
+    "english": "last",
+    "soundmark": "/læst/"
+  },
+  {
+    "chinese": "星期；周",
+    "english": "week",
+    "soundmark": "/wik/"
+  },
+  {
+    "chinese": "周末",
+    "english": "weekend",
+    "soundmark": "/'wikɛnd/"
+  },
+  {
+    "chinese": "上周末",
+    "english": "last weekend",
+    "soundmark": "/læst/ /'wikɛnd/"
+  },
+  {
+    "chinese": "我上周末和她聊过天",
+    "english": "I talked with her last weekend",
+    "soundmark": "/aɪ/ /tɔkt/ /wɪð/ /hɚ/ /læst/ /'wikɛnd/"
+  },
+  {
+    "chinese": "改变",
+    "english": "to change",
+    "soundmark": "/tə/ /tʃendʒ/"
+  },
+  {
+    "chinese": "世界",
+    "english": "the world",
+    "soundmark": "/ðə/ /wɝld/"
+  },
+  {
+    "chinese": "改变世界",
+    "english": "to change the world",
+    "soundmark": "/tə/ /tʃendʒ/ /ðə/ /wɝld/"
+  },
+  {
+    "chinese": "她想要改变世界",
+    "english": "she wants to change the world",
+    "soundmark": "/ʃi/ /wɑnts/ /tə/ /tʃendʒ/ /ðə/ /wɝld/"
+  },
+  {
+    "chinese": "她（过去）想要改变世界",
+    "english": "she wanted to change the world",
+    "soundmark": "/ʃi/ /wɑntɪd/ /tə/ /tʃendʒ/ /ðə/ /wɝld/"
+  },
+  {
+    "chinese": "年轻的",
+    "english": "young",
+    "soundmark": "/jʌŋ/"
+  },
+  {
+    "chinese": "她（过去）是年轻的",
+    "english": "she was young",
+    "soundmark": "/ʃi/ /wəz/ /jʌŋ/"
+  },
+  {
+    "chinese": "当......的时候",
+    "english": "when",
+    "soundmark": "/wɛn/"
+  },
+  {
+    "chinese": "当她（过去）是年轻的时候",
+    "english": "when she was young",
+    "soundmark": "/wɛn/ /ʃi/ /wəz/ /jʌŋ/"
+  },
+  {
+    "chinese": "她（过去）想要改变世界当她",
+    "english": "she wanted to change the world when she was young",
+    "soundmark": "/ʃi/ /wɑntɪd/ /tə/ /tʃendʒ/ /ðə/ /wɝld/ /wɛn/ /ʃi/ /wəz/ /jʌŋ/"
+  },
+  {
+    "chinese": "她（过去）告诉我",
+    "english": "she told me",
+    "soundmark": "/ʃi/ /told/ /mi/"
+  },
+  {
+    "chinese": "她（过去）告诉我她（过去）想要改变世界当她（过去）是年轻的时候",
+    "english": "she told me she wanted to change the world when she was young",
+    "soundmark": "/ʃi/ /told/ /mi/ /ʃi/ /wɑntɪd/ /tə/ /tʃendʒ/ /ðə/ /wɝld/ /wɛn/ /ʃi/ /wəz/ /jʌŋ/"
+  },
+  {
+    "chinese": "我上周末和她聊过天而且她告诉我她（想要）改变世界当她",
+    "english": "I talked with her last weekend and she told me she wanted to change the world when she was young",
+    "soundmark": "/aɪ/ /tɔkt/ /wɪð/ /hɚ/ /læst/ /'wikɛnd/ /ənd/ /ʃi/ /told/ /mi/ /ʃi/ /wɑntɪd/ /tə/ /tʃendʒ/ /ðə/ /wɝld/ /wɛn/ /ʃi/ /wəz/ /jʌŋ/"
+  }
 ]

--- a/scripts/courses/15.5.json
+++ b/scripts/courses/15.5.json
@@ -1,907 +1,907 @@
 [
-	{
-		"chinese": "吃",
-		"english": "to eat",
-		"soundmark": "/tə/ /it/"
-	},
-	{
-		"chinese": "鸡蛋",
-		"english": "eggs",
-		"soundmark": "/ɛgz/"
-	},
-	{
-		"chinese": "吃鸡蛋",
-		"english": "to eat eggs",
-		"soundmark": "/tə/ /it/ /ɛgz/"
-	},
-	{
-		"chinese": "正在吃",
-		"english": "eating",
-		"soundmark": "/'itɪŋ/"
-	},
-	{
-		"chinese": "正在吃鸡蛋",
-		"english": "eating eggs",
-		"soundmark": "/'itɪŋ/ /ɛgz/"
-	},
-	{
-		"chinese": "我是",
-		"english": "I am",
-		"soundmark": "/aɪ/ /æm/"
-	},
-	{
-		"chinese": "我是星荣",
-		"english": "I am Xingrong",
-		"soundmark": "/aɪ/ /æm/"
-	},
-	{
-		"chinese": "正在吃鸡蛋",
-		"english": "eating eggs",
-		"soundmark": "/'itɪŋ/ /ɛgz/"
-	},
-	{
-		"chinese": "我正在吃鸡蛋",
-		"english": "I am eating eggs",
-		"soundmark": "/aɪ/ /æm/ /'itɪŋ/ /ɛgz/"
-	},
-	{
-		"chinese": "厨房",
-		"english": "the kitchen",
-		"soundmark": "/ðə/ /'kɪtʃɪn/"
-	},
-	{
-		"chinese": "在厨房里",
-		"english": "in the kitchen",
-		"soundmark": "/ɪn/ /ðə/ /'kɪtʃɪn/"
-	},
-	{
-		"chinese": "我在厨房里（现在）正在吃鸡蛋",
-		"english": "I am eating eggs in the kitchen",
-		"soundmark": "/aɪ/ /æm/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/ /（I，现在时）be am/ /æm/ /（I，过去时）be was/ /wəz/"
-	},
-	{
-		"chinese": "我在厨房里（过去）正在吃鸡蛋",
-		"english": "I was eating eggs in the kitchen",
-		"soundmark": "/aɪ/ /wəz/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/ /（you，现在时）be are/ /ɚ/"
-	},
-	{
-		"chinese": "你在厨房里（现在）正在吃鸡蛋",
-		"english": "you are eating eggs in the kitchen",
-		"soundmark": "/ju/ /ɚ/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/ /（you，过去时）be were/ /wɚ/"
-	},
-	{
-		"chinese": "你在厨房里（过去）正在吃鸡蛋",
-		"english": "you were eating eggs in the kitchen",
-		"soundmark": "/ju/ /wɚ/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
-	},
-	{
-		"chinese": "他们",
-		"english": "they",
-		"soundmark": "/ðe/ /（they，现在时）be are/ /ɚ/"
-	},
-	{
-		"chinese": "他们在厨房里（现在）正在吃鸡蛋",
-		"english": "they are eating eggs in the kitchen",
-		"soundmark": "/ðe/ /ɚ/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/ /（they，过去时）be were/ /wɚ/"
-	},
-	{
-		"chinese": "他们在厨房里（过去）正在吃鸡蛋",
-		"english": "they were eating eggs in the kitchen",
-		"soundmark": "/ðe/ /wɚ/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
-	},
-	{
-		"chinese": "喝",
-		"english": "to drink",
-		"soundmark": "/tə/ /drɪŋk/"
-	},
-	{
-		"chinese": "茶",
-		"english": "tea",
-		"soundmark": "/ti/"
-	},
-	{
-		"chinese": "喝茶",
-		"english": "to drink tea",
-		"soundmark": "/tə/ /drɪŋk/ /ti/"
-	},
-	{
-		"chinese": "正在喝",
-		"english": "drinking",
-		"soundmark": "/'drɪŋkɪŋ/"
-	},
-	{
-		"chinese": "正在喝茶",
-		"english": "drinking tea",
-		"soundmark": "/'drɪŋkɪŋ/ /ti/"
-	},
-	{
-		"chinese": "他们",
-		"english": "they",
-		"soundmark": "/ðe/ /（they，现在时）be are/ /ɚ/"
-	},
-	{
-		"chinese": "他们（现在）正在喝茶",
-		"english": "they are drinking tea",
-		"soundmark": "/ðe/ /ɚ/ /'drɪŋkɪŋ/ /ti/"
-	},
-	{
-		"chinese": "花园",
-		"english": "the garden",
-		"soundmark": "/ðə/ /ˈɡɑrdn/"
-	},
-	{
-		"chinese": "在花园里",
-		"english": "in the garden",
-		"soundmark": "/ɪn/ /ðə/ /ˈɡɑrdn/"
-	},
-	{
-		"chinese": "他们在花园里（现在）正在喝",
-		"english": "they are drinking tea in the garden",
-		"soundmark": "/ðe/ /ɚ/ /'drɪŋkɪŋ/ /ti/ /ɪn/ /ðə/ /ˈɡɑrdn/"
-	},
-	{
-		"chinese": "茶",
-		"english": "（they，过去时）be were",
-		"soundmark": "/wɚ/"
-	},
-	{
-		"chinese": "他们在花园里（过去）正在喝茶",
-		"english": "they were drinking tea in the garden",
-		"soundmark": "/ðe/ /wɚ/ /'drɪŋkɪŋ/ /ti/ /ɪn/ /ðə/ /ˈɡɑrdn/"
-	},
-	{
-		"chinese": "我在厨房里（过去）正在吃鸡蛋",
-		"english": "I was eating eggs in the kitchen",
-		"soundmark": "/aɪ/ /wəz/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
-	},
-	{
-		"chinese": "与此同时",
-		"english": "while",
-		"soundmark": "/waɪl/"
-	},
-	{
-		"chinese": "他们在花园里（过去）正在喝茶与此同时我在厨房里（过去）正在吃鸡蛋",
-		"english": "they were drinking tea in the garden while I was eating eggs in the kitchen",
-		"soundmark": "/ðe/ /wɚ/ /'drɪŋkɪŋ/ /ti/ /ɪn/ /ðə/ /ˈɡɑrdn/ /waɪl/ /aɪ/ /wəz/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
-	},
-	{
-		"chinese": "教",
-		"english": "to teach",
-		"soundmark": "/tə/ /titʃ/"
-	},
-	{
-		"chinese": "我们",
-		"english": "us",
-		"soundmark": "/ʌs/"
-	},
-	{
-		"chinese": "教我们",
-		"english": "to teach us",
-		"soundmark": "/tə/ /titʃ/ /ʌs/"
-	},
-	{
-		"chinese": "正在教",
-		"english": "teaching",
-		"soundmark": "/'titʃɪŋ/"
-	},
-	{
-		"chinese": "正在教我们",
-		"english": "teaching us",
-		"soundmark": "/'titʃɪŋ/ /ʌs/"
-	},
-	{
-		"chinese": "说",
-		"english": "to speak",
-		"soundmark": "/tə/ /spik/"
-	},
-	{
-		"chinese": "英语",
-		"english": "English",
-		"soundmark": "/ˈɪŋɡlɪʃ/"
-	},
-	{
-		"chinese": "说英语",
-		"english": "to speak English",
-		"soundmark": "/tə/ /spik/ /ˈɪŋɡlɪʃ/"
-	},
-	{
-		"chinese": "如何",
-		"english": "how",
-		"soundmark": "/haʊ/"
-	},
-	{
-		"chinese": "如何说英语",
-		"english": "how to speak English",
-		"soundmark": "/haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/"
-	},
-	{
-		"chinese": "正在教我们如何说英语",
-		"english": "teaching us how to speak English",
-		"soundmark": "/'titʃɪŋ/ /ʌs/ /haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/ /（he，现在时）be is/ /ɪz/"
-	},
-	{
-		"chinese": "星荣正在教我们如何说英语",
-		"english": "Xingrong is teaching us how to speak English",
-		"soundmark": "/ɪz/ /'titʃɪŋ/ /ʌs/ /haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/ /（he，过去时）be was/ /wəz/"
-	},
-	{
-		"chinese": "星荣（过去）正在教我们如何说英语",
-		"english": "Xingrong was teaching us how to speak English",
-		"soundmark": "/wəz/ /'titʃɪŋ/ /ʌs/ /haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/"
-	},
-	{
-		"chinese": "学习",
-		"english": "to learn",
-		"soundmark": "/tə/ /lɝn/"
-	},
-	{
-		"chinese": "英语",
-		"english": "English",
-		"soundmark": "/ˈɪŋɡlɪʃ/"
-	},
-	{
-		"chinese": "学习英语",
-		"english": "to learn English",
-		"soundmark": "/tə/ /lɝn/ /ˈɪŋɡlɪʃ/"
-	},
-	{
-		"chinese": "正在学习",
-		"english": "learning",
-		"soundmark": "/'lɝnɪŋ/"
-	},
-	{
-		"chinese": "正在学习英语",
-		"english": "learning English",
-		"soundmark": "/'lɝnɪŋ/ /ˈɪŋɡlɪʃ/ /（I，现在时）be am/ /æm/"
-	},
-	{
-		"chinese": "我正在学习英语",
-		"english": "I am learning English",
-		"soundmark": "/aɪ/ /æm/ /'lɝnɪŋ/ /ˈɪŋɡlɪʃ/"
-	},
-	{
-		"chinese": "视频",
-		"english": "videos",
-		"soundmark": "/'vɪdɪoz/"
-	},
-	{
-		"chinese": "他的",
-		"english": "his",
-		"soundmark": "/hɪz/"
-	},
-	{
-		"chinese": "他的视频",
-		"english": "his videos",
-		"soundmark": "/hɪz/ /'vɪdɪoz/"
-	},
-	{
-		"chinese": "观看",
-		"english": "to watch",
-		"soundmark": "/tə/ /wɑtʃ/"
-	},
-	{
-		"chinese": "观看他的视频",
-		"english": "to watch his videos",
-		"soundmark": "/tə/ /wɑtʃ/ /hɪz/ /'vɪdɪoz/"
-	},
-	{
-		"chinese": "正在观看",
-		"english": "watching",
-		"soundmark": "/'wɑtʃɪŋ/"
-	},
-	{
-		"chinese": "正在观看他的视频",
-		"english": "watching his videos",
-		"soundmark": "/'wɑtʃɪŋ/ /hɪz/ /'vɪdɪoz/"
-	},
-	{
-		"chinese": "通过......的方式",
-		"english": "by",
-		"soundmark": "/baɪ/"
-	},
-	{
-		"chinese": "通过观看他的视频的方式",
-		"english": "by watching his videos",
-		"soundmark": "/baɪ/ /'wɑtʃɪŋ/ /hɪz/ /'vɪdɪoz/"
-	},
-	{
-		"chinese": "我正在学习英语",
-		"english": "I am learning English",
-		"soundmark": "/aɪ/ /æm/ /'lɝnɪŋ/ /ˈɪŋɡlɪʃ/"
-	},
-	{
-		"chinese": "我正在通过观看他的视频的方式学习英语",
-		"english": "I am learning English by watching his videos",
-		"soundmark": "/aɪ/ /æm/ /'lɝnɪŋ/ /ˈɪŋɡlɪʃ/ /baɪ/ /'wɑtʃɪŋ/ /hɪz/ /'vɪdɪoz/ /（I，过去时）be was/ /wəz/"
-	},
-	{
-		"chinese": "我（过去）正在通过观看他的视频的方式学习英语",
-		"english": "I was learning English by watching his videos",
-		"soundmark": "/aɪ/ /wəz/ /'lɝnɪŋ/ /ˈɪŋɡlɪʃ/ /baɪ/ /'wɑtʃɪŋ/ /hɪz/ /'vɪdɪoz/"
-	},
-	{
-		"chinese": "星荣（过去）正在教我们如何说英语",
-		"english": "Xingrong was teaching us how to speak English",
-		"soundmark": "/wəz/ /'titʃɪŋ/ /ʌs/ /haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/"
-	},
-	{
-		"chinese": "与此同时",
-		"english": "while",
-		"soundmark": "/waɪl/"
-	},
-	{
-		"chinese": "星荣（过去）正在教我们如何说英语与此同时我（过去）正在通过观看他的视频的方式学习英语",
-		"english": "Xingrong was teaching us how to speak English while I was learning English by watching his videos",
-		"soundmark": "/wəz/ /'titʃɪŋ/ /ʌs/ /haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/ /waɪl/ /aɪ/ /wəz/ /'lɝnɪŋ/ /ˈɪŋɡlɪʃ/ /baɪ/ /'wɑtʃɪŋ/ /hɪz/ /'vɪdɪoz/"
-	},
-	{
-		"chinese": "走路",
-		"english": "to walk",
-		"soundmark": "/tə/ /wɔk/"
-	},
-	{
-		"chinese": "家",
-		"english": "home",
-		"soundmark": "/hom/"
-	},
-	{
-		"chinese": "走路回家",
-		"english": "to walk home",
-		"soundmark": "/tə/ /wɔk/ /hom/"
-	},
-	{
-		"chinese": "学校",
-		"english": "school",
-		"soundmark": "/skul/"
-	},
-	{
-		"chinese": "从",
-		"english": "from",
-		"soundmark": "/frʌm/"
-	},
-	{
-		"chinese": "从学校",
-		"english": "from school",
-		"soundmark": "/frʌm/ /skul/"
-	},
-	{
-		"chinese": "从学校走路回家",
-		"english": "to walk home from school",
-		"soundmark": "/tə/ /wɔk/ /hom/ /frʌm/ /skul/"
-	},
-	{
-		"chinese": "正在从学校走路回家",
-		"english": "walking home from school",
-		"soundmark": "/'wɔkɪŋ/ /hom/ /frʌm/ /skul/ /（I，现在时）be am/ /æm/"
-	},
-	{
-		"chinese": "我正在从学校走路回家",
-		"english": "I am walking home from school",
-		"soundmark": "/aɪ/ /æm/ /'wɔkɪŋ/ /hom/ /frʌm/ /skul/ /（I，过去时）be was/ /wəz/"
-	},
-	{
-		"chinese": "我（过去）正在从学校走路回家",
-		"english": "I was walking home from school",
-		"soundmark": "/aɪ/ /wəz/ /'wɔkɪŋ/ /hom/ /frʌm/ /skul/"
-	},
-	{
-		"chinese": "朋友",
-		"english": "friend",
-		"soundmark": "/frɛnd/"
-	},
-	{
-		"chinese": "老的",
-		"english": "old",
-		"soundmark": "/old/"
-	},
-	{
-		"chinese": "一个老朋友",
-		"english": "an old friend",
-		"soundmark": "/ən/ /old/ /frɛnd/"
-	},
-	{
-		"chinese": "遇见",
-		"english": "to meet",
-		"soundmark": "/tə/ /mit/"
-	},
-	{
-		"chinese": "遇见一个老朋友",
-		"english": "to meet an old friend",
-		"soundmark": "/tə/ /mit/ /ən/ /old/ /frɛnd/ /（过去）遇见 met/ /mɛt/ /（过去）遇见一个老朋友 met an old friend/ /mɛt/ /ən/ /old/ /frɛnd/"
-	},
-	{
-		"chinese": "我（过去）遇见一个老朋友",
-		"english": "I met an old friend",
-		"soundmark": "/aɪ/ /mɛt/ /ən/ /old/ /frɛnd/"
-	},
-	{
-		"chinese": "我（过去）正在从学校走路回家",
-		"english": "I was walking home from school",
-		"soundmark": "/aɪ/ /wəz/ /'wɔkɪŋ/ /hom/ /frʌm/ /skul/"
-	},
-	{
-		"chinese": "当......的时候",
-		"english": "when",
-		"soundmark": "/wɛn/"
-	},
-	{
-		"chinese": "当我（过去）正在从学校走路回家的时候",
-		"english": "when I was walking home from school",
-		"soundmark": "/wɛn/ /aɪ/ /wəz/ /'wɔkɪŋ/ /hom/ /frʌm/ /skul/"
-	},
-	{
-		"chinese": "当我（过去）正在从学校走路回家的时候我（过去）遇见一个老朋友",
-		"english": "I met an old friend when I was walking home from school",
-		"soundmark": "/aɪ/ /mɛt/ /ən/ /old/ /frɛnd/ /wɛn/ /aɪ/ /wəz/ /'wɔkɪŋ/ /hom/ /frʌm/ /skul/"
-	},
-	{
-		"chinese": "睡觉",
-		"english": "to sleep",
-		"soundmark": "/tə/ /slip/"
-	},
-	{
-		"chinese": "卧室",
-		"english": "the bedroom",
-		"soundmark": "/ðə/ /'bɛdrum/"
-	},
-	{
-		"chinese": "在卧室里",
-		"english": "in the bedroom",
-		"soundmark": "/ɪn/ /ðə/ /'bɛdrum/"
-	},
-	{
-		"chinese": "在卧室里睡觉",
-		"english": "to sleep in the bed room",
-		"soundmark": "/tə/ /slip/ /ɪn/ /ðə/ /'bɛdrum/"
-	},
-	{
-		"chinese": "正在睡觉",
-		"english": "sleeping",
-		"soundmark": "/ˈslipɪŋ/"
-	},
-	{
-		"chinese": "正在在卧室里睡觉",
-		"english": "sleeping in the bedroom",
-		"soundmark": "/ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/ /（I，现在时）be am/ /æm/"
-	},
-	{
-		"chinese": "我正在在卧室里睡觉",
-		"english": "I am sleeping in the bedroom",
-		"soundmark": "/aɪ/ /æm/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/ /（I，过去时）be was/ /wəz/"
-	},
-	{
-		"chinese": "我（过去）正在在卧室里睡觉",
-		"english": "I was sleeping in the bedroom",
-		"soundmark": "/aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/"
-	},
-	{
-		"chinese": "打电话",
-		"english": "to call",
-		"soundmark": "/tə/ /kɔl/"
-	},
-	{
-		"chinese": "打电话给我",
-		"english": "to call me",
-		"soundmark": "/tə/ /kɔl/ /mi/ /（过去）打电话 called/ /kɔld/ /（过去）打电话给我 called me/ /kɔld/ /mi/"
-	},
-	{
-		"chinese": "她",
-		"english": "she",
-		"soundmark": "/ʃi/"
-	},
-	{
-		"chinese": "她（过去）打电话给我",
-		"english": "she called me",
-		"soundmark": "/ʃi/ /kɔld/ /mi/"
-	},
-	{
-		"chinese": "当......的时候",
-		"english": "when",
-		"soundmark": "/wɛn/"
-	},
-	{
-		"chinese": "当她（过去）打电话给我的时候",
-		"english": "when she called me",
-		"soundmark": "/wɛn/ /ʃi/ /kɔld/ /mi/"
-	},
-	{
-		"chinese": "我（过去）正在在卧室里睡觉",
-		"english": "I was sleeping in the bedroom",
-		"soundmark": "/aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/"
-	},
-	{
-		"chinese": "当她打电话给我的时候我（过去）正在在卧室里睡觉",
-		"english": "I was sleeping in the bedroom when she called me",
-		"soundmark": "/aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/ /wɛn/ /ʃi/ /kɔld/ /mi/"
-	},
-	{
-		"chinese": "玩",
-		"english": "to play",
-		"soundmark": "/tə/ /ple/"
-	},
-	{
-		"chinese": "钢琴",
-		"english": "the piano",
-		"soundmark": "/ðə/ /pɪ'æno/"
-	},
-	{
-		"chinese": "弹钢琴",
-		"english": "to play the piano",
-		"soundmark": "/tə/ /ple/ /ðə/ /pɪ'æno/"
-	},
-	{
-		"chinese": "正在玩",
-		"english": "playing",
-		"soundmark": "/pleɪŋ/"
-	},
-	{
-		"chinese": "正在弹钢琴",
-		"english": "playing the piano",
-		"soundmark": "/pleɪŋ/ /ðə/ /pɪ'æno/ /（她，现在时）be is/ /ɪz/"
-	},
-	{
-		"chinese": "她正在弹钢琴",
-		"english": "she is playing the piano",
-		"soundmark": "/ʃi/ /ɪz/ /pleɪŋ/ /ðə/ /pɪ'æno/ /（她，过去时）be was/ /wəz/"
-	},
-	{
-		"chinese": "她（过去）正在弹钢琴",
-		"english": "she was playing the piano",
-		"soundmark": "/ʃi/ /wəz/ /pleɪŋ/ /ðə/ /pɪ'æno/"
-	},
-	{
-		"chinese": "起居室；客厅",
-		"english": "the living room",
-		"soundmark": "/ðə/ /'lɪvɪŋ/ /rum/"
-	},
-	{
-		"chinese": "在客厅",
-		"english": "in the living room",
-		"soundmark": "/ɪn/ /ðə/ /'lɪvɪŋ/ /rum/"
-	},
-	{
-		"chinese": "她（过去）正在在客厅弹钢琴",
-		"english": "she was playing the piano in the living room",
-		"soundmark": "/ʃi/ /wəz/ /pleɪŋ/ /ðə/ /pɪ'æno/ /ɪn/ /ðə/ /'lɪvɪŋ/ /rum/"
-	},
-	{
-		"chinese": "与此同时",
-		"english": "while",
-		"soundmark": "/waɪl/"
-	},
-	{
-		"chinese": "我（过去）正在在卧室里睡觉",
-		"english": "I was sleeping in the bedroom",
-		"soundmark": "/aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/"
-	},
-	{
-		"chinese": "她（过去）正在在客厅弹钢琴与此同时我（过去）正在在卧室里睡觉",
-		"english": "she was playing the piano in the living room while I was sleeping in the bedroom",
-		"soundmark": "/ʃi/ /wəz/ /pleɪŋ/ /ðə/ /pɪ'æno/ /ɪn/ /ðə/ /'lɪvɪŋ/ /rum/ /waɪl/ /aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/"
-	},
-	{
-		"chinese": "中文 原形 第三人称单数 过去式想要",
-		"english": "want wants",
-		"soundmark": "/wanted/"
-	},
-	{
-		"chinese": "喜欢",
-		"english": "like likes",
-		"soundmark": "/liked/"
-	},
-	{
-		"chinese": "有；(+to)不得不",
-		"english": "have has",
-		"soundmark": "/had/"
-	},
-	{
-		"chinese": "计划",
-		"english": "plan plans",
-		"soundmark": "/planned/"
-	},
-	{
-		"chinese": "需要",
-		"english": "need needs",
-		"soundmark": "/needed/"
-	},
-	{
-		"chinese": "做",
-		"english": "do does",
-		"soundmark": "/did/"
-	},
-	{
-		"chinese": "告诉",
-		"english": "tell tells",
-		"soundmark": "/told/"
-	},
-	{
-		"chinese": "说话",
-		"english": "talk talks",
-		"soundmark": "/talked/"
-	},
-	{
-		"chinese": "是 be（am）",
-		"english": "is",
-		"soundmark": "/was/"
-	},
-	{
-		"chinese": "是 be（is ）",
-		"english": "is",
-		"soundmark": "/was/"
-	},
-	{
-		"chinese": "是 be（are）",
-		"english": "is",
-		"soundmark": "/were/"
-	},
-	{
-		"chinese": "看到",
-		"english": "see sees",
-		"soundmark": "/saw/"
-	},
-	{
-		"chinese": "吃",
-		"english": "eat eats",
-		"soundmark": "/ate/"
-	},
-	{
-		"chinese": "喝",
-		"english": "drink drinks",
-		"soundmark": "/drank/"
-	},
-	{
-		"chinese": "知道",
-		"english": "know knows",
-		"soundmark": "/knew/"
-	},
-	{
-		"chinese": "忘记",
-		"english": "forget forgets",
-		"soundmark": "/forgot/"
-	},
-	{
-		"chinese": "失去",
-		"english": "lose loses",
-		"soundmark": "/lost/"
-	},
-	{
-		"chinese": "离开",
-		"english": "leave leaves",
-		"soundmark": "/left/"
-	},
-	{
-		"chinese": "睡觉",
-		"english": "sleep sleeps",
-		"soundmark": "/slept/"
-	},
-	{
-		"chinese": "明白",
-		"english": "understand understands",
-		"soundmark": "/understood/"
-	},
-	{
-		"chinese": "买",
-		"english": "buy buys",
-		"soundmark": "/bought/"
-	},
-	{
-		"chinese": "洗",
-		"english": "wash washes",
-		"soundmark": "/washed/"
-	},
-	{
-		"chinese": "打电话",
-		"english": "call calls",
-		"soundmark": "/called/"
-	},
-	{
-		"chinese": "帮助",
-		"english": "help helps",
-		"soundmark": "/helped/"
-	},
-	{
-		"chinese": "相信",
-		"english": "believe believes",
-		"soundmark": "/believed/"
-	},
-	{
-		"chinese": "学习",
-		"english": "study studies",
-		"soundmark": "/studied/"
-	},
-	{
-		"chinese": "解释",
-		"english": "explain explains",
-		"soundmark": "/explained/"
-	},
-	{
-		"chinese": "问",
-		"english": "ask asks",
-		"soundmark": "/asked/"
-	},
-	{
-		"chinese": "飞",
-		"english": "fly flies",
-		"soundmark": "/flew/"
-	},
-	{
-		"chinese": "阅读",
-		"english": "read reads",
-		"soundmark": "/read/"
-	},
-	{
-		"chinese": "走路",
-		"english": "walk walks",
-		"soundmark": "/walked/"
-	},
-	{
-		"chinese": "跳舞",
-		"english": "dance dances",
-		"soundmark": "/danced/"
-	},
-	{
-		"chinese": "回答",
-		"english": "answer answers",
-		"soundmark": "/answered/"
-	},
-	{
-		"chinese": "工作",
-		"english": "work works",
-		"soundmark": "/worked/"
-	},
-	{
-		"chinese": "待在",
-		"english": "stay stays",
-		"soundmark": "/stayed/"
-	},
-	{
-		"chinese": "支付",
-		"english": "pay pays",
-		"soundmark": "/paid/"
-	},
-	{
-		"chinese": "旅行",
-		"english": "travel travels",
-		"soundmark": "/traveled/"
-	},
-	{
-		"chinese": "给",
-		"english": "give gives",
-		"soundmark": "/gave/"
-	},
-	{
-		"chinese": "达到",
-		"english": "get gets",
-		"soundmark": "/got/"
-	},
-	{
-		"chinese": "锁",
-		"english": "lock locks",
-		"soundmark": "/locked/"
-	},
-	{
-		"chinese": "记得",
-		"english": "remember remembers",
-		"soundmark": "/remembered/"
-	},
-	{
-		"chinese": "清理",
-		"english": "clean cleans",
-		"soundmark": "/cleaned/"
-	},
-	{
-		"chinese": "找到",
-		"english": "find finds",
-		"soundmark": "/found/"
-	},
-	{
-		"chinese": "关闭",
-		"english": "close closes",
-		"soundmark": "/closed/"
-	},
-	{
-		"chinese": "教",
-		"english": "teach teaches",
-		"soundmark": "/taught/"
-	},
-	{
-		"chinese": "展示",
-		"english": "show shows",
-		"soundmark": "/showed/"
-	},
-	{
-		"chinese": "让",
-		"english": "let lets",
-		"soundmark": "/let/"
-	},
-	{
-		"chinese": "休息",
-		"english": "rest rests",
-		"soundmark": "/rested/"
-	},
-	{
-		"chinese": "用",
-		"english": "use uses",
-		"soundmark": "/used/"
-	},
-	{
-		"chinese": "做饭",
-		"english": "cook cooks",
-		"soundmark": "/cooked/"
-	},
-	{
-		"chinese": "去",
-		"english": "go goes",
-		"soundmark": "/went/"
-	},
-	{
-		"chinese": "决定",
-		"english": "decide decides",
-		"soundmark": "/decided/"
-	},
-	{
-		"chinese": "驾驶",
-		"english": "drive drives",
-		"soundmark": "/drove/"
-	},
-	{
-		"chinese": "改变",
-		"english": "change changes",
-		"soundmark": "/changed/"
-	},
-	{
-		"chinese": "尝试",
-		"english": "try tries",
-		"soundmark": "/tried/"
-	},
-	{
-		"chinese": "停止",
-		"english": "stop stops",
-		"soundmark": "/Stopped/"
-	},
-	{
-		"chinese": "参加",
-		"english": "join joins",
-		"soundmark": "/joined/"
-	},
-	{
-		"chinese": "邀请",
-		"english": "invite invites",
-		"soundmark": "/invited/"
-	},
-	{
-		"chinese": "拒绝",
-		"english": "refuse refuses",
-		"soundmark": "/refused/"
-	},
-	{
-		"chinese": "接受",
-		"english": "accept accepts",
-		"soundmark": "/accepted/"
-	},
-	{
-		"chinese": "学习",
-		"english": "learn learns",
-		"soundmark": "/learnt/"
-	},
-	{
-		"chinese": "完成",
-		"english": "finish finishes",
-		"soundmark": "/finished/"
-	},
-	{
-		"chinese": "看",
-		"english": "watch watches",
-		"soundmark": "/watched/"
-	},
-	{
-		"chinese": "游泳",
-		"english": "swim swims",
-		"soundmark": "/swam/"
-	},
-	{
-		"chinese": "掌握",
-		"english": "master masters",
-		"soundmark": "/mastered/"
-	}
+  {
+    "chinese": "吃",
+    "english": "to eat",
+    "soundmark": "/tə/ /it/"
+  },
+  {
+    "chinese": "鸡蛋",
+    "english": "eggs",
+    "soundmark": "/ɛgz/"
+  },
+  {
+    "chinese": "吃鸡蛋",
+    "english": "to eat eggs",
+    "soundmark": "/tə/ /it/ /ɛgz/"
+  },
+  {
+    "chinese": "正在吃",
+    "english": "eating",
+    "soundmark": "/'itɪŋ/"
+  },
+  {
+    "chinese": "正在吃鸡蛋",
+    "english": "eating eggs",
+    "soundmark": "/'itɪŋ/ /ɛgz/"
+  },
+  {
+    "chinese": "我是",
+    "english": "I am",
+    "soundmark": "/aɪ/ /æm/"
+  },
+  {
+    "chinese": "我是星荣",
+    "english": "I am Xingrong",
+    "soundmark": "/aɪ/ /æm/"
+  },
+  {
+    "chinese": "正在吃鸡蛋",
+    "english": "eating eggs",
+    "soundmark": "/'itɪŋ/ /ɛgz/"
+  },
+  {
+    "chinese": "我正在吃鸡蛋",
+    "english": "I am eating eggs",
+    "soundmark": "/aɪ/ /æm/ /'itɪŋ/ /ɛgz/"
+  },
+  {
+    "chinese": "厨房",
+    "english": "the kitchen",
+    "soundmark": "/ðə/ /'kɪtʃɪn/"
+  },
+  {
+    "chinese": "在厨房里",
+    "english": "in the kitchen",
+    "soundmark": "/ɪn/ /ðə/ /'kɪtʃɪn/"
+  },
+  {
+    "chinese": "我在厨房里（现在）正在吃鸡蛋",
+    "english": "I am eating eggs in the kitchen",
+    "soundmark": "/aɪ/ /æm/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/ /（I，现在时）be am/ /æm/ /（I，过去时）be was/ /wəz/"
+  },
+  {
+    "chinese": "我在厨房里（过去）正在吃鸡蛋",
+    "english": "I was eating eggs in the kitchen",
+    "soundmark": "/aɪ/ /wəz/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/ /（you，现在时）be are/ /ɚ/"
+  },
+  {
+    "chinese": "你在厨房里（现在）正在吃鸡蛋",
+    "english": "you are eating eggs in the kitchen",
+    "soundmark": "/ju/ /ɚ/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/ /（you，过去时）be were/ /wɚ/"
+  },
+  {
+    "chinese": "你在厨房里（过去）正在吃鸡蛋",
+    "english": "you were eating eggs in the kitchen",
+    "soundmark": "/ju/ /wɚ/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
+  },
+  {
+    "chinese": "他们",
+    "english": "they",
+    "soundmark": "/ðe/ /（they，现在时）be are/ /ɚ/"
+  },
+  {
+    "chinese": "他们在厨房里（现在）正在吃鸡蛋",
+    "english": "they are eating eggs in the kitchen",
+    "soundmark": "/ðe/ /ɚ/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/ /（they，过去时）be were/ /wɚ/"
+  },
+  {
+    "chinese": "他们在厨房里（过去）正在吃鸡蛋",
+    "english": "they were eating eggs in the kitchen",
+    "soundmark": "/ðe/ /wɚ/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
+  },
+  {
+    "chinese": "喝",
+    "english": "to drink",
+    "soundmark": "/tə/ /drɪŋk/"
+  },
+  {
+    "chinese": "茶",
+    "english": "tea",
+    "soundmark": "/ti/"
+  },
+  {
+    "chinese": "喝茶",
+    "english": "to drink tea",
+    "soundmark": "/tə/ /drɪŋk/ /ti/"
+  },
+  {
+    "chinese": "正在喝",
+    "english": "drinking",
+    "soundmark": "/'drɪŋkɪŋ/"
+  },
+  {
+    "chinese": "正在喝茶",
+    "english": "drinking tea",
+    "soundmark": "/'drɪŋkɪŋ/ /ti/"
+  },
+  {
+    "chinese": "他们",
+    "english": "they",
+    "soundmark": "/ðe/ /（they，现在时）be are/ /ɚ/"
+  },
+  {
+    "chinese": "他们（现在）正在喝茶",
+    "english": "they are drinking tea",
+    "soundmark": "/ðe/ /ɚ/ /'drɪŋkɪŋ/ /ti/"
+  },
+  {
+    "chinese": "花园",
+    "english": "the garden",
+    "soundmark": "/ðə/ /ˈɡɑrdn/"
+  },
+  {
+    "chinese": "在花园里",
+    "english": "in the garden",
+    "soundmark": "/ɪn/ /ðə/ /ˈɡɑrdn/"
+  },
+  {
+    "chinese": "他们在花园里（现在）正在喝",
+    "english": "they are drinking tea in the garden",
+    "soundmark": "/ðe/ /ɚ/ /'drɪŋkɪŋ/ /ti/ /ɪn/ /ðə/ /ˈɡɑrdn/"
+  },
+  {
+    "chinese": "茶",
+    "english": "be were",
+    "soundmark": "/wɚ/"
+  },
+  {
+    "chinese": "他们在花园里（过去）正在喝茶",
+    "english": "they were drinking tea in the garden",
+    "soundmark": "/ðe/ /wɚ/ /'drɪŋkɪŋ/ /ti/ /ɪn/ /ðə/ /ˈɡɑrdn/"
+  },
+  {
+    "chinese": "我在厨房里（过去）正在吃鸡蛋",
+    "english": "I was eating eggs in the kitchen",
+    "soundmark": "/aɪ/ /wəz/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
+  },
+  {
+    "chinese": "与此同时",
+    "english": "while",
+    "soundmark": "/waɪl/"
+  },
+  {
+    "chinese": "他们在花园里（过去）正在喝茶与此同时我在厨房里（过去）正在吃鸡蛋",
+    "english": "they were drinking tea in the garden while I was eating eggs in the kitchen",
+    "soundmark": "/ðe/ /wɚ/ /'drɪŋkɪŋ/ /ti/ /ɪn/ /ðə/ /ˈɡɑrdn/ /waɪl/ /aɪ/ /wəz/ /'itɪŋ/ /ɛgz/ /ɪn/ /ðə/ /'kɪtʃɪn/"
+  },
+  {
+    "chinese": "教",
+    "english": "to teach",
+    "soundmark": "/tə/ /titʃ/"
+  },
+  {
+    "chinese": "我们",
+    "english": "us",
+    "soundmark": "/ʌs/"
+  },
+  {
+    "chinese": "教我们",
+    "english": "to teach us",
+    "soundmark": "/tə/ /titʃ/ /ʌs/"
+  },
+  {
+    "chinese": "正在教",
+    "english": "teaching",
+    "soundmark": "/'titʃɪŋ/"
+  },
+  {
+    "chinese": "正在教我们",
+    "english": "teaching us",
+    "soundmark": "/'titʃɪŋ/ /ʌs/"
+  },
+  {
+    "chinese": "说",
+    "english": "to speak",
+    "soundmark": "/tə/ /spik/"
+  },
+  {
+    "chinese": "英语",
+    "english": "English",
+    "soundmark": "/ˈɪŋɡlɪʃ/"
+  },
+  {
+    "chinese": "说英语",
+    "english": "to speak English",
+    "soundmark": "/tə/ /spik/ /ˈɪŋɡlɪʃ/"
+  },
+  {
+    "chinese": "如何",
+    "english": "how",
+    "soundmark": "/haʊ/"
+  },
+  {
+    "chinese": "如何说英语",
+    "english": "how to speak English",
+    "soundmark": "/haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/"
+  },
+  {
+    "chinese": "正在教我们如何说英语",
+    "english": "teaching us how to speak English",
+    "soundmark": "/'titʃɪŋ/ /ʌs/ /haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/ /（he，现在时）be is/ /ɪz/"
+  },
+  {
+    "chinese": "星荣正在教我们如何说英语",
+    "english": "Xingrong is teaching us how to speak English",
+    "soundmark": "/ɪz/ /'titʃɪŋ/ /ʌs/ /haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/ /（he，过去时）be was/ /wəz/"
+  },
+  {
+    "chinese": "星荣（过去）正在教我们如何说英语",
+    "english": "Xingrong was teaching us how to speak English",
+    "soundmark": "/wəz/ /'titʃɪŋ/ /ʌs/ /haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/"
+  },
+  {
+    "chinese": "学习",
+    "english": "to learn",
+    "soundmark": "/tə/ /lɝn/"
+  },
+  {
+    "chinese": "英语",
+    "english": "English",
+    "soundmark": "/ˈɪŋɡlɪʃ/"
+  },
+  {
+    "chinese": "学习英语",
+    "english": "to learn English",
+    "soundmark": "/tə/ /lɝn/ /ˈɪŋɡlɪʃ/"
+  },
+  {
+    "chinese": "正在学习",
+    "english": "learning",
+    "soundmark": "/'lɝnɪŋ/"
+  },
+  {
+    "chinese": "正在学习英语",
+    "english": "learning English",
+    "soundmark": "/'lɝnɪŋ/ /ˈɪŋɡlɪʃ/ /（I，现在时）be am/ /æm/"
+  },
+  {
+    "chinese": "我正在学习英语",
+    "english": "I am learning English",
+    "soundmark": "/aɪ/ /æm/ /'lɝnɪŋ/ /ˈɪŋɡlɪʃ/"
+  },
+  {
+    "chinese": "视频",
+    "english": "videos",
+    "soundmark": "/'vɪdɪoz/"
+  },
+  {
+    "chinese": "他的",
+    "english": "his",
+    "soundmark": "/hɪz/"
+  },
+  {
+    "chinese": "他的视频",
+    "english": "his videos",
+    "soundmark": "/hɪz/ /'vɪdɪoz/"
+  },
+  {
+    "chinese": "观看",
+    "english": "to watch",
+    "soundmark": "/tə/ /wɑtʃ/"
+  },
+  {
+    "chinese": "观看他的视频",
+    "english": "to watch his videos",
+    "soundmark": "/tə/ /wɑtʃ/ /hɪz/ /'vɪdɪoz/"
+  },
+  {
+    "chinese": "正在观看",
+    "english": "watching",
+    "soundmark": "/'wɑtʃɪŋ/"
+  },
+  {
+    "chinese": "正在观看他的视频",
+    "english": "watching his videos",
+    "soundmark": "/'wɑtʃɪŋ/ /hɪz/ /'vɪdɪoz/"
+  },
+  {
+    "chinese": "通过......的方式",
+    "english": "by",
+    "soundmark": "/baɪ/"
+  },
+  {
+    "chinese": "通过观看他的视频的方式",
+    "english": "by watching his videos",
+    "soundmark": "/baɪ/ /'wɑtʃɪŋ/ /hɪz/ /'vɪdɪoz/"
+  },
+  {
+    "chinese": "我正在学习英语",
+    "english": "I am learning English",
+    "soundmark": "/aɪ/ /æm/ /'lɝnɪŋ/ /ˈɪŋɡlɪʃ/"
+  },
+  {
+    "chinese": "我正在通过观看他的视频的方式学习英语",
+    "english": "I am learning English by watching his videos",
+    "soundmark": "/aɪ/ /æm/ /'lɝnɪŋ/ /ˈɪŋɡlɪʃ/ /baɪ/ /'wɑtʃɪŋ/ /hɪz/ /'vɪdɪoz/ /（I，过去时）be was/ /wəz/"
+  },
+  {
+    "chinese": "我（过去）正在通过观看他的视频的方式学习英语",
+    "english": "I was learning English by watching his videos",
+    "soundmark": "/aɪ/ /wəz/ /'lɝnɪŋ/ /ˈɪŋɡlɪʃ/ /baɪ/ /'wɑtʃɪŋ/ /hɪz/ /'vɪdɪoz/"
+  },
+  {
+    "chinese": "星荣（过去）正在教我们如何说英语",
+    "english": "Xingrong was teaching us how to speak English",
+    "soundmark": "/wəz/ /'titʃɪŋ/ /ʌs/ /haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/"
+  },
+  {
+    "chinese": "与此同时",
+    "english": "while",
+    "soundmark": "/waɪl/"
+  },
+  {
+    "chinese": "星荣（过去）正在教我们如何说英语与此同时我（过去）正在通过观看他的视频的方式学习英语",
+    "english": "Xingrong was teaching us how to speak English while I was learning English by watching his videos",
+    "soundmark": "/wəz/ /'titʃɪŋ/ /ʌs/ /haʊ/ /tə/ /spik/ /ˈɪŋɡlɪʃ/ /waɪl/ /aɪ/ /wəz/ /'lɝnɪŋ/ /ˈɪŋɡlɪʃ/ /baɪ/ /'wɑtʃɪŋ/ /hɪz/ /'vɪdɪoz/"
+  },
+  {
+    "chinese": "走路",
+    "english": "to walk",
+    "soundmark": "/tə/ /wɔk/"
+  },
+  {
+    "chinese": "家",
+    "english": "home",
+    "soundmark": "/hom/"
+  },
+  {
+    "chinese": "走路回家",
+    "english": "to walk home",
+    "soundmark": "/tə/ /wɔk/ /hom/"
+  },
+  {
+    "chinese": "学校",
+    "english": "school",
+    "soundmark": "/skul/"
+  },
+  {
+    "chinese": "从",
+    "english": "from",
+    "soundmark": "/frʌm/"
+  },
+  {
+    "chinese": "从学校",
+    "english": "from school",
+    "soundmark": "/frʌm/ /skul/"
+  },
+  {
+    "chinese": "从学校走路回家",
+    "english": "to walk home from school",
+    "soundmark": "/tə/ /wɔk/ /hom/ /frʌm/ /skul/"
+  },
+  {
+    "chinese": "正在从学校走路回家",
+    "english": "walking home from school",
+    "soundmark": "/'wɔkɪŋ/ /hom/ /frʌm/ /skul/ /（I，现在时）be am/ /æm/"
+  },
+  {
+    "chinese": "我正在从学校走路回家",
+    "english": "I am walking home from school",
+    "soundmark": "/aɪ/ /æm/ /'wɔkɪŋ/ /hom/ /frʌm/ /skul/ /（I，过去时）be was/ /wəz/"
+  },
+  {
+    "chinese": "我（过去）正在从学校走路回家",
+    "english": "I was walking home from school",
+    "soundmark": "/aɪ/ /wəz/ /'wɔkɪŋ/ /hom/ /frʌm/ /skul/"
+  },
+  {
+    "chinese": "朋友",
+    "english": "friend",
+    "soundmark": "/frɛnd/"
+  },
+  {
+    "chinese": "老的",
+    "english": "old",
+    "soundmark": "/old/"
+  },
+  {
+    "chinese": "一个老朋友",
+    "english": "an old friend",
+    "soundmark": "/ən/ /old/ /frɛnd/"
+  },
+  {
+    "chinese": "遇见",
+    "english": "to meet",
+    "soundmark": "/tə/ /mit/"
+  },
+  {
+    "chinese": "遇见一个老朋友",
+    "english": "to meet an old friend",
+    "soundmark": "/tə/ /mit/ /ən/ /old/ /frɛnd/ /（过去）遇见 met/ /mɛt/ /（过去）遇见一个老朋友 met an old friend/ /mɛt/ /ən/ /old/ /frɛnd/"
+  },
+  {
+    "chinese": "我（过去）遇见一个老朋友",
+    "english": "I met an old friend",
+    "soundmark": "/aɪ/ /mɛt/ /ən/ /old/ /frɛnd/"
+  },
+  {
+    "chinese": "我（过去）正在从学校走路回家",
+    "english": "I was walking home from school",
+    "soundmark": "/aɪ/ /wəz/ /'wɔkɪŋ/ /hom/ /frʌm/ /skul/"
+  },
+  {
+    "chinese": "当......的时候",
+    "english": "when",
+    "soundmark": "/wɛn/"
+  },
+  {
+    "chinese": "当我（过去）正在从学校走路回家的时候",
+    "english": "when I was walking home from school",
+    "soundmark": "/wɛn/ /aɪ/ /wəz/ /'wɔkɪŋ/ /hom/ /frʌm/ /skul/"
+  },
+  {
+    "chinese": "当我（过去）正在从学校走路回家的时候我（过去）遇见一个老朋友",
+    "english": "I met an old friend when I was walking home from school",
+    "soundmark": "/aɪ/ /mɛt/ /ən/ /old/ /frɛnd/ /wɛn/ /aɪ/ /wəz/ /'wɔkɪŋ/ /hom/ /frʌm/ /skul/"
+  },
+  {
+    "chinese": "睡觉",
+    "english": "to sleep",
+    "soundmark": "/tə/ /slip/"
+  },
+  {
+    "chinese": "卧室",
+    "english": "the bedroom",
+    "soundmark": "/ðə/ /'bɛdrum/"
+  },
+  {
+    "chinese": "在卧室里",
+    "english": "in the bedroom",
+    "soundmark": "/ɪn/ /ðə/ /'bɛdrum/"
+  },
+  {
+    "chinese": "在卧室里睡觉",
+    "english": "to sleep in the bedroom",
+    "soundmark": "/tə/ /slip/ /ɪn/ /ðə/ /'bɛdrum/"
+  },
+  {
+    "chinese": "正在睡觉",
+    "english": "sleeping",
+    "soundmark": "/ˈslipɪŋ/"
+  },
+  {
+    "chinese": "正在在卧室里睡觉",
+    "english": "sleeping in the bedroom",
+    "soundmark": "/ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/ /（I，现在时）be am/ /æm/"
+  },
+  {
+    "chinese": "我正在在卧室里睡觉",
+    "english": "I am sleeping in the bedroom",
+    "soundmark": "/aɪ/ /æm/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/ /（I，过去时）be was/ /wəz/"
+  },
+  {
+    "chinese": "我（过去）正在在卧室里睡觉",
+    "english": "I was sleeping in the bedroom",
+    "soundmark": "/aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/"
+  },
+  {
+    "chinese": "打电话",
+    "english": "to call",
+    "soundmark": "/tə/ /kɔl/"
+  },
+  {
+    "chinese": "打电话给我",
+    "english": "to call me",
+    "soundmark": "/tə/ /kɔl/ /mi/ /（过去）打电话 called/ /kɔld/ /（过去）打电话给我 called me/ /kɔld/ /mi/"
+  },
+  {
+    "chinese": "她",
+    "english": "she",
+    "soundmark": "/ʃi/"
+  },
+  {
+    "chinese": "她（过去）打电话给我",
+    "english": "she called me",
+    "soundmark": "/ʃi/ /kɔld/ /mi/"
+  },
+  {
+    "chinese": "当......的时候",
+    "english": "when",
+    "soundmark": "/wɛn/"
+  },
+  {
+    "chinese": "当她（过去）打电话给我的时候",
+    "english": "when she called me",
+    "soundmark": "/wɛn/ /ʃi/ /kɔld/ /mi/"
+  },
+  {
+    "chinese": "我（过去）正在在卧室里睡觉",
+    "english": "I was sleeping in the bedroom",
+    "soundmark": "/aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/"
+  },
+  {
+    "chinese": "当她打电话给我的时候我（过去）正在在卧室里睡觉",
+    "english": "I was sleeping in the bedroom when she called me",
+    "soundmark": "/aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/ /wɛn/ /ʃi/ /kɔld/ /mi/"
+  },
+  {
+    "chinese": "玩",
+    "english": "to play",
+    "soundmark": "/tə/ /ple/"
+  },
+  {
+    "chinese": "钢琴",
+    "english": "the piano",
+    "soundmark": "/ðə/ /pɪ'æno/"
+  },
+  {
+    "chinese": "弹钢琴",
+    "english": "to play the piano",
+    "soundmark": "/tə/ /ple/ /ðə/ /pɪ'æno/"
+  },
+  {
+    "chinese": "正在玩",
+    "english": "playing",
+    "soundmark": "/pleɪŋ/"
+  },
+  {
+    "chinese": "正在弹钢琴",
+    "english": "playing the piano",
+    "soundmark": "/pleɪŋ/ /ðə/ /pɪ'æno/ /（她，现在时）be is/ /ɪz/"
+  },
+  {
+    "chinese": "她正在弹钢琴",
+    "english": "she is playing the piano",
+    "soundmark": "/ʃi/ /ɪz/ /pleɪŋ/ /ðə/ /pɪ'æno/ /（她，过去时）be was/ /wəz/"
+  },
+  {
+    "chinese": "她（过去）正在弹钢琴",
+    "english": "she was playing the piano",
+    "soundmark": "/ʃi/ /wəz/ /pleɪŋ/ /ðə/ /pɪ'æno/"
+  },
+  {
+    "chinese": "起居室；客厅",
+    "english": "the living room",
+    "soundmark": "/ðə/ /'lɪvɪŋ/ /rum/"
+  },
+  {
+    "chinese": "在客厅",
+    "english": "in the living room",
+    "soundmark": "/ɪn/ /ðə/ /'lɪvɪŋ/ /rum/"
+  },
+  {
+    "chinese": "她（过去）正在在客厅弹钢琴",
+    "english": "she was playing the piano in the living room",
+    "soundmark": "/ʃi/ /wəz/ /pleɪŋ/ /ðə/ /pɪ'æno/ /ɪn/ /ðə/ /'lɪvɪŋ/ /rum/"
+  },
+  {
+    "chinese": "与此同时",
+    "english": "while",
+    "soundmark": "/waɪl/"
+  },
+  {
+    "chinese": "我（过去）正在在卧室里睡觉",
+    "english": "I was sleeping in the bedroom",
+    "soundmark": "/aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/"
+  },
+  {
+    "chinese": "她（过去）正在在客厅弹钢琴与此同时我（过去）正在在卧室里睡觉",
+    "english": "she was playing the piano in the living room while I was sleeping in the bedroom",
+    "soundmark": "/ʃi/ /wəz/ /pleɪŋ/ /ðə/ /pɪ'æno/ /ɪn/ /ðə/ /'lɪvɪŋ/ /rum/ /waɪl/ /aɪ/ /wəz/ /ˈslipɪŋ/ /ɪn/ /ðə/ /'bɛdrum/"
+  },
+  {
+    "chinese": "中文 原形 第三人称单数 过去式想要",
+    "english": "want wants",
+    "soundmark": "/wanted/"
+  },
+  {
+    "chinese": "喜欢",
+    "english": "like likes",
+    "soundmark": "/liked/"
+  },
+  {
+    "chinese": "有；(+to)不得不",
+    "english": "have has",
+    "soundmark": "/had/"
+  },
+  {
+    "chinese": "计划",
+    "english": "plan plans",
+    "soundmark": "/planned/"
+  },
+  {
+    "chinese": "需要",
+    "english": "need needs",
+    "soundmark": "/needed/"
+  },
+  {
+    "chinese": "做",
+    "english": "do does",
+    "soundmark": "/did/"
+  },
+  {
+    "chinese": "告诉",
+    "english": "tell tells",
+    "soundmark": "/told/"
+  },
+  {
+    "chinese": "说话",
+    "english": "talk talks",
+    "soundmark": "/talked/"
+  },
+  {
+    "chinese": "是 be（am）",
+    "english": "is",
+    "soundmark": "/was/"
+  },
+  {
+    "chinese": "是 be（is ）",
+    "english": "is",
+    "soundmark": "/was/"
+  },
+  {
+    "chinese": "是 be（are）",
+    "english": "is",
+    "soundmark": "/were/"
+  },
+  {
+    "chinese": "看到",
+    "english": "see sees",
+    "soundmark": "/saw/"
+  },
+  {
+    "chinese": "吃",
+    "english": "eat eats",
+    "soundmark": "/ate/"
+  },
+  {
+    "chinese": "喝",
+    "english": "drink drinks",
+    "soundmark": "/drank/"
+  },
+  {
+    "chinese": "知道",
+    "english": "know knows",
+    "soundmark": "/knew/"
+  },
+  {
+    "chinese": "忘记",
+    "english": "forget forgets",
+    "soundmark": "/forgot/"
+  },
+  {
+    "chinese": "失去",
+    "english": "lose loses",
+    "soundmark": "/lost/"
+  },
+  {
+    "chinese": "离开",
+    "english": "leave leaves",
+    "soundmark": "/left/"
+  },
+  {
+    "chinese": "睡觉",
+    "english": "sleep sleeps",
+    "soundmark": "/slept/"
+  },
+  {
+    "chinese": "明白",
+    "english": "understand understands",
+    "soundmark": "/understood/"
+  },
+  {
+    "chinese": "买",
+    "english": "buy buys",
+    "soundmark": "/bought/"
+  },
+  {
+    "chinese": "洗",
+    "english": "wash washes",
+    "soundmark": "/washed/"
+  },
+  {
+    "chinese": "打电话",
+    "english": "call calls",
+    "soundmark": "/called/"
+  },
+  {
+    "chinese": "帮助",
+    "english": "help helps",
+    "soundmark": "/helped/"
+  },
+  {
+    "chinese": "相信",
+    "english": "believe believes",
+    "soundmark": "/believed/"
+  },
+  {
+    "chinese": "学习",
+    "english": "study studies",
+    "soundmark": "/studied/"
+  },
+  {
+    "chinese": "解释",
+    "english": "explain explains",
+    "soundmark": "/explained/"
+  },
+  {
+    "chinese": "问",
+    "english": "ask asks",
+    "soundmark": "/asked/"
+  },
+  {
+    "chinese": "飞",
+    "english": "fly flies",
+    "soundmark": "/flew/"
+  },
+  {
+    "chinese": "阅读",
+    "english": "read reads",
+    "soundmark": "/read/"
+  },
+  {
+    "chinese": "走路",
+    "english": "walk walks",
+    "soundmark": "/walked/"
+  },
+  {
+    "chinese": "跳舞",
+    "english": "dance dances",
+    "soundmark": "/danced/"
+  },
+  {
+    "chinese": "回答",
+    "english": "answer answers",
+    "soundmark": "/answered/"
+  },
+  {
+    "chinese": "工作",
+    "english": "work works",
+    "soundmark": "/worked/"
+  },
+  {
+    "chinese": "待在",
+    "english": "stay stays",
+    "soundmark": "/stayed/"
+  },
+  {
+    "chinese": "支付",
+    "english": "pay pays",
+    "soundmark": "/paid/"
+  },
+  {
+    "chinese": "旅行",
+    "english": "travel travels",
+    "soundmark": "/traveled/"
+  },
+  {
+    "chinese": "给",
+    "english": "give gives",
+    "soundmark": "/gave/"
+  },
+  {
+    "chinese": "达到",
+    "english": "get gets",
+    "soundmark": "/got/"
+  },
+  {
+    "chinese": "锁",
+    "english": "lock locks",
+    "soundmark": "/locked/"
+  },
+  {
+    "chinese": "记得",
+    "english": "remember remembers",
+    "soundmark": "/remembered/"
+  },
+  {
+    "chinese": "清理",
+    "english": "clean cleans",
+    "soundmark": "/cleaned/"
+  },
+  {
+    "chinese": "找到",
+    "english": "find finds",
+    "soundmark": "/found/"
+  },
+  {
+    "chinese": "关闭",
+    "english": "close closes",
+    "soundmark": "/closed/"
+  },
+  {
+    "chinese": "教",
+    "english": "teach teaches",
+    "soundmark": "/taught/"
+  },
+  {
+    "chinese": "展示",
+    "english": "show shows",
+    "soundmark": "/showed/"
+  },
+  {
+    "chinese": "让",
+    "english": "let lets",
+    "soundmark": "/let/"
+  },
+  {
+    "chinese": "休息",
+    "english": "rest rests",
+    "soundmark": "/rested/"
+  },
+  {
+    "chinese": "用",
+    "english": "use uses",
+    "soundmark": "/used/"
+  },
+  {
+    "chinese": "做饭",
+    "english": "cook cooks",
+    "soundmark": "/cooked/"
+  },
+  {
+    "chinese": "去",
+    "english": "go goes",
+    "soundmark": "/went/"
+  },
+  {
+    "chinese": "决定",
+    "english": "decide decides",
+    "soundmark": "/decided/"
+  },
+  {
+    "chinese": "驾驶",
+    "english": "drive drives",
+    "soundmark": "/drove/"
+  },
+  {
+    "chinese": "改变",
+    "english": "change changes",
+    "soundmark": "/changed/"
+  },
+  {
+    "chinese": "尝试",
+    "english": "try tries",
+    "soundmark": "/tried/"
+  },
+  {
+    "chinese": "停止",
+    "english": "stop stops",
+    "soundmark": "/Stopped/"
+  },
+  {
+    "chinese": "参加",
+    "english": "join joins",
+    "soundmark": "/joined/"
+  },
+  {
+    "chinese": "邀请",
+    "english": "invite invites",
+    "soundmark": "/invited/"
+  },
+  {
+    "chinese": "拒绝",
+    "english": "refuse refuses",
+    "soundmark": "/refused/"
+  },
+  {
+    "chinese": "接受",
+    "english": "accept accepts",
+    "soundmark": "/accepted/"
+  },
+  {
+    "chinese": "学习",
+    "english": "learn learns",
+    "soundmark": "/learnt/"
+  },
+  {
+    "chinese": "完成",
+    "english": "finish finishes",
+    "soundmark": "/finished/"
+  },
+  {
+    "chinese": "看",
+    "english": "watch watches",
+    "soundmark": "/watched/"
+  },
+  {
+    "chinese": "游泳",
+    "english": "swim swims",
+    "soundmark": "/swam/"
+  },
+  {
+    "chinese": "掌握",
+    "english": "master masters",
+    "soundmark": "/mastered/"
+  }
 ]

--- a/scripts/courses/15.json
+++ b/scripts/courses/15.json
@@ -1,1022 +1,1022 @@
 [
-	{
-		"chinese": "我们的",
-		"english": "our",
-		"soundmark": "/'aʊɚ/"
-	},
-	{
-		"chinese": "团队",
-		"english": "team",
-		"soundmark": "/tim/"
-	},
-	{
-		"chinese": "我们的团队",
-		"english": "our team",
-		"soundmark": "/'aʊɚ/ /tim/"
-	},
-	{
-		"chinese": "加入",
-		"english": "to join",
-		"soundmark": "/tə/ /dʒɔɪn/"
-	},
-	{
-		"chinese": "加入我们的团队",
-		"english": "to join our team",
-		"soundmark": "/tə/ /dʒɔɪn/ /'aʊɚ/ /tim/"
-	},
-	{
-		"chinese": "决定",
-		"english": "to decide",
-		"soundmark": "/tə/ /dɪ'saɪd/"
-	},
-	{
-		"chinese": "决定加入我们的团队",
-		"english": "to decide to join our team",
-		"soundmark": "/tə/ /dɪ'saɪd/ /tə/ /dʒɔɪn/ /'aʊɚ/ /tim/"
-	},
-	{
-		"chinese": "他决定加入我们的团队",
-		"english": "he decides to join our team",
-		"soundmark": "/hi/ /dɪ'saɪdz/ /tə/ /dʒɔɪn/ /'aʊɚ/ /tim/"
-	},
-	{
-		"chinese": "他（过去）决定加入我们的团队",
-		"english": "he decided to join our team",
-		"soundmark": "/hi/ /dɪ'saɪdɪd/ /tə/ /dʒɔɪn/ /'aʊɚ/ /tim/"
-	},
-	{
-		"chinese": "邀请",
-		"english": "to invite",
-		"soundmark": "/tə/ /ɪn'vaɪt/"
-	},
-	{
-		"chinese": "邀请（名词）",
-		"english": "invitation",
-		"soundmark": "/ɪnvɪ'teʃən/"
-	},
-	{
-		"chinese": "这个邀请",
-		"english": "the invitation",
-		"soundmark": "/ði/ /ɪnvɪ'teʃən/"
-	},
-	{
-		"chinese": "接受",
-		"english": "to accept",
-		"soundmark": "/tə/ /ək'sɛpt/"
-	},
-	{
-		"chinese": "接受这个邀请",
-		"english": "to accept the invitation",
-		"soundmark": "/tə/ /ək'sɛpt/ /ði/ /ɪnvɪ'teʃən/"
-	},
-	{
-		"chinese": "加入我们的团队",
-		"english": "to join our team",
-		"soundmark": "/tə/ /dʒɔɪn/ /'aʊɚ/ /tim/"
-	},
-	{
-		"chinese": "加入我们的团队的邀请",
-		"english": "the invitation to join our team",
-		"soundmark": "/ði/ /ɪnvɪ'teʃən/ /tə/ /dʒɔɪn/ /'aʊɚ/ /tim/"
-	},
-	{
-		"chinese": "接受加入我们团队的邀请",
-		"english": "to accept the invitation to join our team",
-		"soundmark": "/tə/ /ək'sɛpt/ /ði/ /ɪnvɪ'teʃən/ /tə/ /dʒɔɪn/ /'aʊɚ/ /tim/"
-	},
-	{
-		"chinese": "他接受加入我们团队的邀请",
-		"english": "he accepts the invitation to join our team",
-		"soundmark": "/hi/ /ək'sɛpts/ /ði/ /ɪnvɪ'teʃən/ /tə/ /dʒɔɪn/ /'aʊɚ/ /tim/"
-	},
-	{
-		"chinese": "他不接受加入我们团队的邀请",
-		"english": "he doesn't accept the invitation to join our team",
-		"soundmark": "/hi/ /ˈdʌznt/ /ək'sɛpt/ /ði/ /ɪnvɪ'teʃən/ /tə/ /dʒɔɪn/ /'aʊɚ/ /tim/"
-	},
-	{
-		"chinese": "他接受了加入我们团队的邀请",
-		"english": "he accepted the invitation to join our team",
-		"soundmark": "/hi/ /ək'sɛptɪd/ /ði/ /ɪnvɪ'teʃən/ /tə/ /dʒɔɪn/ /'aʊɚ/ /tim/"
-	},
-	{
-		"chinese": "他（过去）没有接受加入我们团队的邀请",
-		"english": "he didn't accept the invitation to join our team",
-		"soundmark": "/hi/ /ˈdɪdnt/ /ək'sɛpt/ /ði/ /ɪnvɪ'teʃən/ /tə/ /dʒɔɪn/ /'aʊɚ/ /tim/"
-	},
-	{
-		"chinese": "这个礼物",
-		"english": "the gift",
-		"soundmark": "/ðə/ /ɡɪft/"
-	},
-	{
-		"chinese": "接受",
-		"english": "to accept",
-		"soundmark": "/tə/ /ək'sɛpt/"
-	},
-	{
-		"chinese": "接受这个礼物",
-		"english": "to accept the gift",
-		"soundmark": "/tə/ /ək'sɛpt/ /ðə/ /ɡɪft/"
-	},
-	{
-		"chinese": "他",
-		"english": "he",
-		"soundmark": "/hi/"
-	},
-	{
-		"chinese": "他接受这个礼物",
-		"english": "he accepts the gift",
-		"soundmark": "/hi/ /ək'sɛpts/ /ðə/ /ɡɪft/"
-	},
-	{
-		"chinese": "他不接受这个礼物",
-		"english": "he doesn't accept the gift",
-		"soundmark": "/hi/ /ˈdʌznt/ /ək'sɛpt/ /ðə/ /ɡɪft/"
-	},
-	{
-		"chinese": "他（过去）接受这个礼物",
-		"english": "he accepted the gift",
-		"soundmark": "/hi/ /ək'sɛptɪd/ /ðə/ /ɡɪft/"
-	},
-	{
-		"chinese": "他（过去）没有接受这个礼物",
-		"english": "he didn't accept the gift",
-		"soundmark": "/hi/ /ˈdɪdnt/ /ək'sɛpt/ /ðə/ /ɡɪft/"
-	},
-	{
-		"chinese": "他想要",
-		"english": "he wants",
-		"soundmark": "/hi/ /wɑnts/"
-	},
-	{
-		"chinese": "他想要接受这个礼物",
-		"english": "he wants to accept the gift",
-		"soundmark": "/hi/ /wɑnts/ /tə/ /ək'sɛpt/ /ðə/ /ɡɪft/"
-	},
-	{
-		"chinese": "他不想接受这个礼物",
-		"english": "he doesn't want to accept the gift",
-		"soundmark": "/hi/ /ˈdʌznt/ /wɑnt/ /tə/ /ək'sɛpt/ /ðə/ /ɡɪft/"
-	},
-	{
-		"chinese": "他（过去）想要接受这个礼物",
-		"english": "he wanted to accept the gift",
-		"soundmark": "/hi/ /wɑntɪd/ /tə/ /ək'sɛpt/ /ðə/ /ɡɪft/"
-	},
-	{
-		"chinese": "他（过去）不想接受这个礼物",
-		"english": "he didn't want to accept the gift",
-		"soundmark": "/hi/ /ˈdɪdnt/ /wɑnt/ /tə/ /ək'sɛpt/ /ðə/ /ɡɪft/"
-	},
-	{
-		"chinese": "完成",
-		"english": "to finish",
-		"soundmark": "/tə/ /'fɪnɪʃ/"
-	},
-	{
-		"chinese": "你的",
-		"english": "your",
-		"soundmark": "/jʊr/"
-	},
-	{
-		"chinese": "家庭作业",
-		"english": "homework",
-		"soundmark": "/'hom'wɝk/"
-	},
-	{
-		"chinese": "你的家庭作业",
-		"english": "your homework",
-		"soundmark": "/jʊr/ /'hom'wɝk/"
-	},
-	{
-		"chinese": "完成你的家庭作业",
-		"english": "to finish your homework",
-		"soundmark": "/tə/ /'fɪnɪʃ/ /jʊr/ /'hom'wɝk/"
-	},
-	{
-		"chinese": "我想要你",
-		"english": "I want you",
-		"soundmark": "/aɪ/ /wɑnt/ /ju/"
-	},
-	{
-		"chinese": "我想要你完成你的家庭作业",
-		"english": "I want you to finish your homework",
-		"soundmark": "/aɪ/ /wɑnt/ /ju/ /tə/ /'fɪnɪʃ/ /jʊr/ /'hom'wɝk/"
-	},
-	{
-		"chinese": "看",
-		"english": "to watch",
-		"soundmark": "/tə/ /wɔtʃ/"
-	},
-	{
-		"chinese": "电视",
-		"english": "TV",
-		"soundmark": "/ˈtiˈvi/"
-	},
-	{
-		"chinese": "看电视",
-		"english": "to watch TV",
-		"soundmark": "/tə/ /wɔtʃ/ /ˈtiˈvi/"
-	},
-	{
-		"chinese": "你看电视",
-		"english": "you watch TV",
-		"soundmark": "/ju/ /wɔtʃ/ /ˈtiˈvi/"
-	},
-	{
-		"chinese": "在......之前",
-		"english": "before",
-		"soundmark": "/bɪ'fɔr/"
-	},
-	{
-		"chinese": "在你看电视之前",
-		"english": "before you watch TV",
-		"soundmark": "/bɪ'fɔr/ /ju/ /wɔtʃ/ /ˈtiˈvi/"
-	},
-	{
-		"chinese": "我想要你完成你的家庭作业",
-		"english": "I want you to finish your homework",
-		"soundmark": "/aɪ/ /wɑnt/ /ju/ /tə/ /'fɪnɪʃ/ /jʊr/ /'hom'wɝk/"
-	},
-	{
-		"chinese": "我想要你完成你的家庭作业在你看电视之前",
-		"english": "I want you to finish your homework before you watch TV",
-		"soundmark": "/aɪ/ /wɑnt/ /ju/ /tə/ /'fɪnɪʃ/ /jʊr/ /'hom'wɝk/ /bɪ'fɔr/ /ju/ /wɔtʃ/ /ˈtiˈvi/"
-	},
-	{
-		"chinese": "可以",
-		"english": "can",
-		"soundmark": "/kæn/"
-	},
-	{
-		"chinese": "你可以",
-		"english": "you can",
-		"soundmark": "/ju/ /kæn/"
-	},
-	{
-		"chinese": "你可以看电视",
-		"english": "you can watch TV",
-		"soundmark": "/ju/ /kæn/ /wɔtʃ/ /ˈtiˈvi/"
-	},
-	{
-		"chinese": "你不可以看电视",
-		"english": "you can not watch TV",
-		"soundmark": "/ju/ /kæn/ /nɑt/ /wɔtʃ/ /ˈtiˈvi/"
-	},
-	{
-		"chinese": "想要",
-		"english": "want",
-		"soundmark": "/wɑnt/"
-	},
-	{
-		"chinese": "你想要",
-		"english": "you want",
-		"soundmark": "/ju/ /wɑnt/"
-	},
-	{
-		"chinese": "是否；如果",
-		"english": "if",
-		"soundmark": "/ɪf/"
-	},
-	{
-		"chinese": "如果你想的话",
-		"english": "if you want",
-		"soundmark": "/ɪf/ /ju/ /wɑnt/"
-	},
-	{
-		"chinese": "你可以看电视",
-		"english": "you can watch TV",
-		"soundmark": "/ju/ /kæn/ /wɔtʃ/ /ˈtiˈvi/"
-	},
-	{
-		"chinese": "你可以看电视如果你想的话",
-		"english": "you can watch TV if you want",
-		"soundmark": "/ju/ /kæn/ /wɔtʃ/ /ˈtiˈvi/ /ɪf/ /ju/ /wɑnt/"
-	},
-	{
-		"chinese": "回答",
-		"english": "to answer",
-		"soundmark": "/tə/ /'ænsɚ/"
-	},
-	{
-		"chinese": "这个问题",
-		"english": "the question",
-		"soundmark": "/ðə/ /'kwɛstʃən/"
-	},
-	{
-		"chinese": "回答这个问题",
-		"english": "to answer the question",
-		"soundmark": "/tə/ /'ænsɚ/ /ðə/ /'kwɛstʃən/"
-	},
-	{
-		"chinese": "拒绝",
-		"english": "to refuse",
-		"soundmark": "/tə/ /ri'fjuz/"
-	},
-	{
-		"chinese": "拒绝回答这个问题",
-		"english": "to refuse to answer the question",
-		"soundmark": "/tə/ /ri'fjuz/ /tə/ /'ænsɚ/ /ðə/ /'kwɛstʃən/"
-	},
-	{
-		"chinese": "我想拒绝回答这个问题",
-		"english": "I want to refuse to answer the question",
-		"soundmark": "/aɪ/ /wɑnt/ /tə/ /ri'fjuz/ /tə/ /'ænsɚ/ /ðə/ /'kwɛstʃən/"
-	},
-	{
-		"chinese": "我拒绝回答这个问题",
-		"english": "I refuse to answer the question",
-		"soundmark": "/aɪ/ /ri'fjuz/ /tə/ /'ænsɚ/ /ðə/ /'kwɛstʃən/"
-	},
-	{
-		"chinese": "我（过去）拒绝回答这个问题",
-		"english": "I refused to answer the question",
-		"soundmark": "/aɪ/ /ri'fjuzd/ /tə/ /'ænsɚ/ /ðə/ /'kwɛstʃən/"
-	},
-	{
-		"chinese": "这个问题",
-		"english": "the question",
-		"soundmark": "/ðə/ /'kwɛstʃən/"
-	},
-	{
-		"chinese": "困难的",
-		"english": "difficult",
-		"soundmark": "/'dɪfɪkəlt/"
-	},
-	{
-		"chinese": "这个问题是困难的",
-		"english": "the question is difficult",
-		"soundmark": "/ðə/ /'kwɛstʃən/ /ɪz/ /'dɪfɪkəlt/"
-	},
-	{
-		"chinese": "这个问题（过去）是困难的",
-		"english": "the question was difficult",
-		"soundmark": "/ðə/ /'kwɛstʃən/ /wəz/ /'dɪfɪkəlt/"
-	},
-	{
-		"chinese": "非常",
-		"english": "very",
-		"soundmark": "/ˈvɛri/"
-	},
-	{
-		"chinese": "这个问题（过去）是非常困难的",
-		"english": "the question was very difficult",
-		"soundmark": "/ðə/ /'kwɛstʃən/ /wəz/ /ˈvɛri/ /'dɪfɪkəlt/"
-	},
-	{
-		"chinese": "对我来说",
-		"english": "for me",
-		"soundmark": "/fɝ/ /mi/"
-	},
-	{
-		"chinese": "这个问题（过去）是非常困难的对我来说",
-		"english": "the question was very difficult for me",
-		"soundmark": "/ðə/ /'kwɛstʃən/ /wəz/ /ˈvɛri/ /'dɪfɪkəlt/ /fɝ/ /mi/"
-	},
-	{
-		"chinese": "因为",
-		"english": "because",
-		"soundmark": "/bɪ'kɔz/"
-	},
-	{
-		"chinese": "因为这个问题（过去）是非常困难的对我来说",
-		"english": "because the question was very difficult for me",
-		"soundmark": "/bɪ'kɔz/ /ðə/ /'kwɛstʃən/ /wəz/ /ˈvɛri/ /'dɪfɪkəlt/ /fɝ/ /mi/"
-	},
-	{
-		"chinese": "我（过去）拒绝回答这个问题",
-		"english": "I refused to answer the question",
-		"soundmark": "/aɪ/ /ri'fjuzd/ /tə/ /'ænsɚ/ /ðə/ /'kwɛstʃən/"
-	},
-	{
-		"chinese": "我（过去）拒绝回答这个问题因为这个问题（过去）是非常困难的对我来说",
-		"english": "I refused to answer the question because the question was very difficult for me",
-		"soundmark": "/aɪ/ /ri'fjuzd/ /tə/ /'ænsɚ/ /ðə/ /'kwɛstʃən/ /bɪ'kɔz/ /ðə/ /'kwɛstʃən/ /wəz/ /ˈvɛri/ /'dɪfɪkəlt/ /fɝ/ /mi/"
-	},
-	{
-		"chinese": "我（过去）拒绝回答这个问题因为它（过去）是非常困难的对我来说",
-		"english": "I refused to answer the question because it was very difficult for me",
-		"soundmark": "/aɪ/ /ri'fjuzd/ /tə/ /'ænsɚ/ /ðə/ /'kwɛstʃən/ /bɪ'kɔz/ /ɪt/ /wəz/ /ˈvɛri/ /'dɪfɪkəlt/ /fɝ/ /mi/"
-	},
-	{
-		"chinese": "困难的",
-		"english": "difficult",
-		"soundmark": "/'dɪfɪkəlt/"
-	},
-	{
-		"chinese": "它是困难的",
-		"english": "it is difficult",
-		"soundmark": "/ɪt/ /ɪz/ /'dɪfɪkəlt/"
-	},
-	{
-		"chinese": "完成",
-		"english": "to finish",
-		"soundmark": "/tə/ /'fɪnɪʃ/"
-	},
-	{
-		"chinese": "这个工作",
-		"english": "the work",
-		"soundmark": "/ðə/ /wɝk/"
-	},
-	{
-		"chinese": "完成这个工作",
-		"english": "to finish the work",
-		"soundmark": "/tə/ /'fɪnɪʃ/ /ðə/ /wɝk/"
-	},
-	{
-		"chinese": "完成这个工作（它）是困难的",
-		"english": "it is difficult to finish the work",
-		"soundmark": "/ɪt/ /ɪz/ /'dɪfɪkəlt/ /tə/ /'fɪnɪʃ/ /ðə/ /wɝk/"
-	},
-	{
-		"chinese": "一天",
-		"english": "a day",
-		"soundmark": "/ə/ /de/"
-	},
-	{
-		"chinese": "在一天内",
-		"english": "in a day",
-		"soundmark": "/ɪn/ /ə/ /de/"
-	},
-	{
-		"chinese": "在一天内完成这个工作",
-		"english": "（它）是困难的 it is difficult to finish the work in a day",
-		"soundmark": "/ɪt/ /ɪz/ /'dɪfɪkəlt/ /tə/ /'fɪnɪʃ/ /ðə/ /wɝk/ /ɪn/ /ə/ /de/"
-	},
-	{
-		"chinese": "危险的",
-		"english": "dangerous",
-		"soundmark": "/'dendʒərəs/"
-	},
-	{
-		"chinese": "它是危险的",
-		"english": "it is dangerous",
-		"soundmark": "/ɪt/ /ɪz/ /'dendʒərəs/"
-	},
-	{
-		"chinese": "游泳",
-		"english": "to swim",
-		"soundmark": "/tə/ /swɪm/"
-	},
-	{
-		"chinese": "大海",
-		"english": "the sea",
-		"soundmark": "/ðə/ /si/"
-	},
-	{
-		"chinese": "在大海里",
-		"english": "in the sea",
-		"soundmark": "/ɪn/ /ðə/ /si/"
-	},
-	{
-		"chinese": "在大海里游泳",
-		"english": "to swim in the sea",
-		"soundmark": "/tə/ /swɪm/ /ɪn/ /ðə/ /si/"
-	},
-	{
-		"chinese": "在大海里游泳（它）是危险的",
-		"english": "it is dangerous to swim in the sea",
-		"soundmark": "/ɪt/ /ɪz/ /'dendʒərəs/ /tə/ /swɪm/ /ɪn/ /ðə/ /si/"
-	},
-	{
-		"chinese": "认为",
-		"english": "think",
-		"soundmark": "/θɪŋk/"
-	},
-	{
-		"chinese": "我认为",
-		"english": "I think",
-		"soundmark": "/aɪ/ /θɪŋk/"
-	},
-	{
-		"chinese": "我认为在大海里游泳（它）是危险的",
-		"english": "I think it is dangerous to swim in the sea",
-		"soundmark": "/aɪ/ /θɪŋk/ /ɪt/ /ɪz/ /'dendʒərəs/ /tə/ /swɪm/ /ɪn/ /ðə/ /si/"
-	},
-	{
-		"chinese": "我不认为在大海里游泳",
-		"english": "（它）是危险的 I don't think it is dangerous to swim in the sea",
-		"soundmark": "/aɪ/ /dont/ /θɪŋk/ /ɪt/ /ɪz/ /'dendʒərəs/ /tə/ /swɪm/ /ɪn/ /ðə/ /si/"
-	},
-	{
-		"chinese": "我拒绝",
-		"english": "I refuse",
-		"soundmark": "/aɪ/ /ri'fjuz/"
-	},
-	{
-		"chinese": "我拒绝在大海里游泳",
-		"english": "I refuse to swim in the sea",
-		"soundmark": "/aɪ/ /ri'fjuz/ /tə/ /swɪm/ /ɪn/ /ðə/ /si/"
-	},
-	{
-		"chinese": "因为",
-		"english": "because",
-		"soundmark": "/bɪ'kɔz/"
-	},
-	{
-		"chinese": "因为它是危险的",
-		"english": "because it is dangerous",
-		"soundmark": "/bɪ'kɔz/ /ɪt/ /ɪz/ /'dendʒərəs/"
-	},
-	{
-		"chinese": "我拒绝在大海里游泳因为它是危险的",
-		"english": "I refuse to swim in the sea because it is dangerous",
-		"soundmark": "/aɪ/ /ri'fjuz/ /tə/ /swɪm/ /ɪn/ /ðə/ /si/ /bɪ'kɔz/ /ɪt/ /ɪz/ /'dendʒərəs/"
-	},
-	{
-		"chinese": "接受",
-		"english": "to accept",
-		"soundmark": "/tə/ /ək'sɛpt/"
-	},
-	{
-		"chinese": "这个挑战",
-		"english": "the challenge",
-		"soundmark": "/ðə/ /'tʃælɪndʒ/"
-	},
-	{
-		"chinese": "接受这个挑战",
-		"english": "to accept the challenge",
-		"soundmark": "/tə/ /ək'sɛpt/ /ðə/ /'tʃælɪndʒ/"
-	},
-	{
-		"chinese": "我必须接受这个挑战",
-		"english": "I have to accept the challenge",
-		"soundmark": "/aɪ/ /hæv/ /tə/ /ək'sɛpt/ /ðə/ /'tʃælɪndʒ/"
-	},
-	{
-		"chinese": "我（过去）必须接受这个挑战",
-		"english": "I had to accept the challenge",
-		"soundmark": "/aɪ/ /hæd/ /tə/ /ək'sɛpt/ /ðə/ /'tʃælɪndʒ/"
-	},
-	{
-		"chinese": "我（过去）不必接受这个挑战",
-		"english": "I didn't have to accept the challenge",
-		"soundmark": "/aɪ/ /ˈdɪdnt/ /hæv/ /tə/ /ək'sɛpt/ /ðə/ /'tʃælɪndʒ/"
-	},
-	{
-		"chinese": "我接受这个挑战",
-		"english": "I accept the challenge",
-		"soundmark": "/aɪ/ /ək'sɛpt/ /ðə/ /'tʃælɪndʒ/"
-	},
-	{
-		"chinese": "我不接受这个挑战",
-		"english": "I don't accept the challenge",
-		"soundmark": "/aɪ/ /dont/ /ək'sɛpt/ /ðə/ /'tʃælɪndʒ/"
-	},
-	{
-		"chinese": "我（过去）接受这个挑战",
-		"english": "I accepted the challenge",
-		"soundmark": "/aɪ/ /ək'sɛptɪd/ /ðə/ /'tʃælɪndʒ/"
-	},
-	{
-		"chinese": "我（过去）不接受这个挑战",
-		"english": "I didn't accept the challenge",
-		"soundmark": "/aɪ/ /ˈdɪdnt/ /ək'sɛpt/ /ðə/ /'tʃælɪndʒ/"
-	},
-	{
-		"chinese": "大的",
-		"english": "big",
-		"soundmark": "/bɪɡ/"
-	},
-	{
-		"chinese": "一个大的挑战",
-		"english": "a big challenge",
-		"soundmark": "/ə/ /bɪɡ/ /'tʃælɪndʒ/"
-	},
-	{
-		"chinese": "英语",
-		"english": "English",
-		"soundmark": "/ˈɪŋɡlɪʃ/"
-	},
-	{
-		"chinese": "英语是一个大的挑战",
-		"english": "English is a big challenge",
-		"soundmark": "/ˈɪŋɡlɪʃ/ /ɪz/ /ə/ /bɪɡ/ /'tʃælɪndʒ/"
-	},
-	{
-		"chinese": "对我来说",
-		"english": "for me",
-		"soundmark": "/fɝ/ /mi/"
-	},
-	{
-		"chinese": "英语是一个大的挑战对我来说",
-		"english": "English is a big challenge for me",
-		"soundmark": "/ˈɪŋɡlɪʃ/ /ɪz/ /ə/ /bɪɡ/ /'tʃælɪndʒ/ /fɝ/ /mi/"
-	},
-	{
-		"chinese": "英语不是一个大的挑战对我来说",
-		"english": "English is not a big challenge for me",
-		"soundmark": "/ˈɪŋɡlɪʃ/ /ɪz/ /nɑt/ /ə/ /bɪɡ/ /'tʃælɪndʒ/ /fɝ/ /mi/"
-	},
-	{
-		"chinese": "掌握",
-		"english": "to master",
-		"soundmark": "/tə/ /'mæstɚ/"
-	},
-	{
-		"chinese": "英语",
-		"english": "English",
-		"soundmark": "/ˈɪŋɡlɪʃ/"
-	},
-	{
-		"chinese": "掌握英语",
-		"english": "to master English",
-		"soundmark": "/tə/ /'mæstɚ/ /ˈɪŋɡlɪʃ/"
-	},
-	{
-		"chinese": "我将会",
-		"english": "I will",
-		"soundmark": "/aɪ/ /wɪl/"
-	},
-	{
-		"chinese": "我将会掌握英语",
-		"english": "I will master English",
-		"soundmark": "/aɪ/ /wɪl/ /'mæstɚ/ /ˈɪŋɡlɪʃ/"
-	},
-	{
-		"chinese": "将来",
-		"english": "the future",
-		"soundmark": "/ðə/ /'fjʊtʃɚ/"
-	},
-	{
-		"chinese": "在将来",
-		"english": "in the future",
-		"soundmark": "/ɪn/ /ðə/ /'fjʊtʃɚ/"
-	},
-	{
-		"chinese": "不远的",
-		"english": "near",
-		"soundmark": "/nɪr/"
-	},
-	{
-		"chinese": "在不远的将来",
-		"english": "in the near future",
-		"soundmark": "/ɪn/ /ðə/ /nɪr/ /'fjʊtʃɚ/"
-	},
-	{
-		"chinese": "我将会在不远的将来掌握英语",
-		"english": "I will master English in the near future",
-		"soundmark": "/aɪ/ /wɪl/ /'mæstɚ/ /ˈɪŋɡlɪʃ/ /ɪn/ /ðə/ /nɪr/ /'fjʊtʃɚ/"
-	},
-	{
-		"chinese": "我知道",
-		"english": "I know",
-		"soundmark": "/aɪ/ /no/"
-	},
-	{
-		"chinese": "我知道我将会在不远的将来掌握英语",
-		"english": "I know I will master English in the near future",
-		"soundmark": "/aɪ/ /no/ /aɪ/ /wɪl/ /'mæstɚ/ /ˈɪŋɡlɪʃ/ /ɪn/ /ðə/ /nɪr/ /'fjʊtʃɚ/"
-	},
-	{
-		"chinese": "而且",
-		"english": "and",
-		"soundmark": "/ənd/"
-	},
-	{
-		"chinese": "而且我知道我将会在不远的",
-		"english": "and I know I will master english",
-		"soundmark": "/ənd/ /aɪ/ /no/ /aɪ/ /wɪl/ /'mæstɚ/ /ˈɪŋɡlɪʃ/"
-	},
-	{
-		"chinese": "将来掌握英语",
-		"english": "in the near future",
-		"soundmark": "/ɪn/ /ðə/ /nɪr/ /'fjʊtʃɚ/"
-	},
-	{
-		"chinese": "英语不是一个大的挑战对我来说",
-		"english": "English is not a big challenge for me",
-		"soundmark": "/ˈɪŋɡlɪʃ/ /ɪz/ /nɑt/ /ə/ /bɪɡ/ /'tʃælɪndʒ/ /fɝ/ /mi/"
-	},
-	{
-		"chinese": "英语不是一个大的挑战对我来说而且我知道我将会在不远的将来掌握英语",
-		"english": "English is not a big challenge for me and I know I will master english in the near future",
-		"soundmark": "/ˈɪŋɡlɪʃ/ /ɪz/ /nɑt/ /ə/ /bɪɡ/ /'tʃælɪndʒ/ /fɝ/ /mi/ /ənd/ /aɪ/ /no/ /aɪ/ /wɪl/ /'mæstɚ/ /ˈɪŋɡlɪʃ/ /ɪn/ /ðə/ /nɪr/ /'fjʊtʃɚ/"
-	},
-	{
-		"chinese": "中文 原形 第三人称单数 过去式想要",
-		"english": "want wants",
-		"soundmark": "/wanted/"
-	},
-	{
-		"chinese": "喜欢",
-		"english": "like likes",
-		"soundmark": "/liked/"
-	},
-	{
-		"chinese": "有；(+to)不得不",
-		"english": "have has",
-		"soundmark": "/had/"
-	},
-	{
-		"chinese": "计划",
-		"english": "plan plans",
-		"soundmark": "/planned/"
-	},
-	{
-		"chinese": "需要",
-		"english": "need needs",
-		"soundmark": "/needed/"
-	},
-	{
-		"chinese": "做",
-		"english": "do does",
-		"soundmark": "/did/"
-	},
-	{
-		"chinese": "告诉",
-		"english": "tell tells",
-		"soundmark": "/told/"
-	},
-	{
-		"chinese": "说话",
-		"english": "talk talks",
-		"soundmark": "/talked/"
-	},
-	{
-		"chinese": "是 be（am）",
-		"english": "is",
-		"soundmark": "/was/"
-	},
-	{
-		"chinese": "是 be（is ）",
-		"english": "is",
-		"soundmark": "/was/"
-	},
-	{
-		"chinese": "是 be（are）",
-		"english": "is",
-		"soundmark": "/were/"
-	},
-	{
-		"chinese": "看到",
-		"english": "see sees",
-		"soundmark": "/saw/"
-	},
-	{
-		"chinese": "吃",
-		"english": "eat eats",
-		"soundmark": "/ate/"
-	},
-	{
-		"chinese": "喝",
-		"english": "drink drinks",
-		"soundmark": "/drank/"
-	},
-	{
-		"chinese": "知道",
-		"english": "know knows",
-		"soundmark": "/knew/"
-	},
-	{
-		"chinese": "忘记",
-		"english": "forget forgets",
-		"soundmark": "/forgot/"
-	},
-	{
-		"chinese": "失去",
-		"english": "lose loses",
-		"soundmark": "/lost/"
-	},
-	{
-		"chinese": "离开",
-		"english": "leave leaves",
-		"soundmark": "/left/"
-	},
-	{
-		"chinese": "睡觉",
-		"english": "sleep sleeps",
-		"soundmark": "/slept/"
-	},
-	{
-		"chinese": "明白",
-		"english": "understand understands",
-		"soundmark": "/understood/"
-	},
-	{
-		"chinese": "买",
-		"english": "buy buys",
-		"soundmark": "/bought/"
-	},
-	{
-		"chinese": "洗",
-		"english": "wash washes",
-		"soundmark": "/washed/"
-	},
-	{
-		"chinese": "打电话",
-		"english": "call calls",
-		"soundmark": "/called/"
-	},
-	{
-		"chinese": "帮助",
-		"english": "help helps",
-		"soundmark": "/helped/"
-	},
-	{
-		"chinese": "相信",
-		"english": "believe believes",
-		"soundmark": "/believed/"
-	},
-	{
-		"chinese": "学习",
-		"english": "study studies",
-		"soundmark": "/studied/"
-	},
-	{
-		"chinese": "解释",
-		"english": "explain explains",
-		"soundmark": "/explained/"
-	},
-	{
-		"chinese": "问",
-		"english": "ask asks",
-		"soundmark": "/asked/"
-	},
-	{
-		"chinese": "飞",
-		"english": "fly flies",
-		"soundmark": "/flew/"
-	},
-	{
-		"chinese": "阅读",
-		"english": "read reads",
-		"soundmark": "/read/"
-	},
-	{
-		"chinese": "走路",
-		"english": "walk walks",
-		"soundmark": "/walked/"
-	},
-	{
-		"chinese": "跳舞",
-		"english": "dance dances",
-		"soundmark": "/danced/"
-	},
-	{
-		"chinese": "回答",
-		"english": "answer answers",
-		"soundmark": "/answered/"
-	},
-	{
-		"chinese": "工作",
-		"english": "work works",
-		"soundmark": "/worked/"
-	},
-	{
-		"chinese": "待在",
-		"english": "stay stays",
-		"soundmark": "/stayed/"
-	},
-	{
-		"chinese": "支付",
-		"english": "pay pays",
-		"soundmark": "/paid/"
-	},
-	{
-		"chinese": "旅行",
-		"english": "travel travels",
-		"soundmark": "/traveled/"
-	},
-	{
-		"chinese": "给",
-		"english": "give gives",
-		"soundmark": "/gave/"
-	},
-	{
-		"chinese": "达到",
-		"english": "get gets",
-		"soundmark": "/got/"
-	},
-	{
-		"chinese": "锁",
-		"english": "lock locks",
-		"soundmark": "/locked/"
-	},
-	{
-		"chinese": "记得",
-		"english": "remember remembers",
-		"soundmark": "/remembered/"
-	},
-	{
-		"chinese": "清理",
-		"english": "clean cleans",
-		"soundmark": "/cleaned/"
-	},
-	{
-		"chinese": "找到",
-		"english": "find finds",
-		"soundmark": "/found/"
-	},
-	{
-		"chinese": "关闭",
-		"english": "close closes",
-		"soundmark": "/closed/"
-	},
-	{
-		"chinese": "教",
-		"english": "teach teaches",
-		"soundmark": "/taught/"
-	},
-	{
-		"chinese": "展示",
-		"english": "show shows",
-		"soundmark": "/showed/"
-	},
-	{
-		"chinese": "让",
-		"english": "let lets",
-		"soundmark": "/let/"
-	},
-	{
-		"chinese": "休息",
-		"english": "rest rests",
-		"soundmark": "/rested/"
-	},
-	{
-		"chinese": "用",
-		"english": "use uses",
-		"soundmark": "/used/"
-	},
-	{
-		"chinese": "做饭",
-		"english": "cook cooks",
-		"soundmark": "/cooked/"
-	},
-	{
-		"chinese": "去",
-		"english": "go goes",
-		"soundmark": "/went/"
-	},
-	{
-		"chinese": "决定",
-		"english": "decide decides",
-		"soundmark": "/decided/"
-	},
-	{
-		"chinese": "驾驶",
-		"english": "drive drives",
-		"soundmark": "/drove/"
-	},
-	{
-		"chinese": "改变",
-		"english": "change changes",
-		"soundmark": "/changed/"
-	},
-	{
-		"chinese": "尝试",
-		"english": "try tries",
-		"soundmark": "/tried/"
-	},
-	{
-		"chinese": "停止",
-		"english": "stop stops",
-		"soundmark": "/Stopped/"
-	},
-	{
-		"chinese": "参加",
-		"english": "join joins",
-		"soundmark": "/joined/"
-	},
-	{
-		"chinese": "邀请",
-		"english": "invite invites",
-		"soundmark": "/invited/"
-	},
-	{
-		"chinese": "拒绝",
-		"english": "refuse refuses",
-		"soundmark": "/refused/"
-	},
-	{
-		"chinese": "接受",
-		"english": "accept accepts",
-		"soundmark": "/accepted/"
-	},
-	{
-		"chinese": "学习",
-		"english": "learn learns",
-		"soundmark": "/learnt/"
-	},
-	{
-		"chinese": "完成",
-		"english": "finish finishes",
-		"soundmark": "/finished/"
-	},
-	{
-		"chinese": "看",
-		"english": "watch watches",
-		"soundmark": "/watched/"
-	},
-	{
-		"chinese": "游泳",
-		"english": "swim swims",
-		"soundmark": "/swam/"
-	},
-	{
-		"chinese": "掌握",
-		"english": "master masters",
-		"soundmark": "/mastered/"
-	}
+  {
+    "chinese": "我们的",
+    "english": "our",
+    "soundmark": "/'aʊɚ/"
+  },
+  {
+    "chinese": "团队",
+    "english": "team",
+    "soundmark": "/tim/"
+  },
+  {
+    "chinese": "我们的团队",
+    "english": "our team",
+    "soundmark": "/'aʊɚ/ /tim/"
+  },
+  {
+    "chinese": "加入",
+    "english": "to join",
+    "soundmark": "/tə/ /dʒɔɪn/"
+  },
+  {
+    "chinese": "加入我们的团队",
+    "english": "to join our team",
+    "soundmark": "/tə/ /dʒɔɪn/ /'aʊɚ/ /tim/"
+  },
+  {
+    "chinese": "决定",
+    "english": "to decide",
+    "soundmark": "/tə/ /dɪ'saɪd/"
+  },
+  {
+    "chinese": "决定加入我们的团队",
+    "english": "to decide to join our team",
+    "soundmark": "/tə/ /dɪ'saɪd/ /tə/ /dʒɔɪn/ /'aʊɚ/ /tim/"
+  },
+  {
+    "chinese": "他决定加入我们的团队",
+    "english": "he decides to join our team",
+    "soundmark": "/hi/ /dɪ'saɪdz/ /tə/ /dʒɔɪn/ /'aʊɚ/ /tim/"
+  },
+  {
+    "chinese": "他（过去）决定加入我们的团队",
+    "english": "he decided to join our team",
+    "soundmark": "/hi/ /dɪ'saɪdɪd/ /tə/ /dʒɔɪn/ /'aʊɚ/ /tim/"
+  },
+  {
+    "chinese": "邀请",
+    "english": "to invite",
+    "soundmark": "/tə/ /ɪn'vaɪt/"
+  },
+  {
+    "chinese": "邀请（名词）",
+    "english": "invitation",
+    "soundmark": "/ɪnvɪ'teʃən/"
+  },
+  {
+    "chinese": "这个邀请",
+    "english": "the invitation",
+    "soundmark": "/ði/ /ɪnvɪ'teʃən/"
+  },
+  {
+    "chinese": "接受",
+    "english": "to accept",
+    "soundmark": "/tə/ /ək'sɛpt/"
+  },
+  {
+    "chinese": "接受这个邀请",
+    "english": "to accept the invitation",
+    "soundmark": "/tə/ /ək'sɛpt/ /ði/ /ɪnvɪ'teʃən/"
+  },
+  {
+    "chinese": "加入我们的团队",
+    "english": "to join our team",
+    "soundmark": "/tə/ /dʒɔɪn/ /'aʊɚ/ /tim/"
+  },
+  {
+    "chinese": "加入我们的团队的邀请",
+    "english": "the invitation to join our team",
+    "soundmark": "/ði/ /ɪnvɪ'teʃən/ /tə/ /dʒɔɪn/ /'aʊɚ/ /tim/"
+  },
+  {
+    "chinese": "接受加入我们团队的邀请",
+    "english": "to accept the invitation to join our team",
+    "soundmark": "/tə/ /ək'sɛpt/ /ði/ /ɪnvɪ'teʃən/ /tə/ /dʒɔɪn/ /'aʊɚ/ /tim/"
+  },
+  {
+    "chinese": "他接受加入我们团队的邀请",
+    "english": "he accepts the invitation to join our team",
+    "soundmark": "/hi/ /ək'sɛpts/ /ði/ /ɪnvɪ'teʃən/ /tə/ /dʒɔɪn/ /'aʊɚ/ /tim/"
+  },
+  {
+    "chinese": "他不接受加入我们团队的邀请",
+    "english": "he doesn't accept the invitation to join our team",
+    "soundmark": "/hi/ /ˈdʌznt/ /ək'sɛpt/ /ði/ /ɪnvɪ'teʃən/ /tə/ /dʒɔɪn/ /'aʊɚ/ /tim/"
+  },
+  {
+    "chinese": "他接受了加入我们团队的邀请",
+    "english": "he accepted the invitation to join our team",
+    "soundmark": "/hi/ /ək'sɛptɪd/ /ði/ /ɪnvɪ'teʃən/ /tə/ /dʒɔɪn/ /'aʊɚ/ /tim/"
+  },
+  {
+    "chinese": "他（过去）没有接受加入我们团队的邀请",
+    "english": "he didn't accept the invitation to join our team",
+    "soundmark": "/hi/ /ˈdɪdnt/ /ək'sɛpt/ /ði/ /ɪnvɪ'teʃən/ /tə/ /dʒɔɪn/ /'aʊɚ/ /tim/"
+  },
+  {
+    "chinese": "这个礼物",
+    "english": "the gift",
+    "soundmark": "/ðə/ /ɡɪft/"
+  },
+  {
+    "chinese": "接受",
+    "english": "to accept",
+    "soundmark": "/tə/ /ək'sɛpt/"
+  },
+  {
+    "chinese": "接受这个礼物",
+    "english": "to accept the gift",
+    "soundmark": "/tə/ /ək'sɛpt/ /ðə/ /ɡɪft/"
+  },
+  {
+    "chinese": "他",
+    "english": "he",
+    "soundmark": "/hi/"
+  },
+  {
+    "chinese": "他接受这个礼物",
+    "english": "he accepts the gift",
+    "soundmark": "/hi/ /ək'sɛpts/ /ðə/ /ɡɪft/"
+  },
+  {
+    "chinese": "他不接受这个礼物",
+    "english": "he doesn't accept the gift",
+    "soundmark": "/hi/ /ˈdʌznt/ /ək'sɛpt/ /ðə/ /ɡɪft/"
+  },
+  {
+    "chinese": "他（过去）接受这个礼物",
+    "english": "he accepted the gift",
+    "soundmark": "/hi/ /ək'sɛptɪd/ /ðə/ /ɡɪft/"
+  },
+  {
+    "chinese": "他（过去）没有接受这个礼物",
+    "english": "he didn't accept the gift",
+    "soundmark": "/hi/ /ˈdɪdnt/ /ək'sɛpt/ /ðə/ /ɡɪft/"
+  },
+  {
+    "chinese": "他想要",
+    "english": "he wants",
+    "soundmark": "/hi/ /wɑnts/"
+  },
+  {
+    "chinese": "他想要接受这个礼物",
+    "english": "he wants to accept the gift",
+    "soundmark": "/hi/ /wɑnts/ /tə/ /ək'sɛpt/ /ðə/ /ɡɪft/"
+  },
+  {
+    "chinese": "他不想接受这个礼物",
+    "english": "he doesn't want to accept the gift",
+    "soundmark": "/hi/ /ˈdʌznt/ /wɑnt/ /tə/ /ək'sɛpt/ /ðə/ /ɡɪft/"
+  },
+  {
+    "chinese": "他（过去）想要接受这个礼物",
+    "english": "he wanted to accept the gift",
+    "soundmark": "/hi/ /wɑntɪd/ /tə/ /ək'sɛpt/ /ðə/ /ɡɪft/"
+  },
+  {
+    "chinese": "他（过去）不想接受这个礼物",
+    "english": "he didn't want to accept the gift",
+    "soundmark": "/hi/ /ˈdɪdnt/ /wɑnt/ /tə/ /ək'sɛpt/ /ðə/ /ɡɪft/"
+  },
+  {
+    "chinese": "完成",
+    "english": "to finish",
+    "soundmark": "/tə/ /'fɪnɪʃ/"
+  },
+  {
+    "chinese": "你的",
+    "english": "your",
+    "soundmark": "/jʊr/"
+  },
+  {
+    "chinese": "家庭作业",
+    "english": "homework",
+    "soundmark": "/'hom'wɝk/"
+  },
+  {
+    "chinese": "你的家庭作业",
+    "english": "your homework",
+    "soundmark": "/jʊr/ /'hom'wɝk/"
+  },
+  {
+    "chinese": "完成你的家庭作业",
+    "english": "to finish your homework",
+    "soundmark": "/tə/ /'fɪnɪʃ/ /jʊr/ /'hom'wɝk/"
+  },
+  {
+    "chinese": "我想要你",
+    "english": "I want you",
+    "soundmark": "/aɪ/ /wɑnt/ /ju/"
+  },
+  {
+    "chinese": "我想要你完成你的家庭作业",
+    "english": "I want you to finish your homework",
+    "soundmark": "/aɪ/ /wɑnt/ /ju/ /tə/ /'fɪnɪʃ/ /jʊr/ /'hom'wɝk/"
+  },
+  {
+    "chinese": "看",
+    "english": "to watch",
+    "soundmark": "/tə/ /wɔtʃ/"
+  },
+  {
+    "chinese": "电视",
+    "english": "TV",
+    "soundmark": "/ˈtiˈvi/"
+  },
+  {
+    "chinese": "看电视",
+    "english": "to watch TV",
+    "soundmark": "/tə/ /wɔtʃ/ /ˈtiˈvi/"
+  },
+  {
+    "chinese": "你看电视",
+    "english": "you watch TV",
+    "soundmark": "/ju/ /wɔtʃ/ /ˈtiˈvi/"
+  },
+  {
+    "chinese": "在......之前",
+    "english": "before",
+    "soundmark": "/bɪ'fɔr/"
+  },
+  {
+    "chinese": "在你看电视之前",
+    "english": "before you watch TV",
+    "soundmark": "/bɪ'fɔr/ /ju/ /wɔtʃ/ /ˈtiˈvi/"
+  },
+  {
+    "chinese": "我想要你完成你的家庭作业",
+    "english": "I want you to finish your homework",
+    "soundmark": "/aɪ/ /wɑnt/ /ju/ /tə/ /'fɪnɪʃ/ /jʊr/ /'hom'wɝk/"
+  },
+  {
+    "chinese": "我想要你完成你的家庭作业在你看电视之前",
+    "english": "I want you to finish your homework before you watch TV",
+    "soundmark": "/aɪ/ /wɑnt/ /ju/ /tə/ /'fɪnɪʃ/ /jʊr/ /'hom'wɝk/ /bɪ'fɔr/ /ju/ /wɔtʃ/ /ˈtiˈvi/"
+  },
+  {
+    "chinese": "可以",
+    "english": "can",
+    "soundmark": "/kæn/"
+  },
+  {
+    "chinese": "你可以",
+    "english": "you can",
+    "soundmark": "/ju/ /kæn/"
+  },
+  {
+    "chinese": "你可以看电视",
+    "english": "you can watch TV",
+    "soundmark": "/ju/ /kæn/ /wɔtʃ/ /ˈtiˈvi/"
+  },
+  {
+    "chinese": "你不可以看电视",
+    "english": "you can not watch TV",
+    "soundmark": "/ju/ /kæn/ /nɑt/ /wɔtʃ/ /ˈtiˈvi/"
+  },
+  {
+    "chinese": "想要",
+    "english": "want",
+    "soundmark": "/wɑnt/"
+  },
+  {
+    "chinese": "你想要",
+    "english": "you want",
+    "soundmark": "/ju/ /wɑnt/"
+  },
+  {
+    "chinese": "是否；如果",
+    "english": "if",
+    "soundmark": "/ɪf/"
+  },
+  {
+    "chinese": "如果你想的话",
+    "english": "if you want",
+    "soundmark": "/ɪf/ /ju/ /wɑnt/"
+  },
+  {
+    "chinese": "你可以看电视",
+    "english": "you can watch TV",
+    "soundmark": "/ju/ /kæn/ /wɔtʃ/ /ˈtiˈvi/"
+  },
+  {
+    "chinese": "你可以看电视如果你想的话",
+    "english": "you can watch TV if you want",
+    "soundmark": "/ju/ /kæn/ /wɔtʃ/ /ˈtiˈvi/ /ɪf/ /ju/ /wɑnt/"
+  },
+  {
+    "chinese": "回答",
+    "english": "to answer",
+    "soundmark": "/tə/ /'ænsɚ/"
+  },
+  {
+    "chinese": "这个问题",
+    "english": "the question",
+    "soundmark": "/ðə/ /'kwɛstʃən/"
+  },
+  {
+    "chinese": "回答这个问题",
+    "english": "to answer the question",
+    "soundmark": "/tə/ /'ænsɚ/ /ðə/ /'kwɛstʃən/"
+  },
+  {
+    "chinese": "拒绝",
+    "english": "to refuse",
+    "soundmark": "/tə/ /ri'fjuz/"
+  },
+  {
+    "chinese": "拒绝回答这个问题",
+    "english": "to refuse to answer the question",
+    "soundmark": "/tə/ /ri'fjuz/ /tə/ /'ænsɚ/ /ðə/ /'kwɛstʃən/"
+  },
+  {
+    "chinese": "我想拒绝回答这个问题",
+    "english": "I want to refuse to answer the question",
+    "soundmark": "/aɪ/ /wɑnt/ /tə/ /ri'fjuz/ /tə/ /'ænsɚ/ /ðə/ /'kwɛstʃən/"
+  },
+  {
+    "chinese": "我拒绝回答这个问题",
+    "english": "I refuse to answer the question",
+    "soundmark": "/aɪ/ /ri'fjuz/ /tə/ /'ænsɚ/ /ðə/ /'kwɛstʃən/"
+  },
+  {
+    "chinese": "我（过去）拒绝回答这个问题",
+    "english": "I refused to answer the question",
+    "soundmark": "/aɪ/ /ri'fjuzd/ /tə/ /'ænsɚ/ /ðə/ /'kwɛstʃən/"
+  },
+  {
+    "chinese": "这个问题",
+    "english": "the question",
+    "soundmark": "/ðə/ /'kwɛstʃən/"
+  },
+  {
+    "chinese": "困难的",
+    "english": "difficult",
+    "soundmark": "/'dɪfɪkəlt/"
+  },
+  {
+    "chinese": "这个问题是困难的",
+    "english": "the question is difficult",
+    "soundmark": "/ðə/ /'kwɛstʃən/ /ɪz/ /'dɪfɪkəlt/"
+  },
+  {
+    "chinese": "这个问题（过去）是困难的",
+    "english": "the question was difficult",
+    "soundmark": "/ðə/ /'kwɛstʃən/ /wəz/ /'dɪfɪkəlt/"
+  },
+  {
+    "chinese": "非常",
+    "english": "very",
+    "soundmark": "/ˈvɛri/"
+  },
+  {
+    "chinese": "这个问题（过去）是非常困难的",
+    "english": "the question was very difficult",
+    "soundmark": "/ðə/ /'kwɛstʃən/ /wəz/ /ˈvɛri/ /'dɪfɪkəlt/"
+  },
+  {
+    "chinese": "对我来说",
+    "english": "for me",
+    "soundmark": "/fɝ/ /mi/"
+  },
+  {
+    "chinese": "这个问题（过去）是非常困难的对我来说",
+    "english": "the question was very difficult for me",
+    "soundmark": "/ðə/ /'kwɛstʃən/ /wəz/ /ˈvɛri/ /'dɪfɪkəlt/ /fɝ/ /mi/"
+  },
+  {
+    "chinese": "因为",
+    "english": "because",
+    "soundmark": "/bɪ'kɔz/"
+  },
+  {
+    "chinese": "因为这个问题（过去）是非常困难的对我来说",
+    "english": "because the question was very difficult for me",
+    "soundmark": "/bɪ'kɔz/ /ðə/ /'kwɛstʃən/ /wəz/ /ˈvɛri/ /'dɪfɪkəlt/ /fɝ/ /mi/"
+  },
+  {
+    "chinese": "我（过去）拒绝回答这个问题",
+    "english": "I refused to answer the question",
+    "soundmark": "/aɪ/ /ri'fjuzd/ /tə/ /'ænsɚ/ /ðə/ /'kwɛstʃən/"
+  },
+  {
+    "chinese": "我（过去）拒绝回答这个问题因为这个问题（过去）是非常困难的对我来说",
+    "english": "I refused to answer the question because the question was very difficult for me",
+    "soundmark": "/aɪ/ /ri'fjuzd/ /tə/ /'ænsɚ/ /ðə/ /'kwɛstʃən/ /bɪ'kɔz/ /ðə/ /'kwɛstʃən/ /wəz/ /ˈvɛri/ /'dɪfɪkəlt/ /fɝ/ /mi/"
+  },
+  {
+    "chinese": "我（过去）拒绝回答这个问题因为它（过去）是非常困难的对我来说",
+    "english": "I refused to answer the question because it was very difficult for me",
+    "soundmark": "/aɪ/ /ri'fjuzd/ /tə/ /'ænsɚ/ /ðə/ /'kwɛstʃən/ /bɪ'kɔz/ /ɪt/ /wəz/ /ˈvɛri/ /'dɪfɪkəlt/ /fɝ/ /mi/"
+  },
+  {
+    "chinese": "困难的",
+    "english": "difficult",
+    "soundmark": "/'dɪfɪkəlt/"
+  },
+  {
+    "chinese": "它是困难的",
+    "english": "it is difficult",
+    "soundmark": "/ɪt/ /ɪz/ /'dɪfɪkəlt/"
+  },
+  {
+    "chinese": "完成",
+    "english": "to finish",
+    "soundmark": "/tə/ /'fɪnɪʃ/"
+  },
+  {
+    "chinese": "这个工作",
+    "english": "the work",
+    "soundmark": "/ðə/ /wɝk/"
+  },
+  {
+    "chinese": "完成这个工作",
+    "english": "to finish the work",
+    "soundmark": "/tə/ /'fɪnɪʃ/ /ðə/ /wɝk/"
+  },
+  {
+    "chinese": "完成这个工作（它）是困难的",
+    "english": "it is difficult to finish the work",
+    "soundmark": "/ɪt/ /ɪz/ /'dɪfɪkəlt/ /tə/ /'fɪnɪʃ/ /ðə/ /wɝk/"
+  },
+  {
+    "chinese": "一天",
+    "english": "a day",
+    "soundmark": "/ə/ /de/"
+  },
+  {
+    "chinese": "在一天内",
+    "english": "in a day",
+    "soundmark": "/ɪn/ /ə/ /de/"
+  },
+  {
+    "chinese": "在一天内完成这个工作",
+    "english": "it is difficult to finish the work in a day",
+    "soundmark": "/ɪt/ /ɪz/ /'dɪfɪkəlt/ /tə/ /'fɪnɪʃ/ /ðə/ /wɝk/ /ɪn/ /ə/ /de/"
+  },
+  {
+    "chinese": "危险的",
+    "english": "dangerous",
+    "soundmark": "/'dendʒərəs/"
+  },
+  {
+    "chinese": "它是危险的",
+    "english": "it is dangerous",
+    "soundmark": "/ɪt/ /ɪz/ /'dendʒərəs/"
+  },
+  {
+    "chinese": "游泳",
+    "english": "to swim",
+    "soundmark": "/tə/ /swɪm/"
+  },
+  {
+    "chinese": "大海",
+    "english": "the sea",
+    "soundmark": "/ðə/ /si/"
+  },
+  {
+    "chinese": "在大海里",
+    "english": "in the sea",
+    "soundmark": "/ɪn/ /ðə/ /si/"
+  },
+  {
+    "chinese": "在大海里游泳",
+    "english": "to swim in the sea",
+    "soundmark": "/tə/ /swɪm/ /ɪn/ /ðə/ /si/"
+  },
+  {
+    "chinese": "在大海里游泳（它）是危险的",
+    "english": "it is dangerous to swim in the sea",
+    "soundmark": "/ɪt/ /ɪz/ /'dendʒərəs/ /tə/ /swɪm/ /ɪn/ /ðə/ /si/"
+  },
+  {
+    "chinese": "认为",
+    "english": "think",
+    "soundmark": "/θɪŋk/"
+  },
+  {
+    "chinese": "我认为",
+    "english": "I think",
+    "soundmark": "/aɪ/ /θɪŋk/"
+  },
+  {
+    "chinese": "我认为在大海里游泳（它）是危险的",
+    "english": "I think it is dangerous to swim in the sea",
+    "soundmark": "/aɪ/ /θɪŋk/ /ɪt/ /ɪz/ /'dendʒərəs/ /tə/ /swɪm/ /ɪn/ /ðə/ /si/"
+  },
+  {
+    "chinese": "我不认为在大海里游泳",
+    "english": "I don't think it is dangerous to swim in the sea",
+    "soundmark": "/aɪ/ /dont/ /θɪŋk/ /ɪt/ /ɪz/ /'dendʒərəs/ /tə/ /swɪm/ /ɪn/ /ðə/ /si/"
+  },
+  {
+    "chinese": "我拒绝",
+    "english": "I refuse",
+    "soundmark": "/aɪ/ /ri'fjuz/"
+  },
+  {
+    "chinese": "我拒绝在大海里游泳",
+    "english": "I refuse to swim in the sea",
+    "soundmark": "/aɪ/ /ri'fjuz/ /tə/ /swɪm/ /ɪn/ /ðə/ /si/"
+  },
+  {
+    "chinese": "因为",
+    "english": "because",
+    "soundmark": "/bɪ'kɔz/"
+  },
+  {
+    "chinese": "因为它是危险的",
+    "english": "because it is dangerous",
+    "soundmark": "/bɪ'kɔz/ /ɪt/ /ɪz/ /'dendʒərəs/"
+  },
+  {
+    "chinese": "我拒绝在大海里游泳因为它是危险的",
+    "english": "I refuse to swim in the sea because it is dangerous",
+    "soundmark": "/aɪ/ /ri'fjuz/ /tə/ /swɪm/ /ɪn/ /ðə/ /si/ /bɪ'kɔz/ /ɪt/ /ɪz/ /'dendʒərəs/"
+  },
+  {
+    "chinese": "接受",
+    "english": "to accept",
+    "soundmark": "/tə/ /ək'sɛpt/"
+  },
+  {
+    "chinese": "这个挑战",
+    "english": "the challenge",
+    "soundmark": "/ðə/ /'tʃælɪndʒ/"
+  },
+  {
+    "chinese": "接受这个挑战",
+    "english": "to accept the challenge",
+    "soundmark": "/tə/ /ək'sɛpt/ /ðə/ /'tʃælɪndʒ/"
+  },
+  {
+    "chinese": "我必须接受这个挑战",
+    "english": "I have to accept the challenge",
+    "soundmark": "/aɪ/ /hæv/ /tə/ /ək'sɛpt/ /ðə/ /'tʃælɪndʒ/"
+  },
+  {
+    "chinese": "我（过去）必须接受这个挑战",
+    "english": "I had to accept the challenge",
+    "soundmark": "/aɪ/ /hæd/ /tə/ /ək'sɛpt/ /ðə/ /'tʃælɪndʒ/"
+  },
+  {
+    "chinese": "我（过去）不必接受这个挑战",
+    "english": "I didn't have to accept the challenge",
+    "soundmark": "/aɪ/ /ˈdɪdnt/ /hæv/ /tə/ /ək'sɛpt/ /ðə/ /'tʃælɪndʒ/"
+  },
+  {
+    "chinese": "我接受这个挑战",
+    "english": "I accept the challenge",
+    "soundmark": "/aɪ/ /ək'sɛpt/ /ðə/ /'tʃælɪndʒ/"
+  },
+  {
+    "chinese": "我不接受这个挑战",
+    "english": "I don't accept the challenge",
+    "soundmark": "/aɪ/ /dont/ /ək'sɛpt/ /ðə/ /'tʃælɪndʒ/"
+  },
+  {
+    "chinese": "我（过去）接受这个挑战",
+    "english": "I accepted the challenge",
+    "soundmark": "/aɪ/ /ək'sɛptɪd/ /ðə/ /'tʃælɪndʒ/"
+  },
+  {
+    "chinese": "我（过去）不接受这个挑战",
+    "english": "I didn't accept the challenge",
+    "soundmark": "/aɪ/ /ˈdɪdnt/ /ək'sɛpt/ /ðə/ /'tʃælɪndʒ/"
+  },
+  {
+    "chinese": "大的",
+    "english": "big",
+    "soundmark": "/bɪɡ/"
+  },
+  {
+    "chinese": "一个大的挑战",
+    "english": "a big challenge",
+    "soundmark": "/ə/ /bɪɡ/ /'tʃælɪndʒ/"
+  },
+  {
+    "chinese": "英语",
+    "english": "English",
+    "soundmark": "/ˈɪŋɡlɪʃ/"
+  },
+  {
+    "chinese": "英语是一个大的挑战",
+    "english": "English is a big challenge",
+    "soundmark": "/ˈɪŋɡlɪʃ/ /ɪz/ /ə/ /bɪɡ/ /'tʃælɪndʒ/"
+  },
+  {
+    "chinese": "对我来说",
+    "english": "for me",
+    "soundmark": "/fɝ/ /mi/"
+  },
+  {
+    "chinese": "英语是一个大的挑战对我来说",
+    "english": "English is a big challenge for me",
+    "soundmark": "/ˈɪŋɡlɪʃ/ /ɪz/ /ə/ /bɪɡ/ /'tʃælɪndʒ/ /fɝ/ /mi/"
+  },
+  {
+    "chinese": "英语不是一个大的挑战对我来说",
+    "english": "English is not a big challenge for me",
+    "soundmark": "/ˈɪŋɡlɪʃ/ /ɪz/ /nɑt/ /ə/ /bɪɡ/ /'tʃælɪndʒ/ /fɝ/ /mi/"
+  },
+  {
+    "chinese": "掌握",
+    "english": "to master",
+    "soundmark": "/tə/ /'mæstɚ/"
+  },
+  {
+    "chinese": "英语",
+    "english": "English",
+    "soundmark": "/ˈɪŋɡlɪʃ/"
+  },
+  {
+    "chinese": "掌握英语",
+    "english": "to master English",
+    "soundmark": "/tə/ /'mæstɚ/ /ˈɪŋɡlɪʃ/"
+  },
+  {
+    "chinese": "我将会",
+    "english": "I will",
+    "soundmark": "/aɪ/ /wɪl/"
+  },
+  {
+    "chinese": "我将会掌握英语",
+    "english": "I will master English",
+    "soundmark": "/aɪ/ /wɪl/ /'mæstɚ/ /ˈɪŋɡlɪʃ/"
+  },
+  {
+    "chinese": "将来",
+    "english": "the future",
+    "soundmark": "/ðə/ /'fjʊtʃɚ/"
+  },
+  {
+    "chinese": "在将来",
+    "english": "in the future",
+    "soundmark": "/ɪn/ /ðə/ /'fjʊtʃɚ/"
+  },
+  {
+    "chinese": "不远的",
+    "english": "near",
+    "soundmark": "/nɪr/"
+  },
+  {
+    "chinese": "在不远的将来",
+    "english": "in the near future",
+    "soundmark": "/ɪn/ /ðə/ /nɪr/ /'fjʊtʃɚ/"
+  },
+  {
+    "chinese": "我将会在不远的将来掌握英语",
+    "english": "I will master English in the near future",
+    "soundmark": "/aɪ/ /wɪl/ /'mæstɚ/ /ˈɪŋɡlɪʃ/ /ɪn/ /ðə/ /nɪr/ /'fjʊtʃɚ/"
+  },
+  {
+    "chinese": "我知道",
+    "english": "I know",
+    "soundmark": "/aɪ/ /no/"
+  },
+  {
+    "chinese": "我知道我将会在不远的将来掌握英语",
+    "english": "I know I will master English in the near future",
+    "soundmark": "/aɪ/ /no/ /aɪ/ /wɪl/ /'mæstɚ/ /ˈɪŋɡlɪʃ/ /ɪn/ /ðə/ /nɪr/ /'fjʊtʃɚ/"
+  },
+  {
+    "chinese": "而且",
+    "english": "and",
+    "soundmark": "/ənd/"
+  },
+  {
+    "chinese": "而且我知道我将会在不远的",
+    "english": "and I know I will master english",
+    "soundmark": "/ənd/ /aɪ/ /no/ /aɪ/ /wɪl/ /'mæstɚ/ /ˈɪŋɡlɪʃ/"
+  },
+  {
+    "chinese": "将来掌握英语",
+    "english": "in the near future",
+    "soundmark": "/ɪn/ /ðə/ /nɪr/ /'fjʊtʃɚ/"
+  },
+  {
+    "chinese": "英语不是一个大的挑战对我来说",
+    "english": "English is not a big challenge for me",
+    "soundmark": "/ˈɪŋɡlɪʃ/ /ɪz/ /nɑt/ /ə/ /bɪɡ/ /'tʃælɪndʒ/ /fɝ/ /mi/"
+  },
+  {
+    "chinese": "英语不是一个大的挑战对我来说而且我知道我将会在不远的将来掌握英语",
+    "english": "English is not a big challenge for me and I know I will master english in the near future",
+    "soundmark": "/ˈɪŋɡlɪʃ/ /ɪz/ /nɑt/ /ə/ /bɪɡ/ /'tʃælɪndʒ/ /fɝ/ /mi/ /ənd/ /aɪ/ /no/ /aɪ/ /wɪl/ /'mæstɚ/ /ˈɪŋɡlɪʃ/ /ɪn/ /ðə/ /nɪr/ /'fjʊtʃɚ/"
+  },
+  {
+    "chinese": "中文 原形 第三人称单数 过去式想要",
+    "english": "want wants",
+    "soundmark": "/wanted/"
+  },
+  {
+    "chinese": "喜欢",
+    "english": "like likes",
+    "soundmark": "/liked/"
+  },
+  {
+    "chinese": "有；(+to)不得不",
+    "english": "have has",
+    "soundmark": "/had/"
+  },
+  {
+    "chinese": "计划",
+    "english": "plan plans",
+    "soundmark": "/planned/"
+  },
+  {
+    "chinese": "需要",
+    "english": "need needs",
+    "soundmark": "/needed/"
+  },
+  {
+    "chinese": "做",
+    "english": "do does",
+    "soundmark": "/did/"
+  },
+  {
+    "chinese": "告诉",
+    "english": "tell tells",
+    "soundmark": "/told/"
+  },
+  {
+    "chinese": "说话",
+    "english": "talk talks",
+    "soundmark": "/talked/"
+  },
+  {
+    "chinese": "是 be（am）",
+    "english": "is",
+    "soundmark": "/was/"
+  },
+  {
+    "chinese": "是 be（is ）",
+    "english": "is",
+    "soundmark": "/was/"
+  },
+  {
+    "chinese": "是 be（are）",
+    "english": "is",
+    "soundmark": "/were/"
+  },
+  {
+    "chinese": "看到",
+    "english": "see sees",
+    "soundmark": "/saw/"
+  },
+  {
+    "chinese": "吃",
+    "english": "eat eats",
+    "soundmark": "/ate/"
+  },
+  {
+    "chinese": "喝",
+    "english": "drink drinks",
+    "soundmark": "/drank/"
+  },
+  {
+    "chinese": "知道",
+    "english": "know knows",
+    "soundmark": "/knew/"
+  },
+  {
+    "chinese": "忘记",
+    "english": "forget forgets",
+    "soundmark": "/forgot/"
+  },
+  {
+    "chinese": "失去",
+    "english": "lose loses",
+    "soundmark": "/lost/"
+  },
+  {
+    "chinese": "离开",
+    "english": "leave leaves",
+    "soundmark": "/left/"
+  },
+  {
+    "chinese": "睡觉",
+    "english": "sleep sleeps",
+    "soundmark": "/slept/"
+  },
+  {
+    "chinese": "明白",
+    "english": "understand understands",
+    "soundmark": "/understood/"
+  },
+  {
+    "chinese": "买",
+    "english": "buy buys",
+    "soundmark": "/bought/"
+  },
+  {
+    "chinese": "洗",
+    "english": "wash washes",
+    "soundmark": "/washed/"
+  },
+  {
+    "chinese": "打电话",
+    "english": "call calls",
+    "soundmark": "/called/"
+  },
+  {
+    "chinese": "帮助",
+    "english": "help helps",
+    "soundmark": "/helped/"
+  },
+  {
+    "chinese": "相信",
+    "english": "believe believes",
+    "soundmark": "/believed/"
+  },
+  {
+    "chinese": "学习",
+    "english": "study studies",
+    "soundmark": "/studied/"
+  },
+  {
+    "chinese": "解释",
+    "english": "explain explains",
+    "soundmark": "/explained/"
+  },
+  {
+    "chinese": "问",
+    "english": "ask asks",
+    "soundmark": "/asked/"
+  },
+  {
+    "chinese": "飞",
+    "english": "fly flies",
+    "soundmark": "/flew/"
+  },
+  {
+    "chinese": "阅读",
+    "english": "read reads",
+    "soundmark": "/read/"
+  },
+  {
+    "chinese": "走路",
+    "english": "walk walks",
+    "soundmark": "/walked/"
+  },
+  {
+    "chinese": "跳舞",
+    "english": "dance dances",
+    "soundmark": "/danced/"
+  },
+  {
+    "chinese": "回答",
+    "english": "answer answers",
+    "soundmark": "/answered/"
+  },
+  {
+    "chinese": "工作",
+    "english": "work works",
+    "soundmark": "/worked/"
+  },
+  {
+    "chinese": "待在",
+    "english": "stay stays",
+    "soundmark": "/stayed/"
+  },
+  {
+    "chinese": "支付",
+    "english": "pay pays",
+    "soundmark": "/paid/"
+  },
+  {
+    "chinese": "旅行",
+    "english": "travel travels",
+    "soundmark": "/traveled/"
+  },
+  {
+    "chinese": "给",
+    "english": "give gives",
+    "soundmark": "/gave/"
+  },
+  {
+    "chinese": "达到",
+    "english": "get gets",
+    "soundmark": "/got/"
+  },
+  {
+    "chinese": "锁",
+    "english": "lock locks",
+    "soundmark": "/locked/"
+  },
+  {
+    "chinese": "记得",
+    "english": "remember remembers",
+    "soundmark": "/remembered/"
+  },
+  {
+    "chinese": "清理",
+    "english": "clean cleans",
+    "soundmark": "/cleaned/"
+  },
+  {
+    "chinese": "找到",
+    "english": "find finds",
+    "soundmark": "/found/"
+  },
+  {
+    "chinese": "关闭",
+    "english": "close closes",
+    "soundmark": "/closed/"
+  },
+  {
+    "chinese": "教",
+    "english": "teach teaches",
+    "soundmark": "/taught/"
+  },
+  {
+    "chinese": "展示",
+    "english": "show shows",
+    "soundmark": "/showed/"
+  },
+  {
+    "chinese": "让",
+    "english": "let lets",
+    "soundmark": "/let/"
+  },
+  {
+    "chinese": "休息",
+    "english": "rest rests",
+    "soundmark": "/rested/"
+  },
+  {
+    "chinese": "用",
+    "english": "use uses",
+    "soundmark": "/used/"
+  },
+  {
+    "chinese": "做饭",
+    "english": "cook cooks",
+    "soundmark": "/cooked/"
+  },
+  {
+    "chinese": "去",
+    "english": "go goes",
+    "soundmark": "/went/"
+  },
+  {
+    "chinese": "决定",
+    "english": "decide decides",
+    "soundmark": "/decided/"
+  },
+  {
+    "chinese": "驾驶",
+    "english": "drive drives",
+    "soundmark": "/drove/"
+  },
+  {
+    "chinese": "改变",
+    "english": "change changes",
+    "soundmark": "/changed/"
+  },
+  {
+    "chinese": "尝试",
+    "english": "try tries",
+    "soundmark": "/tried/"
+  },
+  {
+    "chinese": "停止",
+    "english": "stop stops",
+    "soundmark": "/Stopped/"
+  },
+  {
+    "chinese": "参加",
+    "english": "join joins",
+    "soundmark": "/joined/"
+  },
+  {
+    "chinese": "邀请",
+    "english": "invite invites",
+    "soundmark": "/invited/"
+  },
+  {
+    "chinese": "拒绝",
+    "english": "refuse refuses",
+    "soundmark": "/refused/"
+  },
+  {
+    "chinese": "接受",
+    "english": "accept accepts",
+    "soundmark": "/accepted/"
+  },
+  {
+    "chinese": "学习",
+    "english": "learn learns",
+    "soundmark": "/learnt/"
+  },
+  {
+    "chinese": "完成",
+    "english": "finish finishes",
+    "soundmark": "/finished/"
+  },
+  {
+    "chinese": "看",
+    "english": "watch watches",
+    "soundmark": "/watched/"
+  },
+  {
+    "chinese": "游泳",
+    "english": "swim swims",
+    "soundmark": "/swam/"
+  },
+  {
+    "chinese": "掌握",
+    "english": "master masters",
+    "soundmark": "/mastered/"
+  }
 ]

--- a/scripts/courses/16.json
+++ b/scripts/courses/16.json
@@ -1,1057 +1,1057 @@
 [
-	{
-		"chinese": "书",
-		"english": "book",
-		"soundmark": "/bʊk/"
-	},
-	{
-		"chinese": "英语",
-		"english": "English",
-		"soundmark": "/ˈɪŋɡlɪʃ/"
-	},
-	{
-		"chinese": "一本英语书",
-		"english": "an English book",
-		"soundmark": "/æn/ /ˈɪŋɡlɪʃ/ /bʊk/"
-	},
-	{
-		"chinese": "阅读",
-		"english": "to read",
-		"soundmark": "/tə/ /rid/"
-	},
-	{
-		"chinese": "阅读一本英语书",
-		"english": "to read an English book",
-		"soundmark": "/tə/ /rid/ /æn/ /ˈɪŋɡlɪʃ/ /bʊk/"
-	},
-	{
-		"chinese": "阅读（ing形式）",
-		"english": "reading",
-		"soundmark": "/ridɪŋ/"
-	},
-	{
-		"chinese": "是；赋值（原型）",
-		"english": "be",
-		"soundmark": "/bi/"
-	},
-	{
-		"chinese": "正在阅读",
-		"english": "be reading",
-		"soundmark": "/bi/ /ridɪŋ/"
-	},
-	{
-		"chinese": "正在阅读一本英语书",
-		"english": "be reading an English book",
-		"soundmark": "/bi/ /ridɪŋ/ /æn/ /ˈɪŋɡlɪʃ/ /bʊk/"
-	},
-	{
-		"chinese": "我",
-		"english": "I",
-		"soundmark": "/aɪ/ /（I，现在时）be am/ /æm/"
-	},
-	{
-		"chinese": "我（现在）正在阅读一本英语书",
-		"english": "I am reading an English book",
-		"soundmark": "/aɪ/ /æm/ /ridɪŋ/ /æn/ /ˈɪŋɡlɪʃ/ /bʊk/"
-	},
-	{
-		"chinese": "这一瞬间；这一刻",
-		"english": "the moment",
-		"soundmark": "/ðə/ /'momənt/"
-	},
-	{
-		"chinese": "在这一刻；此刻",
-		"english": "at the moment",
-		"soundmark": "/æt/ /ðə/ /'momənt/"
-	},
-	{
-		"chinese": "我此刻正在阅读一本英语书",
-		"english": "I am reading an English book at the moment",
-		"soundmark": "/aɪ/ /æm/ /ridɪŋ/ /æn/ /ˈɪŋɡlɪʃ/ /bʊk/ /æt/ /ðə/ /'momənt/ /（I，过去时）be was/ /wəz/"
-	},
-	{
-		"chinese": "我（过去）正在阅读一本英语书",
-		"english": "I was reading an English book",
-		"soundmark": "/aɪ/ /wəz/ /ridɪŋ/ /æn/ /ˈɪŋɡlɪʃ/ /bʊk/"
-	},
-	{
-		"chinese": "昨晚",
-		"english": "last night",
-		"soundmark": "/læst/ /naɪt/"
-	},
-	{
-		"chinese": "我昨晚正在阅读一本英语书",
-		"english": "I was reading an English book last night",
-		"soundmark": "/aɪ/ /wəz/ /ridɪŋ/ /æn/ /ˈɪŋɡlɪʃ/ /bʊk/ /læst/ /naɪt/"
-	},
-	{
-		"chinese": "家",
-		"english": "home",
-		"soundmark": "/hom/"
-	},
-	{
-		"chinese": "工作",
-		"english": "work",
-		"soundmark": "/wɝk/"
-	},
-	{
-		"chinese": "家庭作业",
-		"english": "homework",
-		"soundmark": "/'homwɝk/"
-	},
-	{
-		"chinese": "她的",
-		"english": "her",
-		"soundmark": "/hɚ/"
-	},
-	{
-		"chinese": "她的家庭作业",
-		"english": "her homework",
-		"soundmark": "/hɚ/ /'homwɝk/"
-	},
-	{
-		"chinese": "做",
-		"english": "to do",
-		"soundmark": "/tə/ /du/"
-	},
-	{
-		"chinese": "做她的家庭作业",
-		"english": "to do her homework",
-		"soundmark": "/tə/ /du/ /hɚ/ /'homwɝk/"
-	},
-	{
-		"chinese": "做（ing形式）",
-		"english": "doing",
-		"soundmark": "/ˈduɪŋ/"
-	},
-	{
-		"chinese": "是；赋值（原型）",
-		"english": "be",
-		"soundmark": "/bi/"
-	},
-	{
-		"chinese": "正在做",
-		"english": "be doing",
-		"soundmark": "/bi/ /ˈduɪŋ/"
-	},
-	{
-		"chinese": "正在做她的家庭作业",
-		"english": "be doing her homework",
-		"soundmark": "/bi/ /ˈduɪŋ/ /hɚ/ /'homwɝk/"
-	},
-	{
-		"chinese": "她",
-		"english": "she",
-		"soundmark": "/ʃi/ /（she，现在时）be is/ /ɪz/"
-	},
-	{
-		"chinese": "她（现在）正在做她的家庭作业",
-		"english": "she is doing her homework",
-		"soundmark": "/ʃi/ /ɪz/ /ˈduɪŋ/ /hɚ/ /'homwɝk/"
-	},
-	{
-		"chinese": "女儿",
-		"english": "daughter",
-		"soundmark": "/'dɔtɚ/"
-	},
-	{
-		"chinese": "的",
-		"english": "my",
-		"soundmark": "/maɪ/"
-	},
-	{
-		"chinese": "我的女儿",
-		"english": "my daughter",
-		"soundmark": "/maɪ/ /'dɔtɚ/"
-	},
-	{
-		"chinese": "我的女儿（现在）正在做她的家庭作业",
-		"english": "my daughter is doing her homework",
-		"soundmark": "/maɪ/ /'dɔtɚ/ /ɪz/ /ˈduɪŋ/ /hɚ/ /'homwɝk/"
-	},
-	{
-		"chinese": "在这一刻；此刻",
-		"english": "at the moment",
-		"soundmark": "/æt/ /ðə/ /'momənt/"
-	},
-	{
-		"chinese": "我的女儿此刻正在做她的家庭作业",
-		"english": "my daughter is doing her homework at the moment",
-		"soundmark": "/maɪ/ /'dɔtɚ/ /ɪz/ /ˈduɪŋ/ /hɚ/ /'homwɝk/ /æt/ /ðə/ /'momənt/ /（she，过去时）be was/ /wəz/"
-	},
-	{
-		"chinese": "我的女儿（过去）正在做她的家庭作业",
-		"english": "my daugher was doing her homework",
-		"soundmark": "/maɪ/ /'dɔtɚ/ /wəz/ /ˈduɪŋ/ /hɚ/ /'homwɝk/"
-	},
-	{
-		"chinese": "我（过去）正在阅读一本英语书",
-		"english": "I was reading an English book",
-		"soundmark": "/aɪ/ /wəz/ /ridɪŋ/ /æn/ /ˈɪŋɡlɪʃ/ /bʊk/"
-	},
-	{
-		"chinese": "与此同时",
-		"english": "while",
-		"soundmark": "/waɪl/"
-	},
-	{
-		"chinese": "我（过去）正在阅读一本英语书与此同时我的女儿（过去）正在做她的家庭作业",
-		"english": "I was reading an English book while my daughter was doing her homework",
-		"soundmark": "/aɪ/ /wəz/ /ridɪŋ/ /æn/ /ˈɪŋɡlɪʃ/ /bʊk/ /waɪl/ /maɪ/ /'dɔtɚ/ /wəz/ /ˈduɪŋ/ /hɚ/ /'homwɝk/"
-	},
-	{
-		"chinese": "跑步",
-		"english": "to run",
-		"soundmark": "/tə/ /rʌn/"
-	},
-	{
-		"chinese": "街道",
-		"english": "the street",
-		"soundmark": "/ðə/ /strit/"
-	},
-	{
-		"chinese": "在街上",
-		"english": "in the street",
-		"soundmark": "/ɪn/ /ðə/ /strit/"
-	},
-	{
-		"chinese": "在街上跑步",
-		"english": "to run in the street",
-		"soundmark": "/tə/ /rʌn/ /ɪn/ /ðə/ /strit/"
-	},
-	{
-		"chinese": "跑步（ing形式）",
-		"english": "running",
-		"soundmark": "/'rʌnɪŋ/"
-	},
-	{
-		"chinese": "是；赋值（原型）",
-		"english": "be",
-		"soundmark": "/bi/"
-	},
-	{
-		"chinese": "正在跑步",
-		"english": "be running",
-		"soundmark": "/bi/ /'rʌnɪŋ/"
-	},
-	{
-		"chinese": "正在在街上跑步",
-		"english": "be running in the street",
-		"soundmark": "/bi/ /'rʌnɪŋ/ /ɪn/ /ðə/ /strit/"
-	},
-	{
-		"chinese": "他",
-		"english": "he",
-		"soundmark": "/hi/ /（he，现在时）be is/ /ɪz/"
-	},
-	{
-		"chinese": "他（现在）正在在街上跑步",
-		"english": "he is running in the street",
-		"soundmark": "/hi/ /ɪz/ /'rʌnɪŋ/ /ɪn/ /ðə/ /strit/"
-	},
-	{
-		"chinese": "在这一刻；此刻",
-		"english": "at the moment",
-		"soundmark": "/æt/ /ðə/ /'momənt/"
-	},
-	{
-		"chinese": "他此刻正在在街上跑步",
-		"english": "he is running in the street at the moment",
-		"soundmark": "/hi/ /ɪz/ /'rʌnɪŋ/ /ɪn/ /ðə/ /strit/ /æt/ /ðə/ /'momənt/ /（he，过去时）be was/ /wəz/"
-	},
-	{
-		"chinese": "他（过去）正在在街上跑步",
-		"english": "he was running in the street",
-		"soundmark": "/hi/ /wəz/ /'rʌnɪŋ/ /ɪn/ /ðə/ /strit/"
-	},
-	{
-		"chinese": "游泳",
-		"english": "to swim",
-		"soundmark": "/tə/ /swɪm/"
-	},
-	{
-		"chinese": "游泳池",
-		"english": "the pool",
-		"soundmark": "/ðə/ /pul/"
-	},
-	{
-		"chinese": "在游泳池里",
-		"english": "in the pool",
-		"soundmark": "/ɪn/ /ðə/ /pul/"
-	},
-	{
-		"chinese": "在游泳池里游泳",
-		"english": "to swim in the pool",
-		"soundmark": "/tə/ /swɪm/ /ɪn/ /ðə/ /pul/"
-	},
-	{
-		"chinese": "游泳（ing形式）",
-		"english": "swimming",
-		"soundmark": "/'swɪmɪŋ/"
-	},
-	{
-		"chinese": "是；赋值（原型）",
-		"english": "be",
-		"soundmark": "/bi/"
-	},
-	{
-		"chinese": "正在游泳",
-		"english": "be swimming",
-		"soundmark": "/bi/ /'swɪmɪŋ/"
-	},
-	{
-		"chinese": "正在在游泳池里游泳",
-		"english": "be swimming in the pool",
-		"soundmark": "/bi/ /'swɪmɪŋ/ /ɪn/ /ðə/ /pul/"
-	},
-	{
-		"chinese": "她",
-		"english": "she",
-		"soundmark": "/ʃi/ /（she，现在时）be is/ /ɪz/"
-	},
-	{
-		"chinese": "她（现在）正在游泳池里游泳",
-		"english": "she is swimming in the pool",
-		"soundmark": "/ʃi/ /ɪz/ /'swɪmɪŋ/ /ɪn/ /ðə/ /pul/"
-	},
-	{
-		"chinese": "在这一刻；此刻",
-		"english": "at the moment",
-		"soundmark": "/æt/ /ðə/ /'momənt/"
-	},
-	{
-		"chinese": "她此刻正在游泳池里游泳",
-		"english": "she is swimming in the pool at the",
-		"soundmark": "/ʃi/ /ɪz/ /'swɪmɪŋ/ /ɪn/ /ðə/ /pul/ /æt/ /ðə/ /moment/ /'momənt/ /（she，过去时）be was/ /wəz/"
-	},
-	{
-		"chinese": "她（过去）正在游泳池里游泳",
-		"english": "she was swimming in the pool",
-		"soundmark": "/ʃi/ /wəz/ /'swɪmɪŋ/ /ɪn/ /ðə/ /pul/"
-	},
-	{
-		"chinese": "他（过去）正在在街上跑步",
-		"english": "he was running in the street",
-		"soundmark": "/hi/ /wəz/ /'rʌnɪŋ/ /ɪn/ /ðə/ /strit/"
-	},
-	{
-		"chinese": "与此同时",
-		"english": "while",
-		"soundmark": "/waɪl/"
-	},
-	{
-		"chinese": "他（过去）正在在街上跑步与此同时她（过去）正在游泳池里游泳",
-		"english": "he was running in the street while she was swimming in the pool",
-		"soundmark": "/hi/ /wəz/ /'rʌnɪŋ/ /ɪn/ /ðə/ /strit/ /waɪl/ /ʃi/ /wəz/ /'swɪmɪŋ/ /ɪn/ /ðə/ /pul/"
-	},
-	{
-		"chinese": "房子",
-		"english": "house",
-		"soundmark": "/haʊs/"
-	},
-	{
-		"chinese": "工作",
-		"english": "work",
-		"soundmark": "/wɝk/"
-	},
-	{
-		"chinese": "家务",
-		"english": "the housework",
-		"soundmark": "/ðə/ /'haʊswɝk/"
-	},
-	{
-		"chinese": "做",
-		"english": "to do",
-		"soundmark": "/tə/ /du/"
-	},
-	{
-		"chinese": "做家务",
-		"english": "to do the housework",
-		"soundmark": "/tə/ /du/ /ðə/ /'haʊswɝk/"
-	},
-	{
-		"chinese": "做（ing形式）",
-		"english": "doing",
-		"soundmark": "/ˈduɪŋ/"
-	},
-	{
-		"chinese": "是；赋值（原型）",
-		"english": "be",
-		"soundmark": "/bi/"
-	},
-	{
-		"chinese": "正在做",
-		"english": "be doing",
-		"soundmark": "/bi/ /ˈduɪŋ/"
-	},
-	{
-		"chinese": "正在做家务",
-		"english": "be doing the housework",
-		"soundmark": "/bi/ /ˈduɪŋ/ /ðə/ /'haʊswɝk/"
-	},
-	{
-		"chinese": "她",
-		"english": "she",
-		"soundmark": "/ʃi/ /（she，现在时）be is/ /ɪz/"
-	},
-	{
-		"chinese": "她（现在）正在做家务",
-		"english": "she is doing the housework",
-		"soundmark": "/ʃi/ /ɪz/ /ˈduɪŋ/ /ðə/ /'haʊswɝk/"
-	},
-	{
-		"chinese": "母亲；妈妈",
-		"english": "mother",
-		"soundmark": "/'mʌðɚ/"
-	},
-	{
-		"chinese": "我的",
-		"english": "my",
-		"soundmark": "/maɪ/"
-	},
-	{
-		"chinese": "我的妈妈",
-		"english": "my mother",
-		"soundmark": "/maɪ/ /'mʌðɚ/"
-	},
-	{
-		"chinese": "我的妈妈（现在）正在做家务",
-		"english": "my mother is doing the housework",
-		"soundmark": "/maɪ/ /'mʌðɚ/ /ɪz/ /ˈduɪŋ/ /ðə/ /'haʊswɝk/"
-	},
-	{
-		"chinese": "在这一刻；此刻",
-		"english": "at the moment",
-		"soundmark": "/æt/ /ðə/ /'momənt/"
-	},
-	{
-		"chinese": "我妈此刻正在做家务",
-		"english": "my mother is doing the housework at the moment",
-		"soundmark": "/maɪ/ /'mʌðɚ/ /ɪz/ /ˈduɪŋ/ /ðə/ /'haʊswɝk/ /æt/ /ðə/ /'momənt/ /（she，过去时）be was/ /wəz/"
-	},
-	{
-		"chinese": "我妈（过去）正在做家务",
-		"english": "my mother was doing the housework",
-		"soundmark": "/maɪ/ /'mʌðɚ/ /wəz/ /ˈduɪŋ/ /ðə/ /'haʊswɝk/"
-	},
-	{
-		"chinese": "说话",
-		"english": "to talk",
-		"soundmark": "/tə/ /tɔk/"
-	},
-	{
-		"chinese": "手机",
-		"english": "the phone",
-		"soundmark": "/ðə/ /fon/"
-	},
-	{
-		"chinese": "在手机上",
-		"english": "on the phone",
-		"soundmark": "/ɑn/ /ðə/ /fon/"
-	},
-	{
-		"chinese": "在手机上说话",
-		"english": "to talk on the phone",
-		"soundmark": "/tə/ /tɔk/ /ɑn/ /ðə/ /fon/"
-	},
-	{
-		"chinese": "说话（ing形式）",
-		"english": "talking",
-		"soundmark": "/'tɔkɪŋ/"
-	},
-	{
-		"chinese": "是；赋值（原型）",
-		"english": "be",
-		"soundmark": "/bi/"
-	},
-	{
-		"chinese": "正在说话",
-		"english": "be talking",
-		"soundmark": "/bi/ /'tɔkɪŋ/"
-	},
-	{
-		"chinese": "正在在手机上说话",
-		"english": "be talking on the phone",
-		"soundmark": "/bi/ /'tɔkɪŋ/ /ɑn/ /ðə/ /fon/"
-	},
-	{
-		"chinese": "他",
-		"english": "he",
-		"soundmark": "/hi/ /（he，现在时）be is/ /ɪz/"
-	},
-	{
-		"chinese": "他（现在）正在手机上说话",
-		"english": "he is talking on the phone",
-		"soundmark": "/hi/ /ɪz/ /'tɔkɪŋ/ /ɑn/ /ðə/ /fon/"
-	},
-	{
-		"chinese": "父亲；爸爸",
-		"english": "father",
-		"soundmark": "/'fɑðɚ/"
-	},
-	{
-		"chinese": "我的",
-		"english": "my",
-		"soundmark": "/maɪ/"
-	},
-	{
-		"chinese": "我的父亲",
-		"english": "my father",
-		"soundmark": "/maɪ/ /'fɑðɚ/"
-	},
-	{
-		"chinese": "我爸（现在）正在手机上说话",
-		"english": "my father is talking on the phone",
-		"soundmark": "/maɪ/ /'fɑðɚ/ /ɪz/ /'tɔkɪŋ/ /ɑn/ /ðə/ /fon/"
-	},
-	{
-		"chinese": "在这一刻；此刻",
-		"english": "at the moment",
-		"soundmark": "/æt/ /ðə/ /'momənt/"
-	},
-	{
-		"chinese": "我爸此刻正在手机上说话",
-		"english": "my father is talking on the phone at the moment",
-		"soundmark": "/maɪ/ /'fɑðɚ/ /ɪz/ /'tɔkɪŋ/ /ɑn/ /ðə/ /fon/ /æt/ /ðə/ /'momənt/ /（he，过去时）be was/ /wəz/"
-	},
-	{
-		"chinese": "我爸（过去）正在手机上说话",
-		"english": "my father was talking on the phone",
-		"soundmark": "/maɪ/ /'fɑðɚ/ /wəz/ /'tɔkɪŋ/ /ɑn/ /ðə/ /fon/"
-	},
-	{
-		"chinese": "与此同时",
-		"english": "while",
-		"soundmark": "/waɪl/"
-	},
-	{
-		"chinese": "我妈（过去）正在做家务",
-		"english": "my mother was doing the housework",
-		"soundmark": "/maɪ/ /'mʌðɚ/ /wəz/ /ˈduɪŋ/ /ðə/ /'haʊswɝk/"
-	},
-	{
-		"chinese": "我妈（过去）正在做家务与此同时我爸（过去）正在手机上说话",
-		"english": "my mother was doing the housework while my father was talking on the phone",
-		"soundmark": "/maɪ/ /'mʌðɚ/ /wəz/ /ˈduɪŋ/ /ðə/ /'haʊswɝk/ /waɪl/ /maɪ/ /'fɑðɚ/ /wəz/ /'tɔkɪŋ/ /ɑn/ /ðə/ /fon/"
-	},
-	{
-		"chinese": "看",
-		"english": "to watch",
-		"soundmark": "/tə/ /wɑtʃ/"
-	},
-	{
-		"chinese": "电视",
-		"english": "TV",
-		"soundmark": "/ˈtiˈvi/"
-	},
-	{
-		"chinese": "看电视",
-		"english": "to watch TV",
-		"soundmark": "/tə/ /'wɑtʃ/ /ˈtiˈvi/"
-	},
-	{
-		"chinese": "看（ing形式）",
-		"english": "watching",
-		"soundmark": "/'wɑtʃɪŋ/"
-	},
-	{
-		"chinese": "是；赋值（原型）",
-		"english": "be",
-		"soundmark": "/bi/"
-	},
-	{
-		"chinese": "正在看",
-		"english": "be watching",
-		"soundmark": "/bi/ /'wɑtʃɪŋ/"
-	},
-	{
-		"chinese": "正在看电视",
-		"english": "be watching TV",
-		"soundmark": "/bi/ /'wɑtʃɪŋ/ /ˈtiˈvi/"
-	},
-	{
-		"chinese": "她",
-		"english": "she",
-		"soundmark": "/ʃi/ /（she，现在时）be is/ /ɪz/"
-	},
-	{
-		"chinese": "她（现在）正在看电视",
-		"english": "she is watching TV",
-		"soundmark": "/ʃi/ /ɪz/ /'wɑtʃɪŋ/ /ˈtiˈvi/"
-	},
-	{
-		"chinese": "女儿",
-		"english": "daughter",
-		"soundmark": "/'dɔtɚ/"
-	},
-	{
-		"chinese": "我的女儿",
-		"english": "my daughter",
-		"soundmark": "/maɪ/ /'dɔtɚ/"
-	},
-	{
-		"chinese": "我女儿（现在）正在看电视",
-		"english": "my daughter is watching TV",
-		"soundmark": "/maɪ/ /'dɔtɚ/ /ɪz/ /'wɑtʃɪŋ/ /ˈtiˈvi/"
-	},
-	{
-		"chinese": "在这一刻；此刻",
-		"english": "at the moment",
-		"soundmark": "/æt/ /ðə/ /'momənt/"
-	},
-	{
-		"chinese": "我女儿此刻正在看电视",
-		"english": "my daughter is watching TV at the moment",
-		"soundmark": "/maɪ/ /'dɔtɚ/ /ɪz/ /'wɑtʃɪŋ/ /ˈtiˈvi/ /æt/ /ðə/ /'momənt/ /（she，过去时）be was/ /wəz/"
-	},
-	{
-		"chinese": "我女儿（过去）正在看电视",
-		"english": "my daughter was watching TV",
-		"soundmark": "/maɪ/ /'dɔtɚ/ /wəz/ /'wɑtʃɪŋ/ /ˈtiˈvi/"
-	},
-	{
-		"chinese": "烹饪；做饭",
-		"english": "to cook",
-		"soundmark": "/tə/ /kʊk/"
-	},
-	{
-		"chinese": "牛肉",
-		"english": "beef",
-		"soundmark": "/bif/"
-	},
-	{
-		"chinese": "做牛肉",
-		"english": "to cook beef",
-		"soundmark": "/tə/ /kʊk/ /bif/"
-	},
-	{
-		"chinese": "和",
-		"english": "with",
-		"soundmark": "/wɪð/"
-	},
-	{
-		"chinese": "土豆",
-		"english": "potatoes",
-		"soundmark": "/pə'tetoz/"
-	},
-	{
-		"chinese": "和土豆",
-		"english": "with potatoes",
-		"soundmark": "/wɪð/ /pə'tetoz/"
-	},
-	{
-		"chinese": "牛肉和土豆",
-		"english": "beef with potatoes",
-		"soundmark": "/bif/ /wɪð/ /pə'tetoz/"
-	},
-	{
-		"chinese": "烹饪牛肉和土豆",
-		"english": "to cook beef with potatoes",
-		"soundmark": "/tə/ /kʊk/ /bif/ /wɪð/ /pə'tetoz/"
-	},
-	{
-		"chinese": "烹饪；做饭（ing形式）",
-		"english": "cooking",
-		"soundmark": "/'kʊkɪŋ/"
-	},
-	{
-		"chinese": "是；赋值（原型）",
-		"english": "be",
-		"soundmark": "/bi/"
-	},
-	{
-		"chinese": "正在烹饪",
-		"english": "be cooking",
-		"soundmark": "/bi/ /'kʊkɪŋ/"
-	},
-	{
-		"chinese": "正在做牛肉烧土豆",
-		"english": "be cooking beef with potatoes",
-		"soundmark": "/bi/ /'kʊkɪŋ/ /bif/ /wɪð/ /pə'tetoz/"
-	},
-	{
-		"chinese": "她",
-		"english": "she",
-		"soundmark": "/ʃi/ /（she，现在时）be is/ /ɪz/"
-	},
-	{
-		"chinese": "她（现在）正在做牛肉烧土豆",
-		"english": "she is cooking beef with potatoes",
-		"soundmark": "/ʃi/ /ɪz/ /'kʊkɪŋ/ /bif/ /wɪð/ /pə'tetoz/"
-	},
-	{
-		"chinese": "母亲；妈妈",
-		"english": "mother",
-		"soundmark": "/'mʌðɚ/"
-	},
-	{
-		"chinese": "她的",
-		"english": "her",
-		"soundmark": "/hɚ/"
-	},
-	{
-		"chinese": "她的妈妈",
-		"english": "her mother",
-		"soundmark": "/hɚ/ /'mʌðɚ/"
-	},
-	{
-		"chinese": "她妈妈（现在）正在做牛肉烧土豆",
-		"english": "her mother is cooking beef with potatoes",
-		"soundmark": "/hɚ/ /'mʌðɚ/ /ɪz/ /'kʊkɪŋ/ /bif/ /wɪð/ /pə'tetoz/"
-	},
-	{
-		"chinese": "在这一刻；此刻",
-		"english": "at the moment",
-		"soundmark": "/æt/ /ðə/ /'momənt/"
-	},
-	{
-		"chinese": "她妈妈此刻正在做牛肉烧土豆",
-		"english": "her mother is cooking beef with potatoes at the moment",
-		"soundmark": "/hɚ/ /'mʌðɚ/ /ɪz/ /'kʊkɪŋ/ /bif/ /wɪð/ /pə'tetoz/ /æt/ /ðə/ /'momənt/ /（she，过去时）be was/ /wəz/"
-	},
-	{
-		"chinese": "她妈妈（过去）正在做牛肉烧土豆",
-		"english": "her mother was cooking beef with potatoes",
-		"soundmark": "/hɚ/ /'mʌðɚ/ /wəz/ /'kʊkɪŋ/ /bif/ /wɪð/ /pə'tetoz/"
-	},
-	{
-		"chinese": "我女儿（过去）正在看电视",
-		"english": "my daughter was watching TV",
-		"soundmark": "/maɪ/ /'dɔtɚ/ /wəz/ /'wɑtʃɪŋ/ /ˈtiˈvi/"
-	},
-	{
-		"chinese": "与此同时",
-		"english": "while",
-		"soundmark": "/waɪl/"
-	},
-	{
-		"chinese": "我女儿（过去）正在看电视与此同时她妈妈（过去）正在做牛肉烧土豆",
-		"english": "my daughter was watching TV while her mother was cooking beef with potatoes",
-		"soundmark": "/maɪ/ /'dɔtɚ/ /wəz/ /'wɑtʃɪŋ/ /ˈtiˈvi/ /waɪl/ /hɚ/ /'mʌðɚ/ /wəz/ /'kʊkɪŋ/ /bif/ /wɪð/ /pə'tetoz/"
-	},
-	{
-		"chinese": "中文 原形 第三人称单数 过去式想要",
-		"english": "want wants",
-		"soundmark": "/wanted/"
-	},
-	{
-		"chinese": "喜欢",
-		"english": "like likes",
-		"soundmark": "/liked/"
-	},
-	{
-		"chinese": "有；(+to)不得不",
-		"english": "have has",
-		"soundmark": "/had/"
-	},
-	{
-		"chinese": "计划",
-		"english": "plan plans",
-		"soundmark": "/planned/"
-	},
-	{
-		"chinese": "需要",
-		"english": "need needs",
-		"soundmark": "/needed/"
-	},
-	{
-		"chinese": "做",
-		"english": "do does",
-		"soundmark": "/did/"
-	},
-	{
-		"chinese": "告诉",
-		"english": "tell tells",
-		"soundmark": "/told/"
-	},
-	{
-		"chinese": "说话",
-		"english": "talk talks",
-		"soundmark": "/talked/"
-	},
-	{
-		"chinese": "是 be（am）",
-		"english": "is",
-		"soundmark": "/was/"
-	},
-	{
-		"chinese": "是 be（is ）",
-		"english": "is",
-		"soundmark": "/was/"
-	},
-	{
-		"chinese": "是 be（are）",
-		"english": "is",
-		"soundmark": "/were/"
-	},
-	{
-		"chinese": "看到",
-		"english": "see sees",
-		"soundmark": "/saw/"
-	},
-	{
-		"chinese": "吃",
-		"english": "eat eats",
-		"soundmark": "/ate/"
-	},
-	{
-		"chinese": "喝",
-		"english": "drink drinks",
-		"soundmark": "/drank/"
-	},
-	{
-		"chinese": "知道",
-		"english": "know knows",
-		"soundmark": "/knew/"
-	},
-	{
-		"chinese": "忘记",
-		"english": "forget forgets",
-		"soundmark": "/forgot/"
-	},
-	{
-		"chinese": "失去",
-		"english": "lose loses",
-		"soundmark": "/lost/"
-	},
-	{
-		"chinese": "离开",
-		"english": "leave leaves",
-		"soundmark": "/left/"
-	},
-	{
-		"chinese": "睡觉",
-		"english": "sleep sleeps",
-		"soundmark": "/slept/"
-	},
-	{
-		"chinese": "明白",
-		"english": "understand understands",
-		"soundmark": "/understood/"
-	},
-	{
-		"chinese": "买",
-		"english": "buy buys",
-		"soundmark": "/bought/"
-	},
-	{
-		"chinese": "洗",
-		"english": "wash washes",
-		"soundmark": "/washed/"
-	},
-	{
-		"chinese": "打电话",
-		"english": "call calls",
-		"soundmark": "/called/"
-	},
-	{
-		"chinese": "帮助",
-		"english": "help helps",
-		"soundmark": "/helped/"
-	},
-	{
-		"chinese": "相信",
-		"english": "believe believes",
-		"soundmark": "/believed/"
-	},
-	{
-		"chinese": "学习",
-		"english": "study studies",
-		"soundmark": "/studied/"
-	},
-	{
-		"chinese": "解释",
-		"english": "explain explains",
-		"soundmark": "/explained/"
-	},
-	{
-		"chinese": "问",
-		"english": "ask asks",
-		"soundmark": "/asked/"
-	},
-	{
-		"chinese": "飞",
-		"english": "fly flies",
-		"soundmark": "/flew/"
-	},
-	{
-		"chinese": "阅读",
-		"english": "read reads",
-		"soundmark": "/read/"
-	},
-	{
-		"chinese": "走路",
-		"english": "walk walks",
-		"soundmark": "/walked/"
-	},
-	{
-		"chinese": "跳舞",
-		"english": "dance dances",
-		"soundmark": "/danced/"
-	},
-	{
-		"chinese": "回答",
-		"english": "answer answers",
-		"soundmark": "/answered/"
-	},
-	{
-		"chinese": "工作",
-		"english": "work works",
-		"soundmark": "/worked/"
-	},
-	{
-		"chinese": "待在",
-		"english": "stay stays",
-		"soundmark": "/stayed/"
-	},
-	{
-		"chinese": "支付",
-		"english": "pay pays",
-		"soundmark": "/paid/"
-	},
-	{
-		"chinese": "旅行",
-		"english": "travel travels",
-		"soundmark": "/traveled/"
-	},
-	{
-		"chinese": "给",
-		"english": "give gives",
-		"soundmark": "/gave/"
-	},
-	{
-		"chinese": "达到",
-		"english": "get gets",
-		"soundmark": "/got/"
-	},
-	{
-		"chinese": "锁",
-		"english": "lock locks",
-		"soundmark": "/locked/"
-	},
-	{
-		"chinese": "记得",
-		"english": "remember remembers",
-		"soundmark": "/Remembered/"
-	},
-	{
-		"chinese": "清理",
-		"english": "clean cleans",
-		"soundmark": "/cleaned/"
-	},
-	{
-		"chinese": "找到",
-		"english": "find finds",
-		"soundmark": "/found/"
-	},
-	{
-		"chinese": "关闭",
-		"english": "close closes",
-		"soundmark": "/closed/"
-	},
-	{
-		"chinese": "教",
-		"english": "teach teaches",
-		"soundmark": "/taught/"
-	},
-	{
-		"chinese": "展示",
-		"english": "show shows",
-		"soundmark": "/showed/"
-	},
-	{
-		"chinese": "让",
-		"english": "let lets",
-		"soundmark": "/let/"
-	},
-	{
-		"chinese": "休息",
-		"english": "rest rests",
-		"soundmark": "/rested/"
-	},
-	{
-		"chinese": "用",
-		"english": "use uses",
-		"soundmark": "/used/"
-	},
-	{
-		"chinese": "做饭",
-		"english": "cook cooks",
-		"soundmark": "/cooked/"
-	},
-	{
-		"chinese": "去",
-		"english": "go goes",
-		"soundmark": "/went/"
-	},
-	{
-		"chinese": "决定",
-		"english": "decide decides",
-		"soundmark": "/decided/"
-	},
-	{
-		"chinese": "驾驶",
-		"english": "drive drives",
-		"soundmark": "/drove/"
-	},
-	{
-		"chinese": "改变",
-		"english": "change changes",
-		"soundmark": "/changed/"
-	},
-	{
-		"chinese": "尝试",
-		"english": "try tries",
-		"soundmark": "/tried/"
-	},
-	{
-		"chinese": "停止",
-		"english": "stop stops",
-		"soundmark": "/Stopped/"
-	},
-	{
-		"chinese": "参加",
-		"english": "join joins",
-		"soundmark": "/joined/"
-	},
-	{
-		"chinese": "邀请",
-		"english": "invite invites",
-		"soundmark": "/invited/"
-	},
-	{
-		"chinese": "拒绝",
-		"english": "refuse refuses",
-		"soundmark": "/refused/"
-	},
-	{
-		"chinese": "接受",
-		"english": "accept accepts",
-		"soundmark": "/accepted/"
-	},
-	{
-		"chinese": "学习",
-		"english": "learn learns",
-		"soundmark": "/learnt/"
-	},
-	{
-		"chinese": "完成",
-		"english": "finish finishes",
-		"soundmark": "/finished/"
-	},
-	{
-		"chinese": "看",
-		"english": "watch watches",
-		"soundmark": "/watched/"
-	},
-	{
-		"chinese": "游泳",
-		"english": "swim swims",
-		"soundmark": "/swam/"
-	},
-	{
-		"chinese": "掌握",
-		"english": "master masters",
-		"soundmark": "/mastered/"
-	}
+  {
+    "chinese": "书",
+    "english": "book",
+    "soundmark": "/bʊk/"
+  },
+  {
+    "chinese": "英语",
+    "english": "English",
+    "soundmark": "/ˈɪŋɡlɪʃ/"
+  },
+  {
+    "chinese": "一本英语书",
+    "english": "an English book",
+    "soundmark": "/æn/ /ˈɪŋɡlɪʃ/ /bʊk/"
+  },
+  {
+    "chinese": "阅读",
+    "english": "to read",
+    "soundmark": "/tə/ /rid/"
+  },
+  {
+    "chinese": "阅读一本英语书",
+    "english": "to read an English book",
+    "soundmark": "/tə/ /rid/ /æn/ /ˈɪŋɡlɪʃ/ /bʊk/"
+  },
+  {
+    "chinese": "阅读（ing形式）",
+    "english": "reading",
+    "soundmark": "/ridɪŋ/"
+  },
+  {
+    "chinese": "是；赋值（原型）",
+    "english": "be",
+    "soundmark": "/bi/"
+  },
+  {
+    "chinese": "正在阅读",
+    "english": "be reading",
+    "soundmark": "/bi/ /ridɪŋ/"
+  },
+  {
+    "chinese": "正在阅读一本英语书",
+    "english": "be reading an English book",
+    "soundmark": "/bi/ /ridɪŋ/ /æn/ /ˈɪŋɡlɪʃ/ /bʊk/"
+  },
+  {
+    "chinese": "我",
+    "english": "I",
+    "soundmark": "/aɪ/ /（I，现在时）be am/ /æm/"
+  },
+  {
+    "chinese": "我（现在）正在阅读一本英语书",
+    "english": "I am reading an English book",
+    "soundmark": "/aɪ/ /æm/ /ridɪŋ/ /æn/ /ˈɪŋɡlɪʃ/ /bʊk/"
+  },
+  {
+    "chinese": "这一瞬间；这一刻",
+    "english": "the moment",
+    "soundmark": "/ðə/ /'momənt/"
+  },
+  {
+    "chinese": "在这一刻；此刻",
+    "english": "at the moment",
+    "soundmark": "/æt/ /ðə/ /'momənt/"
+  },
+  {
+    "chinese": "我此刻正在阅读一本英语书",
+    "english": "I am reading an English book at the moment",
+    "soundmark": "/aɪ/ /æm/ /ridɪŋ/ /æn/ /ˈɪŋɡlɪʃ/ /bʊk/ /æt/ /ðə/ /'momənt/ /（I，过去时）be was/ /wəz/"
+  },
+  {
+    "chinese": "我（过去）正在阅读一本英语书",
+    "english": "I was reading an English book",
+    "soundmark": "/aɪ/ /wəz/ /ridɪŋ/ /æn/ /ˈɪŋɡlɪʃ/ /bʊk/"
+  },
+  {
+    "chinese": "昨晚",
+    "english": "last night",
+    "soundmark": "/læst/ /naɪt/"
+  },
+  {
+    "chinese": "我昨晚正在阅读一本英语书",
+    "english": "I was reading an English book last night",
+    "soundmark": "/aɪ/ /wəz/ /ridɪŋ/ /æn/ /ˈɪŋɡlɪʃ/ /bʊk/ /læst/ /naɪt/"
+  },
+  {
+    "chinese": "家",
+    "english": "home",
+    "soundmark": "/hom/"
+  },
+  {
+    "chinese": "工作",
+    "english": "work",
+    "soundmark": "/wɝk/"
+  },
+  {
+    "chinese": "家庭作业",
+    "english": "homework",
+    "soundmark": "/'homwɝk/"
+  },
+  {
+    "chinese": "她的",
+    "english": "her",
+    "soundmark": "/hɚ/"
+  },
+  {
+    "chinese": "她的家庭作业",
+    "english": "her homework",
+    "soundmark": "/hɚ/ /'homwɝk/"
+  },
+  {
+    "chinese": "做",
+    "english": "to do",
+    "soundmark": "/tə/ /du/"
+  },
+  {
+    "chinese": "做她的家庭作业",
+    "english": "to do her homework",
+    "soundmark": "/tə/ /du/ /hɚ/ /'homwɝk/"
+  },
+  {
+    "chinese": "做（ing形式）",
+    "english": "doing",
+    "soundmark": "/ˈduɪŋ/"
+  },
+  {
+    "chinese": "是；赋值（原型）",
+    "english": "be",
+    "soundmark": "/bi/"
+  },
+  {
+    "chinese": "正在做",
+    "english": "be doing",
+    "soundmark": "/bi/ /ˈduɪŋ/"
+  },
+  {
+    "chinese": "正在做她的家庭作业",
+    "english": "be doing her homework",
+    "soundmark": "/bi/ /ˈduɪŋ/ /hɚ/ /'homwɝk/"
+  },
+  {
+    "chinese": "她",
+    "english": "she",
+    "soundmark": "/ʃi/ /（she，现在时）be is/ /ɪz/"
+  },
+  {
+    "chinese": "她（现在）正在做她的家庭作业",
+    "english": "she is doing her homework",
+    "soundmark": "/ʃi/ /ɪz/ /ˈduɪŋ/ /hɚ/ /'homwɝk/"
+  },
+  {
+    "chinese": "女儿",
+    "english": "daughter",
+    "soundmark": "/'dɔtɚ/"
+  },
+  {
+    "chinese": "的",
+    "english": "my",
+    "soundmark": "/maɪ/"
+  },
+  {
+    "chinese": "我的女儿",
+    "english": "my daughter",
+    "soundmark": "/maɪ/ /'dɔtɚ/"
+  },
+  {
+    "chinese": "我的女儿（现在）正在做她的家庭作业",
+    "english": "my daughter is doing her homework",
+    "soundmark": "/maɪ/ /'dɔtɚ/ /ɪz/ /ˈduɪŋ/ /hɚ/ /'homwɝk/"
+  },
+  {
+    "chinese": "在这一刻；此刻",
+    "english": "at the moment",
+    "soundmark": "/æt/ /ðə/ /'momənt/"
+  },
+  {
+    "chinese": "我的女儿此刻正在做她的家庭作业",
+    "english": "my daughter is doing her homework at the moment",
+    "soundmark": "/maɪ/ /'dɔtɚ/ /ɪz/ /ˈduɪŋ/ /hɚ/ /'homwɝk/ /æt/ /ðə/ /'momənt/ /（she，过去时）be was/ /wəz/"
+  },
+  {
+    "chinese": "我的女儿（过去）正在做她的家庭作业",
+    "english": "my daughter was doing her homework",
+    "soundmark": "/maɪ/ /'dɔtɚ/ /wəz/ /ˈduɪŋ/ /hɚ/ /'homwɝk/"
+  },
+  {
+    "chinese": "我（过去）正在阅读一本英语书",
+    "english": "I was reading an English book",
+    "soundmark": "/aɪ/ /wəz/ /ridɪŋ/ /æn/ /ˈɪŋɡlɪʃ/ /bʊk/"
+  },
+  {
+    "chinese": "与此同时",
+    "english": "while",
+    "soundmark": "/waɪl/"
+  },
+  {
+    "chinese": "我（过去）正在阅读一本英语书与此同时我的女儿（过去）正在做她的家庭作业",
+    "english": "I was reading an English book while my daughter was doing her homework",
+    "soundmark": "/aɪ/ /wəz/ /ridɪŋ/ /æn/ /ˈɪŋɡlɪʃ/ /bʊk/ /waɪl/ /maɪ/ /'dɔtɚ/ /wəz/ /ˈduɪŋ/ /hɚ/ /'homwɝk/"
+  },
+  {
+    "chinese": "跑步",
+    "english": "to run",
+    "soundmark": "/tə/ /rʌn/"
+  },
+  {
+    "chinese": "街道",
+    "english": "the street",
+    "soundmark": "/ðə/ /strit/"
+  },
+  {
+    "chinese": "在街上",
+    "english": "in the street",
+    "soundmark": "/ɪn/ /ðə/ /strit/"
+  },
+  {
+    "chinese": "在街上跑步",
+    "english": "to run in the street",
+    "soundmark": "/tə/ /rʌn/ /ɪn/ /ðə/ /strit/"
+  },
+  {
+    "chinese": "跑步（ing形式）",
+    "english": "running",
+    "soundmark": "/'rʌnɪŋ/"
+  },
+  {
+    "chinese": "是；赋值（原型）",
+    "english": "be",
+    "soundmark": "/bi/"
+  },
+  {
+    "chinese": "正在跑步",
+    "english": "be running",
+    "soundmark": "/bi/ /'rʌnɪŋ/"
+  },
+  {
+    "chinese": "正在在街上跑步",
+    "english": "be running in the street",
+    "soundmark": "/bi/ /'rʌnɪŋ/ /ɪn/ /ðə/ /strit/"
+  },
+  {
+    "chinese": "他",
+    "english": "he",
+    "soundmark": "/hi/ /（he，现在时）be is/ /ɪz/"
+  },
+  {
+    "chinese": "他（现在）正在在街上跑步",
+    "english": "he is running in the street",
+    "soundmark": "/hi/ /ɪz/ /'rʌnɪŋ/ /ɪn/ /ðə/ /strit/"
+  },
+  {
+    "chinese": "在这一刻；此刻",
+    "english": "at the moment",
+    "soundmark": "/æt/ /ðə/ /'momənt/"
+  },
+  {
+    "chinese": "他此刻正在在街上跑步",
+    "english": "he is running in the street at the moment",
+    "soundmark": "/hi/ /ɪz/ /'rʌnɪŋ/ /ɪn/ /ðə/ /strit/ /æt/ /ðə/ /'momənt/ /（he，过去时）be was/ /wəz/"
+  },
+  {
+    "chinese": "他（过去）正在在街上跑步",
+    "english": "he was running in the street",
+    "soundmark": "/hi/ /wəz/ /'rʌnɪŋ/ /ɪn/ /ðə/ /strit/"
+  },
+  {
+    "chinese": "游泳",
+    "english": "to swim",
+    "soundmark": "/tə/ /swɪm/"
+  },
+  {
+    "chinese": "游泳池",
+    "english": "the pool",
+    "soundmark": "/ðə/ /pul/"
+  },
+  {
+    "chinese": "在游泳池里",
+    "english": "in the pool",
+    "soundmark": "/ɪn/ /ðə/ /pul/"
+  },
+  {
+    "chinese": "在游泳池里游泳",
+    "english": "to swim in the pool",
+    "soundmark": "/tə/ /swɪm/ /ɪn/ /ðə/ /pul/"
+  },
+  {
+    "chinese": "游泳（ing形式）",
+    "english": "swimming",
+    "soundmark": "/'swɪmɪŋ/"
+  },
+  {
+    "chinese": "是；赋值（原型）",
+    "english": "be",
+    "soundmark": "/bi/"
+  },
+  {
+    "chinese": "正在游泳",
+    "english": "be swimming",
+    "soundmark": "/bi/ /'swɪmɪŋ/"
+  },
+  {
+    "chinese": "正在在游泳池里游泳",
+    "english": "be swimming in the pool",
+    "soundmark": "/bi/ /'swɪmɪŋ/ /ɪn/ /ðə/ /pul/"
+  },
+  {
+    "chinese": "她",
+    "english": "she",
+    "soundmark": "/ʃi/ /（she，现在时）be is/ /ɪz/"
+  },
+  {
+    "chinese": "她（现在）正在游泳池里游泳",
+    "english": "she is swimming in the pool",
+    "soundmark": "/ʃi/ /ɪz/ /'swɪmɪŋ/ /ɪn/ /ðə/ /pul/"
+  },
+  {
+    "chinese": "在这一刻；此刻",
+    "english": "at the moment",
+    "soundmark": "/æt/ /ðə/ /'momənt/"
+  },
+  {
+    "chinese": "她此刻正在游泳池里游泳",
+    "english": "she is swimming in the pool at the moment",
+    "soundmark": "/ʃi/ /ɪz/ /'swɪmɪŋ/ /ɪn/ /ðə/ /pul/ /æt/ /ðə/ /moment/ /'momənt/ /（she，过去时）be was/ /wəz/"
+  },
+  {
+    "chinese": "她（过去）正在游泳池里游泳",
+    "english": "she was swimming in the pool",
+    "soundmark": "/ʃi/ /wəz/ /'swɪmɪŋ/ /ɪn/ /ðə/ /pul/"
+  },
+  {
+    "chinese": "他（过去）正在在街上跑步",
+    "english": "he was running in the street",
+    "soundmark": "/hi/ /wəz/ /'rʌnɪŋ/ /ɪn/ /ðə/ /strit/"
+  },
+  {
+    "chinese": "与此同时",
+    "english": "while",
+    "soundmark": "/waɪl/"
+  },
+  {
+    "chinese": "他（过去）正在在街上跑步与此同时她（过去）正在游泳池里游泳",
+    "english": "he was running in the street while she was swimming in the pool",
+    "soundmark": "/hi/ /wəz/ /'rʌnɪŋ/ /ɪn/ /ðə/ /strit/ /waɪl/ /ʃi/ /wəz/ /'swɪmɪŋ/ /ɪn/ /ðə/ /pul/"
+  },
+  {
+    "chinese": "房子",
+    "english": "house",
+    "soundmark": "/haʊs/"
+  },
+  {
+    "chinese": "工作",
+    "english": "work",
+    "soundmark": "/wɝk/"
+  },
+  {
+    "chinese": "家务",
+    "english": "the housework",
+    "soundmark": "/ðə/ /'haʊswɝk/"
+  },
+  {
+    "chinese": "做",
+    "english": "to do",
+    "soundmark": "/tə/ /du/"
+  },
+  {
+    "chinese": "做家务",
+    "english": "to do the housework",
+    "soundmark": "/tə/ /du/ /ðə/ /'haʊswɝk/"
+  },
+  {
+    "chinese": "做（ing形式）",
+    "english": "doing",
+    "soundmark": "/ˈduɪŋ/"
+  },
+  {
+    "chinese": "是；赋值（原型）",
+    "english": "be",
+    "soundmark": "/bi/"
+  },
+  {
+    "chinese": "正在做",
+    "english": "be doing",
+    "soundmark": "/bi/ /ˈduɪŋ/"
+  },
+  {
+    "chinese": "正在做家务",
+    "english": "be doing the housework",
+    "soundmark": "/bi/ /ˈduɪŋ/ /ðə/ /'haʊswɝk/"
+  },
+  {
+    "chinese": "她",
+    "english": "she",
+    "soundmark": "/ʃi/ /（she，现在时）be is/ /ɪz/"
+  },
+  {
+    "chinese": "她（现在）正在做家务",
+    "english": "she is doing the housework",
+    "soundmark": "/ʃi/ /ɪz/ /ˈduɪŋ/ /ðə/ /'haʊswɝk/"
+  },
+  {
+    "chinese": "母亲；妈妈",
+    "english": "mother",
+    "soundmark": "/'mʌðɚ/"
+  },
+  {
+    "chinese": "我的",
+    "english": "my",
+    "soundmark": "/maɪ/"
+  },
+  {
+    "chinese": "我的妈妈",
+    "english": "my mother",
+    "soundmark": "/maɪ/ /'mʌðɚ/"
+  },
+  {
+    "chinese": "我的妈妈（现在）正在做家务",
+    "english": "my mother is doing the housework",
+    "soundmark": "/maɪ/ /'mʌðɚ/ /ɪz/ /ˈduɪŋ/ /ðə/ /'haʊswɝk/"
+  },
+  {
+    "chinese": "在这一刻；此刻",
+    "english": "at the moment",
+    "soundmark": "/æt/ /ðə/ /'momənt/"
+  },
+  {
+    "chinese": "我妈此刻正在做家务",
+    "english": "my mother is doing the housework at the moment",
+    "soundmark": "/maɪ/ /'mʌðɚ/ /ɪz/ /ˈduɪŋ/ /ðə/ /'haʊswɝk/ /æt/ /ðə/ /'momənt/ /（she，过去时）be was/ /wəz/"
+  },
+  {
+    "chinese": "我妈（过去）正在做家务",
+    "english": "my mother was doing the housework",
+    "soundmark": "/maɪ/ /'mʌðɚ/ /wəz/ /ˈduɪŋ/ /ðə/ /'haʊswɝk/"
+  },
+  {
+    "chinese": "说话",
+    "english": "to talk",
+    "soundmark": "/tə/ /tɔk/"
+  },
+  {
+    "chinese": "手机",
+    "english": "the phone",
+    "soundmark": "/ðə/ /fon/"
+  },
+  {
+    "chinese": "在手机上",
+    "english": "on the phone",
+    "soundmark": "/ɑn/ /ðə/ /fon/"
+  },
+  {
+    "chinese": "在手机上说话",
+    "english": "to talk on the phone",
+    "soundmark": "/tə/ /tɔk/ /ɑn/ /ðə/ /fon/"
+  },
+  {
+    "chinese": "说话（ing形式）",
+    "english": "talking",
+    "soundmark": "/'tɔkɪŋ/"
+  },
+  {
+    "chinese": "是；赋值（原型）",
+    "english": "be",
+    "soundmark": "/bi/"
+  },
+  {
+    "chinese": "正在说话",
+    "english": "be talking",
+    "soundmark": "/bi/ /'tɔkɪŋ/"
+  },
+  {
+    "chinese": "正在在手机上说话",
+    "english": "be talking on the phone",
+    "soundmark": "/bi/ /'tɔkɪŋ/ /ɑn/ /ðə/ /fon/"
+  },
+  {
+    "chinese": "他",
+    "english": "he",
+    "soundmark": "/hi/ /（he，现在时）be is/ /ɪz/"
+  },
+  {
+    "chinese": "他（现在）正在手机上说话",
+    "english": "he is talking on the phone",
+    "soundmark": "/hi/ /ɪz/ /'tɔkɪŋ/ /ɑn/ /ðə/ /fon/"
+  },
+  {
+    "chinese": "父亲；爸爸",
+    "english": "father",
+    "soundmark": "/'fɑðɚ/"
+  },
+  {
+    "chinese": "我的",
+    "english": "my",
+    "soundmark": "/maɪ/"
+  },
+  {
+    "chinese": "我的父亲",
+    "english": "my father",
+    "soundmark": "/maɪ/ /'fɑðɚ/"
+  },
+  {
+    "chinese": "我爸（现在）正在手机上说话",
+    "english": "my father is talking on the phone",
+    "soundmark": "/maɪ/ /'fɑðɚ/ /ɪz/ /'tɔkɪŋ/ /ɑn/ /ðə/ /fon/"
+  },
+  {
+    "chinese": "在这一刻；此刻",
+    "english": "at the moment",
+    "soundmark": "/æt/ /ðə/ /'momənt/"
+  },
+  {
+    "chinese": "我爸此刻正在手机上说话",
+    "english": "my father is talking on the phone at the moment",
+    "soundmark": "/maɪ/ /'fɑðɚ/ /ɪz/ /'tɔkɪŋ/ /ɑn/ /ðə/ /fon/ /æt/ /ðə/ /'momənt/ /（he，过去时）be was/ /wəz/"
+  },
+  {
+    "chinese": "我爸（过去）正在手机上说话",
+    "english": "my father was talking on the phone",
+    "soundmark": "/maɪ/ /'fɑðɚ/ /wəz/ /'tɔkɪŋ/ /ɑn/ /ðə/ /fon/"
+  },
+  {
+    "chinese": "与此同时",
+    "english": "while",
+    "soundmark": "/waɪl/"
+  },
+  {
+    "chinese": "我妈（过去）正在做家务",
+    "english": "my mother was doing the housework",
+    "soundmark": "/maɪ/ /'mʌðɚ/ /wəz/ /ˈduɪŋ/ /ðə/ /'haʊswɝk/"
+  },
+  {
+    "chinese": "我妈（过去）正在做家务与此同时我爸（过去）正在手机上说话",
+    "english": "my mother was doing the housework while my father was talking on the phone",
+    "soundmark": "/maɪ/ /'mʌðɚ/ /wəz/ /ˈduɪŋ/ /ðə/ /'haʊswɝk/ /waɪl/ /maɪ/ /'fɑðɚ/ /wəz/ /'tɔkɪŋ/ /ɑn/ /ðə/ /fon/"
+  },
+  {
+    "chinese": "看",
+    "english": "to watch",
+    "soundmark": "/tə/ /wɑtʃ/"
+  },
+  {
+    "chinese": "电视",
+    "english": "TV",
+    "soundmark": "/ˈtiˈvi/"
+  },
+  {
+    "chinese": "看电视",
+    "english": "to watch TV",
+    "soundmark": "/tə/ /'wɑtʃ/ /ˈtiˈvi/"
+  },
+  {
+    "chinese": "看（ing形式）",
+    "english": "watching",
+    "soundmark": "/'wɑtʃɪŋ/"
+  },
+  {
+    "chinese": "是；赋值（原型）",
+    "english": "be",
+    "soundmark": "/bi/"
+  },
+  {
+    "chinese": "正在看",
+    "english": "be watching",
+    "soundmark": "/bi/ /'wɑtʃɪŋ/"
+  },
+  {
+    "chinese": "正在看电视",
+    "english": "be watching TV",
+    "soundmark": "/bi/ /'wɑtʃɪŋ/ /ˈtiˈvi/"
+  },
+  {
+    "chinese": "她",
+    "english": "she",
+    "soundmark": "/ʃi/ /（she，现在时）be is/ /ɪz/"
+  },
+  {
+    "chinese": "她（现在）正在看电视",
+    "english": "she is watching TV",
+    "soundmark": "/ʃi/ /ɪz/ /'wɑtʃɪŋ/ /ˈtiˈvi/"
+  },
+  {
+    "chinese": "女儿",
+    "english": "daughter",
+    "soundmark": "/'dɔtɚ/"
+  },
+  {
+    "chinese": "我的女儿",
+    "english": "my daughter",
+    "soundmark": "/maɪ/ /'dɔtɚ/"
+  },
+  {
+    "chinese": "我女儿（现在）正在看电视",
+    "english": "my daughter is watching TV",
+    "soundmark": "/maɪ/ /'dɔtɚ/ /ɪz/ /'wɑtʃɪŋ/ /ˈtiˈvi/"
+  },
+  {
+    "chinese": "在这一刻；此刻",
+    "english": "at the moment",
+    "soundmark": "/æt/ /ðə/ /'momənt/"
+  },
+  {
+    "chinese": "我女儿此刻正在看电视",
+    "english": "my daughter is watching TV at the moment",
+    "soundmark": "/maɪ/ /'dɔtɚ/ /ɪz/ /'wɑtʃɪŋ/ /ˈtiˈvi/ /æt/ /ðə/ /'momənt/ /（she，过去时）be was/ /wəz/"
+  },
+  {
+    "chinese": "我女儿（过去）正在看电视",
+    "english": "my daughter was watching TV",
+    "soundmark": "/maɪ/ /'dɔtɚ/ /wəz/ /'wɑtʃɪŋ/ /ˈtiˈvi/"
+  },
+  {
+    "chinese": "烹饪；做饭",
+    "english": "to cook",
+    "soundmark": "/tə/ /kʊk/"
+  },
+  {
+    "chinese": "牛肉",
+    "english": "beef",
+    "soundmark": "/bif/"
+  },
+  {
+    "chinese": "做牛肉",
+    "english": "to cook beef",
+    "soundmark": "/tə/ /kʊk/ /bif/"
+  },
+  {
+    "chinese": "和",
+    "english": "with",
+    "soundmark": "/wɪð/"
+  },
+  {
+    "chinese": "土豆",
+    "english": "potatoes",
+    "soundmark": "/pə'tetoz/"
+  },
+  {
+    "chinese": "和土豆",
+    "english": "with potatoes",
+    "soundmark": "/wɪð/ /pə'tetoz/"
+  },
+  {
+    "chinese": "牛肉和土豆",
+    "english": "beef with potatoes",
+    "soundmark": "/bif/ /wɪð/ /pə'tetoz/"
+  },
+  {
+    "chinese": "烹饪牛肉和土豆",
+    "english": "to cook beef with potatoes",
+    "soundmark": "/tə/ /kʊk/ /bif/ /wɪð/ /pə'tetoz/"
+  },
+  {
+    "chinese": "烹饪；做饭（ing形式）",
+    "english": "cooking",
+    "soundmark": "/'kʊkɪŋ/"
+  },
+  {
+    "chinese": "是；赋值（原型）",
+    "english": "be",
+    "soundmark": "/bi/"
+  },
+  {
+    "chinese": "正在烹饪",
+    "english": "be cooking",
+    "soundmark": "/bi/ /'kʊkɪŋ/"
+  },
+  {
+    "chinese": "正在做牛肉烧土豆",
+    "english": "be cooking beef with potatoes",
+    "soundmark": "/bi/ /'kʊkɪŋ/ /bif/ /wɪð/ /pə'tetoz/"
+  },
+  {
+    "chinese": "她",
+    "english": "she",
+    "soundmark": "/ʃi/ /（she，现在时）be is/ /ɪz/"
+  },
+  {
+    "chinese": "她（现在）正在做牛肉烧土豆",
+    "english": "she is cooking beef with potatoes",
+    "soundmark": "/ʃi/ /ɪz/ /'kʊkɪŋ/ /bif/ /wɪð/ /pə'tetoz/"
+  },
+  {
+    "chinese": "母亲；妈妈",
+    "english": "mother",
+    "soundmark": "/'mʌðɚ/"
+  },
+  {
+    "chinese": "她的",
+    "english": "her",
+    "soundmark": "/hɚ/"
+  },
+  {
+    "chinese": "她的妈妈",
+    "english": "her mother",
+    "soundmark": "/hɚ/ /'mʌðɚ/"
+  },
+  {
+    "chinese": "她妈妈（现在）正在做牛肉烧土豆",
+    "english": "her mother is cooking beef with potatoes",
+    "soundmark": "/hɚ/ /'mʌðɚ/ /ɪz/ /'kʊkɪŋ/ /bif/ /wɪð/ /pə'tetoz/"
+  },
+  {
+    "chinese": "在这一刻；此刻",
+    "english": "at the moment",
+    "soundmark": "/æt/ /ðə/ /'momənt/"
+  },
+  {
+    "chinese": "她妈妈此刻正在做牛肉烧土豆",
+    "english": "her mother is cooking beef with potatoes at the moment",
+    "soundmark": "/hɚ/ /'mʌðɚ/ /ɪz/ /'kʊkɪŋ/ /bif/ /wɪð/ /pə'tetoz/ /æt/ /ðə/ /'momənt/ /（she，过去时）be was/ /wəz/"
+  },
+  {
+    "chinese": "她妈妈（过去）正在做牛肉烧土豆",
+    "english": "her mother was cooking beef with potatoes",
+    "soundmark": "/hɚ/ /'mʌðɚ/ /wəz/ /'kʊkɪŋ/ /bif/ /wɪð/ /pə'tetoz/"
+  },
+  {
+    "chinese": "我女儿（过去）正在看电视",
+    "english": "my daughter was watching TV",
+    "soundmark": "/maɪ/ /'dɔtɚ/ /wəz/ /'wɑtʃɪŋ/ /ˈtiˈvi/"
+  },
+  {
+    "chinese": "与此同时",
+    "english": "while",
+    "soundmark": "/waɪl/"
+  },
+  {
+    "chinese": "我女儿（过去）正在看电视与此同时她妈妈（过去）正在做牛肉烧土豆",
+    "english": "my daughter was watching TV while her mother was cooking beef with potatoes",
+    "soundmark": "/maɪ/ /'dɔtɚ/ /wəz/ /'wɑtʃɪŋ/ /ˈtiˈvi/ /waɪl/ /hɚ/ /'mʌðɚ/ /wəz/ /'kʊkɪŋ/ /bif/ /wɪð/ /pə'tetoz/"
+  },
+  {
+    "chinese": "中文 原形 第三人称单数 过去式想要",
+    "english": "want wants",
+    "soundmark": "/wanted/"
+  },
+  {
+    "chinese": "喜欢",
+    "english": "like likes",
+    "soundmark": "/liked/"
+  },
+  {
+    "chinese": "有；(+to)不得不",
+    "english": "have has",
+    "soundmark": "/had/"
+  },
+  {
+    "chinese": "计划",
+    "english": "plan plans",
+    "soundmark": "/planned/"
+  },
+  {
+    "chinese": "需要",
+    "english": "need needs",
+    "soundmark": "/needed/"
+  },
+  {
+    "chinese": "做",
+    "english": "do does",
+    "soundmark": "/did/"
+  },
+  {
+    "chinese": "告诉",
+    "english": "tell tells",
+    "soundmark": "/told/"
+  },
+  {
+    "chinese": "说话",
+    "english": "talk talks",
+    "soundmark": "/talked/"
+  },
+  {
+    "chinese": "是 be（am）",
+    "english": "is",
+    "soundmark": "/was/"
+  },
+  {
+    "chinese": "是 be（is ）",
+    "english": "is",
+    "soundmark": "/was/"
+  },
+  {
+    "chinese": "是 be（are）",
+    "english": "is",
+    "soundmark": "/were/"
+  },
+  {
+    "chinese": "看到",
+    "english": "see sees",
+    "soundmark": "/saw/"
+  },
+  {
+    "chinese": "吃",
+    "english": "eat eats",
+    "soundmark": "/ate/"
+  },
+  {
+    "chinese": "喝",
+    "english": "drink drinks",
+    "soundmark": "/drank/"
+  },
+  {
+    "chinese": "知道",
+    "english": "know knows",
+    "soundmark": "/knew/"
+  },
+  {
+    "chinese": "忘记",
+    "english": "forget forgets",
+    "soundmark": "/forgot/"
+  },
+  {
+    "chinese": "失去",
+    "english": "lose loses",
+    "soundmark": "/lost/"
+  },
+  {
+    "chinese": "离开",
+    "english": "leave leaves",
+    "soundmark": "/left/"
+  },
+  {
+    "chinese": "睡觉",
+    "english": "sleep sleeps",
+    "soundmark": "/slept/"
+  },
+  {
+    "chinese": "明白",
+    "english": "understand understands",
+    "soundmark": "/understood/"
+  },
+  {
+    "chinese": "买",
+    "english": "buy buys",
+    "soundmark": "/bought/"
+  },
+  {
+    "chinese": "洗",
+    "english": "wash washes",
+    "soundmark": "/washed/"
+  },
+  {
+    "chinese": "打电话",
+    "english": "call calls",
+    "soundmark": "/called/"
+  },
+  {
+    "chinese": "帮助",
+    "english": "help helps",
+    "soundmark": "/helped/"
+  },
+  {
+    "chinese": "相信",
+    "english": "believe believes",
+    "soundmark": "/believed/"
+  },
+  {
+    "chinese": "学习",
+    "english": "study studies",
+    "soundmark": "/studied/"
+  },
+  {
+    "chinese": "解释",
+    "english": "explain explains",
+    "soundmark": "/explained/"
+  },
+  {
+    "chinese": "问",
+    "english": "ask asks",
+    "soundmark": "/asked/"
+  },
+  {
+    "chinese": "飞",
+    "english": "fly flies",
+    "soundmark": "/flew/"
+  },
+  {
+    "chinese": "阅读",
+    "english": "read reads",
+    "soundmark": "/read/"
+  },
+  {
+    "chinese": "走路",
+    "english": "walk walks",
+    "soundmark": "/walked/"
+  },
+  {
+    "chinese": "跳舞",
+    "english": "dance dances",
+    "soundmark": "/danced/"
+  },
+  {
+    "chinese": "回答",
+    "english": "answer answers",
+    "soundmark": "/answered/"
+  },
+  {
+    "chinese": "工作",
+    "english": "work works",
+    "soundmark": "/worked/"
+  },
+  {
+    "chinese": "待在",
+    "english": "stay stays",
+    "soundmark": "/stayed/"
+  },
+  {
+    "chinese": "支付",
+    "english": "pay pays",
+    "soundmark": "/paid/"
+  },
+  {
+    "chinese": "旅行",
+    "english": "travel travels",
+    "soundmark": "/traveled/"
+  },
+  {
+    "chinese": "给",
+    "english": "give gives",
+    "soundmark": "/gave/"
+  },
+  {
+    "chinese": "达到",
+    "english": "get gets",
+    "soundmark": "/got/"
+  },
+  {
+    "chinese": "锁",
+    "english": "lock locks",
+    "soundmark": "/locked/"
+  },
+  {
+    "chinese": "记得",
+    "english": "remember remembers",
+    "soundmark": "/Remembered/"
+  },
+  {
+    "chinese": "清理",
+    "english": "clean cleans",
+    "soundmark": "/cleaned/"
+  },
+  {
+    "chinese": "找到",
+    "english": "find finds",
+    "soundmark": "/found/"
+  },
+  {
+    "chinese": "关闭",
+    "english": "close closes",
+    "soundmark": "/closed/"
+  },
+  {
+    "chinese": "教",
+    "english": "teach teaches",
+    "soundmark": "/taught/"
+  },
+  {
+    "chinese": "展示",
+    "english": "show shows",
+    "soundmark": "/showed/"
+  },
+  {
+    "chinese": "让",
+    "english": "let lets",
+    "soundmark": "/let/"
+  },
+  {
+    "chinese": "休息",
+    "english": "rest rests",
+    "soundmark": "/rested/"
+  },
+  {
+    "chinese": "用",
+    "english": "use uses",
+    "soundmark": "/used/"
+  },
+  {
+    "chinese": "做饭",
+    "english": "cook cooks",
+    "soundmark": "/cooked/"
+  },
+  {
+    "chinese": "去",
+    "english": "go goes",
+    "soundmark": "/went/"
+  },
+  {
+    "chinese": "决定",
+    "english": "decide decides",
+    "soundmark": "/decided/"
+  },
+  {
+    "chinese": "驾驶",
+    "english": "drive drives",
+    "soundmark": "/drove/"
+  },
+  {
+    "chinese": "改变",
+    "english": "change changes",
+    "soundmark": "/changed/"
+  },
+  {
+    "chinese": "尝试",
+    "english": "try tries",
+    "soundmark": "/tried/"
+  },
+  {
+    "chinese": "停止",
+    "english": "stop stops",
+    "soundmark": "/Stopped/"
+  },
+  {
+    "chinese": "参加",
+    "english": "join joins",
+    "soundmark": "/joined/"
+  },
+  {
+    "chinese": "邀请",
+    "english": "invite invites",
+    "soundmark": "/invited/"
+  },
+  {
+    "chinese": "拒绝",
+    "english": "refuse refuses",
+    "soundmark": "/refused/"
+  },
+  {
+    "chinese": "接受",
+    "english": "accept accepts",
+    "soundmark": "/accepted/"
+  },
+  {
+    "chinese": "学习",
+    "english": "learn learns",
+    "soundmark": "/learnt/"
+  },
+  {
+    "chinese": "完成",
+    "english": "finish finishes",
+    "soundmark": "/finished/"
+  },
+  {
+    "chinese": "看",
+    "english": "watch watches",
+    "soundmark": "/watched/"
+  },
+  {
+    "chinese": "游泳",
+    "english": "swim swims",
+    "soundmark": "/swam/"
+  },
+  {
+    "chinese": "掌握",
+    "english": "master masters",
+    "soundmark": "/mastered/"
+  }
 ]

--- a/scripts/courses/17.json
+++ b/scripts/courses/17.json
@@ -1,1002 +1,1002 @@
 [
-	{
-		"chinese": "购物",
-		"english": "to shop",
-		"soundmark": "/tə/ /ʃɑp/"
-	},
-	{
-		"chinese": "想要",
-		"english": "want",
-		"soundmark": "/wɑnt/"
-	},
-	{
-		"chinese": "我们",
-		"english": "we",
-		"soundmark": "/wi/"
-	},
-	{
-		"chinese": "我们想要",
-		"english": "we want",
-		"soundmark": "/wi/ /wɑnt/"
-	},
-	{
-		"chinese": "我们想要购物",
-		"english": "we want to shop",
-		"soundmark": "/wi/ /wɑnt/ /tə/ /ʃɑp/"
-	},
-	{
-		"chinese": "市场",
-		"english": "the market",
-		"soundmark": "/ðə/ /'mɑrkɪt/"
-	},
-	{
-		"chinese": "在",
-		"english": "at",
-		"soundmark": "/ət/"
-	},
-	{
-		"chinese": "在市场",
-		"english": "at the market",
-		"soundmark": "/ət/ /ðə/ /'mɑrkɪt/"
-	},
-	{
-		"chinese": "购物",
-		"english": "to shop",
-		"soundmark": "/tə/ /ʃɑp/"
-	},
-	{
-		"chinese": "在市场购物",
-		"english": "to shop at the market",
-		"soundmark": "/tə/ /ʃɑp/ /ət/ /ðə/ /'mɑrkɪt/"
-	},
-	{
-		"chinese": "我们想要在市场购物",
-		"english": "we want to shop at the market",
-		"soundmark": "/wi/ /wɑnt/ /tə/ /ʃɑp/ /ət/ /ðə/ /'mɑrkɪt/"
-	},
-	{
-		"chinese": "超级",
-		"english": "super",
-		"soundmark": "/'sʊpɚ/"
-	},
-	{
-		"chinese": "超级市场",
-		"english": "supermarket",
-		"soundmark": "/'sʊpɚmɑrkɪt/"
-	},
-	{
-		"chinese": "在超市",
-		"english": "at the supermarket",
-		"soundmark": "/ət/ /ðə/ /'sʊpɚmɑrkɪt/"
-	},
-	{
-		"chinese": "我们想要在超市购物",
-		"english": "we want to shop at the supermarket",
-		"soundmark": "/wi/ /wɑnt/ /tə/ /ʃɑp/ /ət/ /ðə/ /'sʊpɚmɑrkɪt/"
-	},
-	{
-		"chinese": "我们在超市购物",
-		"english": "we shop at the supermarket",
-		"soundmark": "/wi/ /ʃɑp/ /ət/ /ðə/ /'sʊpɚmɑrkɪt/"
-	},
-	{
-		"chinese": "购物(ing形式)",
-		"english": "shopping",
-		"soundmark": "/'ʃɑpɪŋ/"
-	},
-	{
-		"chinese": "是；赋值(原型)",
-		"english": "be",
-		"soundmark": "/bi/"
-	},
-	{
-		"chinese": "正在购物",
-		"english": "be shopping",
-		"soundmark": "/bi/"
-	},
-	{
-		"chinese": "我们",
-		"english": "we",
-		"soundmark": "/wi/ /(we，现在时)be are/ /ɚ/"
-	},
-	{
-		"chinese": "我们(现在)正在购物",
-		"english": "we are shopping",
-		"soundmark": "/wi/ /ɚ/ /'ʃɑpɪŋ/"
-	},
-	{
-		"chinese": "在超市",
-		"english": "at the supermarket",
-		"soundmark": "/ət/ /ðə/ /'sʊpɚmɑrkɪt/"
-	},
-	{
-		"chinese": "我们(现在)正在在超市购物",
-		"english": "we are shopping at the supermarket",
-		"soundmark": "/wi/ /ɚ/ /'ʃɑpɪŋ/ /ət/ /ðə/ /'sʊpɚmɑrkɪt/"
-	},
-	{
-		"chinese": "现在",
-		"english": "now",
-		"soundmark": "/naʊ/"
-	},
-	{
-		"chinese": "我们现在正在在超市购物",
-		"english": "we are shopping at the supermarket now",
-		"soundmark": "/wi/ /ɚ/ /'ʃɑpɪŋ/ /ət/ /ðə/ /'sʊpɚmɑrkɪt/ /naʊ/ /(we，过去时)be were/ /wɚ/"
-	},
-	{
-		"chinese": "我们(过去)正在在超市购物",
-		"english": "we were shopping at the supermarket",
-		"soundmark": "/wi/ /wɚ/ /'ʃɑpɪŋ/ /ət/ /ðə/ /'sʊpɚmɑrkɪt/"
-	},
-	{
-		"chinese": "打电话",
-		"english": "to call",
-		"soundmark": "/tə/ /kɔl/ /(过去)打电话 called/ /kɔld/"
-	},
-	{
-		"chinese": "我",
-		"english": "me",
-		"soundmark": "/mi/ /(过去)打电话给我 called me/ /kɔld/ /mi/"
-	},
-	{
-		"chinese": "你(过去)打电话给我",
-		"english": "you called me",
-		"soundmark": "/ju/ /kɔld/ /mi/"
-	},
-	{
-		"chinese": "当......的时候",
-		"english": "when",
-		"soundmark": "/wɛn/"
-	},
-	{
-		"chinese": "当你(过去)打电话给我的时候",
-		"english": "when you called me",
-		"soundmark": "/wɛn/ /ju/ /kɔld/ /mi/"
-	},
-	{
-		"chinese": "星期天",
-		"english": "Sunday",
-		"soundmark": "/ˈsʌnde/"
-	},
-	{
-		"chinese": "上一个",
-		"english": "last",
-		"soundmark": "/læst/"
-	},
-	{
-		"chinese": "上周日",
-		"english": "last Sunday",
-		"soundmark": "/læst/ /ˈsʌnde/"
-	},
-	{
-		"chinese": "当你上周日打电话给我的时候",
-		"english": "when you called me last Sunday",
-		"soundmark": "/wɛn/ /ju/ /kɔld/ /mi/ /læst/ /ˈsʌnde/"
-	},
-	{
-		"chinese": "我们(过去)正在在超市购物当你上周日打电话给我的时候",
-		"english": "we were shopping at the supermarket when you called me last Sunday",
-		"soundmark": "/wi/ /wɚ/ /'ʃɑpɪŋ/ /ət/ /ðə/ /'sʊpɚmɑrkɪt/ /wɛn/ /ju/ /kɔld/ /mi/ /læst/ /ˈsʌnde/"
-	},
-	{
-		"chinese": "我们上周日正在在超市购物",
-		"english": "we were shopping at the supermarket last Sunday",
-		"soundmark": "/wi/ /wɚ/ /'ʃɑpɪŋ/ /ət/ /ðə/ /'sʊpɚmɑrkɪt/ /læst/ /ˈsʌnde/"
-	},
-	{
-		"chinese": "我们(过去)正在购物",
-		"english": "we were shopping",
-		"soundmark": "/wi/ /wɚ/ /'ʃɑpɪŋ/ /(we，现在时)be are/ /ɚ/"
-	},
-	{
-		"chinese": "我们(现在)正在购物",
-		"english": "we are shopping",
-		"soundmark": "/wi/ /ɚ/ /'ʃɑpɪŋ/"
-	},
-	{
-		"chinese": "将会",
-		"english": "will",
-		"soundmark": "/wɪl/"
-	},
-	{
-		"chinese": "我们将会正在购物",
-		"english": "we will be shopping",
-		"soundmark": "/wi/ /wɪl/ /bi/ /'ʃɑpɪŋ/"
-	},
-	{
-		"chinese": "在超市",
-		"english": "at the supermarket",
-		"soundmark": "/ət/ /ðə/ /'sʊpɚmɑrkɪt/"
-	},
-	{
-		"chinese": "我们将会正在在超市购物",
-		"english": "we will be shopping at the supermarket",
-		"soundmark": "/wi/ /wɪl/ /bi/ /'ʃɑpɪŋ/ /ət/ /ðə/ /'sʊpɚmɑrkɪt/"
-	},
-	{
-		"chinese": "星期一",
-		"english": "Monday",
-		"soundmark": "/ˈmʌnde/"
-	},
-	{
-		"chinese": "下一个",
-		"english": "next",
-		"soundmark": "/nɛkst/"
-	},
-	{
-		"chinese": "下周一",
-		"english": "next Monday",
-		"soundmark": "/nɛkst/ /ˈmʌnde/"
-	},
-	{
-		"chinese": "我们将会在下周一正在在超市购物",
-		"english": "we will be shopping at the supermarket next Monday",
-		"soundmark": "/wi/ /wɪl/ /bi/ /'ʃɑpɪŋ/ /ət/ /ðə/ /'sʊpɚmɑrkɪt/ /nɛkst/ /ˈmʌnde/"
-	},
-	{
-		"chinese": "等待",
-		"english": "to wait",
-		"soundmark": "/tə/ /wet/"
-	},
-	{
-		"chinese": "我需要",
-		"english": "I need",
-		"soundmark": "/aɪ/ /nid/"
-	},
-	{
-		"chinese": "我需要等待",
-		"english": "I need to wait",
-		"soundmark": "/aɪ/ /nid/ /tə/ /wet/"
-	},
-	{
-		"chinese": "朋友",
-		"english": "friend",
-		"soundmark": "/frɛnd/"
-	},
-	{
-		"chinese": "我的",
-		"english": "my",
-		"soundmark": "/maɪ/"
-	},
-	{
-		"chinese": "我的朋友",
-		"english": "my friend",
-		"soundmark": "/maɪ/ /frɛnd/"
-	},
-	{
-		"chinese": "为了",
-		"english": "for",
-		"soundmark": "/fɝ/"
-	},
-	{
-		"chinese": "为了我的朋友",
-		"english": "for my friend",
-		"soundmark": "/fɝ/ /maɪ/ /frɛnd/"
-	},
-	{
-		"chinese": "我需要为了我的朋友等待",
-		"english": "I need to wait for my friend",
-		"soundmark": "/aɪ/ /nid/ /tə/ /wet/ /fɝ/ /maɪ/ /frɛnd/"
-	},
-	{
-		"chinese": "我为了我的朋友等待",
-		"english": "I wait for my friend",
-		"soundmark": "/aɪ/ /wet/ /fɝ/ /maɪ/ /frɛnd/"
-	},
-	{
-		"chinese": "等待(ing形式)",
-		"english": "waiting",
-		"soundmark": "/'wetɪŋ/"
-	},
-	{
-		"chinese": "是；赋值(原型)",
-		"english": "be",
-		"soundmark": "/bi/"
-	},
-	{
-		"chinese": "正在等待",
-		"english": "be waiting",
-		"soundmark": "/bi/ /'wetɪŋ/"
-	},
-	{
-		"chinese": "我",
-		"english": "I",
-		"soundmark": "/aɪ/ /(I，现在时)be am/ /æm/"
-	},
-	{
-		"chinese": "我(现在)正在等待",
-		"english": "I am waiting",
-		"soundmark": "/aɪ/ /æm/ /'wetɪŋ/"
-	},
-	{
-		"chinese": "为了我的朋友",
-		"english": "for my friend",
-		"soundmark": "/fɝ/ /maɪ/ /frɛnd/"
-	},
-	{
-		"chinese": "我(现在)正在为了我的朋友等待",
-		"english": "I am waiting for my friend",
-		"soundmark": "/aɪ/ /æm/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/"
-	},
-	{
-		"chinese": "公交车",
-		"english": "the bus",
-		"soundmark": "/ðə/ /bʌs/"
-	},
-	{
-		"chinese": "停止",
-		"english": "stop",
-		"soundmark": "/stɑp/"
-	},
-	{
-		"chinese": "公交车站",
-		"english": "the bus stop",
-		"soundmark": "/ðə/ /bʌs/ /stɑp/"
-	},
-	{
-		"chinese": "在",
-		"english": "at",
-		"soundmark": "/ət/"
-	},
-	{
-		"chinese": "在公交车站",
-		"english": "at the bus stop",
-		"soundmark": "/ət/ /ðə/ /bʌs/ /stɑp/"
-	},
-	{
-		"chinese": "我在公交车站(现在)正在为了我的朋友等待",
-		"english": "I am waiting for my friend at the bus stop",
-		"soundmark": "/aɪ/ /æm/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/ /ət/ /ðə/ /bʌs/ /stɑp/"
-	},
-	{
-		"chinese": "现在",
-		"english": "now",
-		"soundmark": "/naʊ/"
-	},
-	{
-		"chinese": "我现在在公交车站正在为了我的朋友等待",
-		"english": "I am waiting for my friend at the bus stop now",
-		"soundmark": "/aɪ/ /æm/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/ /ət/ /ðə/ /bʌs/ /stɑp/ /naʊ/ /(I，过去时)be was/ /wəz/"
-	},
-	{
-		"chinese": "我在公交车站(过去)正在为了我的朋友等待",
-		"english": "I was waiting for my friend at the bus stop",
-		"soundmark": "/aɪ/ /wəz/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/ /ət/ /ðə/ /bʌs/ /stɑp/"
-	},
-	{
-		"chinese": "昨天",
-		"english": "yesterday",
-		"soundmark": "/'jɛstɚde/"
-	},
-	{
-		"chinese": "我昨天在公交车站正在为了我的朋友等待",
-		"english": "I was waiting for my friend at the bus stop yesterday",
-		"soundmark": "/aɪ/ /wəz/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/ /ət/ /ðə/ /bʌs/ /stɑp/ /'jɛstɚde/"
-	},
-	{
-		"chinese": "时间；时候",
-		"english": "time",
-		"soundmark": "/taɪm/"
-	},
-	{
-		"chinese": "这个",
-		"english": "this",
-		"soundmark": "/ðɪs/"
-	},
-	{
-		"chinese": "这个时候",
-		"english": "this time",
-		"soundmark": "/ðɪs/ /taɪm/"
-	},
-	{
-		"chinese": "在",
-		"english": "at",
-		"soundmark": "/ət/"
-	},
-	{
-		"chinese": "在这个时候",
-		"english": "at this time",
-		"soundmark": "/ət/ /ðɪs/ /taɪm/"
-	},
-	{
-		"chinese": "昨天",
-		"english": "yesterday",
-		"soundmark": "/'jɛstɚde/"
-	},
-	{
-		"chinese": "在昨天这个时候",
-		"english": "at this time yesterday",
-		"soundmark": "/ət/ /ðɪs/ /taɪm/ /'jɛstɚde/"
-	},
-	{
-		"chinese": "我在昨天这个时候在公交车站正在为了我的朋友等待",
-		"english": "I was waiting for my friend at the bus stop at this time yesterday",
-		"soundmark": "/aɪ/ /wəz/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/ /ət/ /ðə/ /bʌs/ /stɑp/ /ət/ /ðɪs/ /taɪm/ /'jɛstɚde/"
-	},
-	{
-		"chinese": "在......之前",
-		"english": "before",
-		"soundmark": "/bɪ'fɔr/"
-	},
-	{
-		"chinese": "在昨天之前",
-		"english": "before yesterday",
-		"soundmark": "/bɪ'fɔr/ /'jɛstɚde/"
-	},
-	{
-		"chinese": "那一天",
-		"english": "the day",
-		"soundmark": "/ðə/ /de/"
-	},
-	{
-		"chinese": "在昨天之前的那一天(前天)",
-		"english": "the day before yesterday",
-		"soundmark": "/ðə/ /de/ /bɪ'fɔr/ /'jɛstɚde/"
-	},
-	{
-		"chinese": "在这个时候",
-		"english": "at this time",
-		"soundmark": "/ət/ /ðɪs/ /taɪm/"
-	},
-	{
-		"chinese": "在前天这个时候",
-		"english": "at this time the day before yesterday",
-		"soundmark": "/ət/ /ðɪs/ /taɪm/ /ðə/ /de/ /bɪ'fɔr/ /'jɛstɚde/"
-	},
-	{
-		"chinese": "我在前天这个时候在公交车站正在为了我的朋友等待",
-		"english": "I was waiting for my friend at the bus stop at this time the day before yesterday",
-		"soundmark": "/aɪ/ /wəz/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/ /ət/ /ðə/ /bʌs/ /stɑp/ /ət/ /ðɪs/ /taɪm/ /ðə/ /de/ /bɪ'fɔr/ /'jɛstɚde/"
-	},
-	{
-		"chinese": "我(过去)正在为了我的朋友等待",
-		"english": "I was waiting for my friend",
-		"soundmark": "/aɪ/ /wəz/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/ /(I，现在时)be am/ /æm/"
-	},
-	{
-		"chinese": "我(现在)正在为了我的朋友等待",
-		"english": "I am waiting for my friend",
-		"soundmark": "/aɪ/ /æm/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/"
-	},
-	{
-		"chinese": "将来",
-		"english": "will",
-		"soundmark": "/wɪl/"
-	},
-	{
-		"chinese": "我将会正在为了我的朋友等待",
-		"english": "I will be waiting for my friend",
-		"soundmark": "/aɪ/ /wɪl/ /bi/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/"
-	},
-	{
-		"chinese": "公交车",
-		"english": "the bus",
-		"soundmark": "/ðə/ /bʌs/"
-	},
-	{
-		"chinese": "停止",
-		"english": "stop",
-		"soundmark": "/stɑp/"
-	},
-	{
-		"chinese": "公交车站",
-		"english": "the bus stop",
-		"soundmark": "/ðə/ /bʌs/ /stɑp/"
-	},
-	{
-		"chinese": "在公交车站",
-		"english": "at the bus stop",
-		"soundmark": "/ət/ /ðə/ /bʌs/ /stɑp/"
-	},
-	{
-		"chinese": "我将会在公交车站正在为了我的朋友等待",
-		"english": "I will be waiting for my friend at the bus stop",
-		"soundmark": "/aɪ/ /wɪl/ /bi/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/ /ət/ /ðə/ /bʌs/ /stɑp/"
-	},
-	{
-		"chinese": "在这个时候",
-		"english": "at this time",
-		"soundmark": "/ət/ /ðɪs/ /taɪm/"
-	},
-	{
-		"chinese": "明天",
-		"english": "tomorrow",
-		"soundmark": "/tə'mɔro/"
-	},
-	{
-		"chinese": "在明天这个时候",
-		"english": "at this time tomorrow",
-		"soundmark": "/ət/ /ðɪs/ /taɪm/ /tə'mɔro/"
-	},
-	{
-		"chinese": "我将会在明天这个时候在公交车站正在为了我的朋友等待",
-		"english": "I will be waiting for my friend at the bus stop at this time tomorrow",
-		"soundmark": "/aɪ/ /wɪl/ /bi/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/ /ət/ /ðə/ /bʌs/ /stɑp/ /ət/ /ðɪs/ /taɪm/ /tə'mɔro/"
-	},
-	{
-		"chinese": "在......之后",
-		"english": "after",
-		"soundmark": "/'æftɚ/"
-	},
-	{
-		"chinese": "在明天之后",
-		"english": "after tomorrow",
-		"soundmark": "/'æftɚ/ /tə'mɔro/"
-	},
-	{
-		"chinese": "那一天",
-		"english": "the day",
-		"soundmark": "/ðə/ /de/"
-	},
-	{
-		"chinese": "在明天之后的那一天(后天)",
-		"english": "the day after tomorrow",
-		"soundmark": "/ðə/ /de/ /'æftɚ/ /tə'mɔro/"
-	},
-	{
-		"chinese": "在这个时候",
-		"english": "at this time",
-		"soundmark": "/ət/ /ðɪs/ /taɪm/"
-	},
-	{
-		"chinese": "后天这个时候",
-		"english": "at this time the day after tomorrow",
-		"soundmark": "/ət/ /ðɪs/ /taɪm/ /ðə/ /de/ /'æftɚ/ /tə'mɔro/"
-	},
-	{
-		"chinese": "我将会在后天这个时候在公交车站正在为了我的朋友等待",
-		"english": "I will be waiting for my friend at the bus stop at this time the day after tomorrow",
-		"soundmark": "/aɪ/ /wɪl/ /bi/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/ /ət/ /ðə/ /bʌs/ /stɑp/ /ət/ /ðɪs/ /taɪm/ /ðə/ /de/ /'æftɚ/ /tə'mɔro/"
-	},
-	{
-		"chinese": "我将会为了我的朋友正在等待",
-		"english": "I will be waiting for my friend",
-		"soundmark": "/aɪ/ /wɪl/ /bi/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/"
-	},
-	{
-		"chinese": "他",
-		"english": "he",
-		"soundmark": "/hi/"
-	},
-	{
-		"chinese": "他将会为了我的朋友正在等待",
-		"english": "he will be waiting for my friend",
-		"soundmark": "/hi/ /wɪl/ /bi/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/"
-	},
-	{
-		"chinese": "他们",
-		"english": "they",
-		"soundmark": "/ðe/"
-	},
-	{
-		"chinese": "他们将会为了我的朋友正在等待",
-		"english": "they will be waiting for my friend",
-		"soundmark": "/ðe/ /wɪl/ /bi/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/"
-	},
-	{
-		"chinese": "我(现在)正在为了我的朋友等待",
-		"english": "I am waiting for my friend",
-		"soundmark": "/aɪ/ /æm/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/"
-	},
-	{
-		"chinese": "我(现在)正在等待",
-		"english": "I am waiting",
-		"soundmark": "/aɪ/ /æm/ /'wetɪŋ/"
-	},
-	{
-		"chinese": "你",
-		"english": "you",
-		"soundmark": "/ju/"
-	},
-	{
-		"chinese": "为了",
-		"english": "for",
-		"soundmark": "/fɝ/"
-	},
-	{
-		"chinese": "为了你",
-		"english": "for you",
-		"soundmark": "/fɝ/ /ju/"
-	},
-	{
-		"chinese": "我(现在)正在为了你等待",
-		"english": "I am waiting for you",
-		"soundmark": "/aɪ/ /æm/ /'wetɪŋ/ /fɝ/ /ju/"
-	},
-	{
-		"chinese": "问",
-		"english": "to ask",
-		"soundmark": "/tə/ /æsk/"
-	},
-	{
-		"chinese": "我",
-		"english": "me",
-		"soundmark": "/mi/"
-	},
-	{
-		"chinese": "问我",
-		"english": "to ask me",
-		"soundmark": "/tə/ /æsk/ /mi/"
-	},
-	{
-		"chinese": "那个",
-		"english": "that",
-		"soundmark": "/ðæt/"
-	},
-	{
-		"chinese": "问题",
-		"english": "question",
-		"soundmark": "/'kwɛstʃən/"
-	},
-	{
-		"chinese": "那个问题",
-		"english": "that question",
-		"soundmark": "/ðæt/ /'kwɛstʃən/"
-	},
-	{
-		"chinese": "问我那个问题",
-		"english": "to ask me that question",
-		"soundmark": "/tə/ /æsk/ /mi/ /ðæt/ /'kwɛstʃən/"
-	},
-	{
-		"chinese": "我(现在)正在等你问我那个",
-		"english": "I am waiting for you to ask me",
-		"soundmark": "/aɪ/ /æm/ /'wetɪŋ/ /fɝ/ /ju/ /tə/ /æsk/ /mi/"
-	},
-	{
-		"chinese": "中文 原形 第三人称单数 过去式想要",
-		"english": "want wants",
-		"soundmark": "/wanted/"
-	},
-	{
-		"chinese": "喜欢",
-		"english": "like likes",
-		"soundmark": "/liked/"
-	},
-	{
-		"chinese": "有；(+to)不得不",
-		"english": "have has",
-		"soundmark": "/had/"
-	},
-	{
-		"chinese": "计划",
-		"english": "plan plans",
-		"soundmark": "/planned/"
-	},
-	{
-		"chinese": "需要",
-		"english": "need needs",
-		"soundmark": "/needed/"
-	},
-	{
-		"chinese": "做",
-		"english": "do does",
-		"soundmark": "/did/"
-	},
-	{
-		"chinese": "告诉",
-		"english": "tell tells",
-		"soundmark": "/told/"
-	},
-	{
-		"chinese": "说话",
-		"english": "talk talks",
-		"soundmark": "/talked/"
-	},
-	{
-		"chinese": "是 be（am）",
-		"english": "is",
-		"soundmark": "/was/"
-	},
-	{
-		"chinese": "是 be（is ）",
-		"english": "is",
-		"soundmark": "/was/"
-	},
-	{
-		"chinese": "是 be（are）",
-		"english": "is",
-		"soundmark": "/were/"
-	},
-	{
-		"chinese": "看到",
-		"english": "see sees",
-		"soundmark": "/saw/"
-	},
-	{
-		"chinese": "吃",
-		"english": "eat eats",
-		"soundmark": "/ate/"
-	},
-	{
-		"chinese": "喝",
-		"english": "drink drinks",
-		"soundmark": "/drank/"
-	},
-	{
-		"chinese": "知道",
-		"english": "know knows",
-		"soundmark": "/knew/"
-	},
-	{
-		"chinese": "忘记",
-		"english": "forget forgets",
-		"soundmark": "/forgot/"
-	},
-	{
-		"chinese": "失去",
-		"english": "lose loses",
-		"soundmark": "/lost/"
-	},
-	{
-		"chinese": "离开",
-		"english": "leave leaves",
-		"soundmark": "/left/"
-	},
-	{
-		"chinese": "睡觉",
-		"english": "sleep sleeps",
-		"soundmark": "/slept/"
-	},
-	{
-		"chinese": "明白",
-		"english": "understand understands",
-		"soundmark": "/understood/"
-	},
-	{
-		"chinese": "买",
-		"english": "buy buys",
-		"soundmark": "/bought/"
-	},
-	{
-		"chinese": "洗",
-		"english": "wash washes",
-		"soundmark": "/washed/"
-	},
-	{
-		"chinese": "打电话",
-		"english": "call calls",
-		"soundmark": "/called/"
-	},
-	{
-		"chinese": "帮助",
-		"english": "help helps",
-		"soundmark": "/helped/"
-	},
-	{
-		"chinese": "相信",
-		"english": "believe believes",
-		"soundmark": "/believed/"
-	},
-	{
-		"chinese": "学习",
-		"english": "study studies",
-		"soundmark": "/studied/"
-	},
-	{
-		"chinese": "解释",
-		"english": "explain explains",
-		"soundmark": "/explained/"
-	},
-	{
-		"chinese": "问",
-		"english": "ask asks",
-		"soundmark": "/asked/"
-	},
-	{
-		"chinese": "飞",
-		"english": "fly flies",
-		"soundmark": "/flew/"
-	},
-	{
-		"chinese": "问题",
-		"english": "that question",
-		"soundmark": "/ðæt/ /'kwɛstʃən/ /(I，过去时)be was/ /wəz/"
-	},
-	{
-		"chinese": "我(过去)正在等你问我那个问题",
-		"english": "I was waiting for you to ask me that question",
-		"soundmark": "/aɪ/ /wəz/ /'wetɪŋ/ /fɝ/ /ju/ /tə/ /æsk/ /mi/ /ðæt/ /'kwɛstʃən/"
-	},
-	{
-		"chinese": "将会",
-		"english": "will",
-		"soundmark": "/wɪl/"
-	},
-	{
-		"chinese": "我将会正在等你问我那个问题",
-		"english": "I will be waiting for you to ask me that question",
-		"soundmark": "/aɪ/ /wɪl/ /bi/ /'wetɪŋ/ /fɝ/ /ju/ /tə/ /æsk/ /mi/ /ðæt/ /'kwɛstʃən/"
-	},
-	{
-		"chinese": "阅读",
-		"english": "read reads",
-		"soundmark": "/read/"
-	},
-	{
-		"chinese": "走路",
-		"english": "walk walks",
-		"soundmark": "/walked/"
-	},
-	{
-		"chinese": "跳舞",
-		"english": "dance dances",
-		"soundmark": "/danced/"
-	},
-	{
-		"chinese": "回答",
-		"english": "answer answers",
-		"soundmark": "/answered/"
-	},
-	{
-		"chinese": "工作",
-		"english": "work works",
-		"soundmark": "/worked/"
-	},
-	{
-		"chinese": "待在",
-		"english": "stay stays",
-		"soundmark": "/stayed/"
-	},
-	{
-		"chinese": "支付",
-		"english": "pay pays",
-		"soundmark": "/paid/"
-	},
-	{
-		"chinese": "旅行",
-		"english": "travel travels",
-		"soundmark": "/traveled/"
-	},
-	{
-		"chinese": "给",
-		"english": "give gives",
-		"soundmark": "/gave/"
-	},
-	{
-		"chinese": "达到",
-		"english": "get gets",
-		"soundmark": "/got/"
-	},
-	{
-		"chinese": "锁",
-		"english": "lock locks",
-		"soundmark": "/locked/"
-	},
-	{
-		"chinese": "记得",
-		"english": "remember remembers",
-		"soundmark": "/Remembered/"
-	},
-	{
-		"chinese": "清理",
-		"english": "clean cleans",
-		"soundmark": "/cleaned/"
-	},
-	{
-		"chinese": "找到",
-		"english": "find finds",
-		"soundmark": "/found/"
-	},
-	{
-		"chinese": "关闭",
-		"english": "close closes",
-		"soundmark": "/closed/"
-	},
-	{
-		"chinese": "教",
-		"english": "teach teaches",
-		"soundmark": "/taught/"
-	},
-	{
-		"chinese": "展示",
-		"english": "show shows",
-		"soundmark": "/showed/"
-	},
-	{
-		"chinese": "让",
-		"english": "let lets",
-		"soundmark": "/let/"
-	},
-	{
-		"chinese": "休息",
-		"english": "rest rests",
-		"soundmark": "/rested/"
-	},
-	{
-		"chinese": "用",
-		"english": "use uses",
-		"soundmark": "/used/"
-	},
-	{
-		"chinese": "做饭",
-		"english": "cook cooks",
-		"soundmark": "/cooked/"
-	},
-	{
-		"chinese": "去",
-		"english": "go goes",
-		"soundmark": "/went/"
-	},
-	{
-		"chinese": "决定",
-		"english": "decide decides",
-		"soundmark": "/decided/"
-	},
-	{
-		"chinese": "驾驶",
-		"english": "drive drives",
-		"soundmark": "/drove/"
-	},
-	{
-		"chinese": "改变",
-		"english": "change changes",
-		"soundmark": "/changed/"
-	},
-	{
-		"chinese": "尝试",
-		"english": "try tries",
-		"soundmark": "/tried/"
-	},
-	{
-		"chinese": "停止",
-		"english": "stop stops",
-		"soundmark": "/Stopped/"
-	},
-	{
-		"chinese": "参加",
-		"english": "join joins",
-		"soundmark": "/joined/"
-	},
-	{
-		"chinese": "邀请",
-		"english": "invite invites",
-		"soundmark": "/invited/"
-	},
-	{
-		"chinese": "拒绝",
-		"english": "refuse refuses",
-		"soundmark": "/refused/"
-	},
-	{
-		"chinese": "接受",
-		"english": "accept accepts",
-		"soundmark": "/accepted/"
-	},
-	{
-		"chinese": "学习",
-		"english": "learn learns",
-		"soundmark": "/learnt/"
-	},
-	{
-		"chinese": "完成",
-		"english": "finish finishes",
-		"soundmark": "/finished/"
-	},
-	{
-		"chinese": "看",
-		"english": "watch watches",
-		"soundmark": "/watched/"
-	},
-	{
-		"chinese": "游泳",
-		"english": "swim swims",
-		"soundmark": "/swam/"
-	},
-	{
-		"chinese": "掌握",
-		"english": "master masters",
-		"soundmark": "/mastered/"
-	},
-	{
-		"chinese": "购物",
-		"english": "shop shops",
-		"soundmark": "/shopped/"
-	},
-	{
-		"chinese": "等待",
-		"english": "wait waits",
-		"soundmark": "/waited/"
-	}
+  {
+    "chinese": "购物",
+    "english": "to shop",
+    "soundmark": "/tə/ /ʃɑp/"
+  },
+  {
+    "chinese": "想要",
+    "english": "want",
+    "soundmark": "/wɑnt/"
+  },
+  {
+    "chinese": "我们",
+    "english": "we",
+    "soundmark": "/wi/"
+  },
+  {
+    "chinese": "我们想要",
+    "english": "we want",
+    "soundmark": "/wi/ /wɑnt/"
+  },
+  {
+    "chinese": "我们想要购物",
+    "english": "we want to shop",
+    "soundmark": "/wi/ /wɑnt/ /tə/ /ʃɑp/"
+  },
+  {
+    "chinese": "市场",
+    "english": "the market",
+    "soundmark": "/ðə/ /'mɑrkɪt/"
+  },
+  {
+    "chinese": "在",
+    "english": "at",
+    "soundmark": "/ət/"
+  },
+  {
+    "chinese": "在市场",
+    "english": "at the market",
+    "soundmark": "/ət/ /ðə/ /'mɑrkɪt/"
+  },
+  {
+    "chinese": "购物",
+    "english": "to shop",
+    "soundmark": "/tə/ /ʃɑp/"
+  },
+  {
+    "chinese": "在市场购物",
+    "english": "to shop at the market",
+    "soundmark": "/tə/ /ʃɑp/ /ət/ /ðə/ /'mɑrkɪt/"
+  },
+  {
+    "chinese": "我们想要在市场购物",
+    "english": "we want to shop at the market",
+    "soundmark": "/wi/ /wɑnt/ /tə/ /ʃɑp/ /ət/ /ðə/ /'mɑrkɪt/"
+  },
+  {
+    "chinese": "超级",
+    "english": "super",
+    "soundmark": "/'sʊpɚ/"
+  },
+  {
+    "chinese": "超级市场",
+    "english": "supermarket",
+    "soundmark": "/'sʊpɚmɑrkɪt/"
+  },
+  {
+    "chinese": "在超市",
+    "english": "at the supermarket",
+    "soundmark": "/ət/ /ðə/ /'sʊpɚmɑrkɪt/"
+  },
+  {
+    "chinese": "我们想要在超市购物",
+    "english": "we want to shop at the supermarket",
+    "soundmark": "/wi/ /wɑnt/ /tə/ /ʃɑp/ /ət/ /ðə/ /'sʊpɚmɑrkɪt/"
+  },
+  {
+    "chinese": "我们在超市购物",
+    "english": "we shop at the supermarket",
+    "soundmark": "/wi/ /ʃɑp/ /ət/ /ðə/ /'sʊpɚmɑrkɪt/"
+  },
+  {
+    "chinese": "购物(ing形式)",
+    "english": "shopping",
+    "soundmark": "/'ʃɑpɪŋ/"
+  },
+  {
+    "chinese": "是；赋值(原型)",
+    "english": "be",
+    "soundmark": "/bi/"
+  },
+  {
+    "chinese": "正在购物",
+    "english": "be shopping",
+    "soundmark": "/bi/"
+  },
+  {
+    "chinese": "我们",
+    "english": "we",
+    "soundmark": "/wi/ /(we，现在时)be are/ /ɚ/"
+  },
+  {
+    "chinese": "我们(现在)正在购物",
+    "english": "we are shopping",
+    "soundmark": "/wi/ /ɚ/ /'ʃɑpɪŋ/"
+  },
+  {
+    "chinese": "在超市",
+    "english": "at the supermarket",
+    "soundmark": "/ət/ /ðə/ /'sʊpɚmɑrkɪt/"
+  },
+  {
+    "chinese": "我们(现在)正在在超市购物",
+    "english": "we are shopping at the supermarket",
+    "soundmark": "/wi/ /ɚ/ /'ʃɑpɪŋ/ /ət/ /ðə/ /'sʊpɚmɑrkɪt/"
+  },
+  {
+    "chinese": "现在",
+    "english": "now",
+    "soundmark": "/naʊ/"
+  },
+  {
+    "chinese": "我们现在正在在超市购物",
+    "english": "we are shopping at the supermarket now",
+    "soundmark": "/wi/ /ɚ/ /'ʃɑpɪŋ/ /ət/ /ðə/ /'sʊpɚmɑrkɪt/ /naʊ/ /(we，过去时)be were/ /wɚ/"
+  },
+  {
+    "chinese": "我们(过去)正在在超市购物",
+    "english": "we were shopping at the supermarket",
+    "soundmark": "/wi/ /wɚ/ /'ʃɑpɪŋ/ /ət/ /ðə/ /'sʊpɚmɑrkɪt/"
+  },
+  {
+    "chinese": "打电话",
+    "english": "to call",
+    "soundmark": "/tə/ /kɔl/ /(过去)打电话 called/ /kɔld/"
+  },
+  {
+    "chinese": "我",
+    "english": "me",
+    "soundmark": "/mi/ /(过去)打电话给我 called me/ /kɔld/ /mi/"
+  },
+  {
+    "chinese": "你(过去)打电话给我",
+    "english": "you called me",
+    "soundmark": "/ju/ /kɔld/ /mi/"
+  },
+  {
+    "chinese": "当......的时候",
+    "english": "when",
+    "soundmark": "/wɛn/"
+  },
+  {
+    "chinese": "当你(过去)打电话给我的时候",
+    "english": "when you called me",
+    "soundmark": "/wɛn/ /ju/ /kɔld/ /mi/"
+  },
+  {
+    "chinese": "星期天",
+    "english": "Sunday",
+    "soundmark": "/ˈsʌnde/"
+  },
+  {
+    "chinese": "上一个",
+    "english": "last",
+    "soundmark": "/læst/"
+  },
+  {
+    "chinese": "上周日",
+    "english": "last Sunday",
+    "soundmark": "/læst/ /ˈsʌnde/"
+  },
+  {
+    "chinese": "当你上周日打电话给我的时候",
+    "english": "when you called me last Sunday",
+    "soundmark": "/wɛn/ /ju/ /kɔld/ /mi/ /læst/ /ˈsʌnde/"
+  },
+  {
+    "chinese": "我们(过去)正在在超市购物当你上周日打电话给我的时候",
+    "english": "we were shopping at the supermarket when you called me last Sunday",
+    "soundmark": "/wi/ /wɚ/ /'ʃɑpɪŋ/ /ət/ /ðə/ /'sʊpɚmɑrkɪt/ /wɛn/ /ju/ /kɔld/ /mi/ /læst/ /ˈsʌnde/"
+  },
+  {
+    "chinese": "我们上周日正在在超市购物",
+    "english": "we were shopping at the supermarket last Sunday",
+    "soundmark": "/wi/ /wɚ/ /'ʃɑpɪŋ/ /ət/ /ðə/ /'sʊpɚmɑrkɪt/ /læst/ /ˈsʌnde/"
+  },
+  {
+    "chinese": "我们(过去)正在购物",
+    "english": "we were shopping",
+    "soundmark": "/wi/ /wɚ/ /'ʃɑpɪŋ/ /(we，现在时)be are/ /ɚ/"
+  },
+  {
+    "chinese": "我们(现在)正在购物",
+    "english": "we are shopping",
+    "soundmark": "/wi/ /ɚ/ /'ʃɑpɪŋ/"
+  },
+  {
+    "chinese": "将会",
+    "english": "will",
+    "soundmark": "/wɪl/"
+  },
+  {
+    "chinese": "我们将会正在购物",
+    "english": "we will be shopping",
+    "soundmark": "/wi/ /wɪl/ /bi/ /'ʃɑpɪŋ/"
+  },
+  {
+    "chinese": "在超市",
+    "english": "at the supermarket",
+    "soundmark": "/ət/ /ðə/ /'sʊpɚmɑrkɪt/"
+  },
+  {
+    "chinese": "我们将会正在在超市购物",
+    "english": "we will be shopping at the supermarket",
+    "soundmark": "/wi/ /wɪl/ /bi/ /'ʃɑpɪŋ/ /ət/ /ðə/ /'sʊpɚmɑrkɪt/"
+  },
+  {
+    "chinese": "星期一",
+    "english": "Monday",
+    "soundmark": "/ˈmʌnde/"
+  },
+  {
+    "chinese": "下一个",
+    "english": "next",
+    "soundmark": "/nɛkst/"
+  },
+  {
+    "chinese": "下周一",
+    "english": "next Monday",
+    "soundmark": "/nɛkst/ /ˈmʌnde/"
+  },
+  {
+    "chinese": "我们将会在下周一正在在超市购物",
+    "english": "we will be shopping at the supermarket next Monday",
+    "soundmark": "/wi/ /wɪl/ /bi/ /'ʃɑpɪŋ/ /ət/ /ðə/ /'sʊpɚmɑrkɪt/ /nɛkst/ /ˈmʌnde/"
+  },
+  {
+    "chinese": "等待",
+    "english": "to wait",
+    "soundmark": "/tə/ /wet/"
+  },
+  {
+    "chinese": "我需要",
+    "english": "I need",
+    "soundmark": "/aɪ/ /nid/"
+  },
+  {
+    "chinese": "我需要等待",
+    "english": "I need to wait",
+    "soundmark": "/aɪ/ /nid/ /tə/ /wet/"
+  },
+  {
+    "chinese": "朋友",
+    "english": "friend",
+    "soundmark": "/frɛnd/"
+  },
+  {
+    "chinese": "我的",
+    "english": "my",
+    "soundmark": "/maɪ/"
+  },
+  {
+    "chinese": "我的朋友",
+    "english": "my friend",
+    "soundmark": "/maɪ/ /frɛnd/"
+  },
+  {
+    "chinese": "为了",
+    "english": "for",
+    "soundmark": "/fɝ/"
+  },
+  {
+    "chinese": "为了我的朋友",
+    "english": "for my friend",
+    "soundmark": "/fɝ/ /maɪ/ /frɛnd/"
+  },
+  {
+    "chinese": "我需要为了我的朋友等待",
+    "english": "I need to wait for my friend",
+    "soundmark": "/aɪ/ /nid/ /tə/ /wet/ /fɝ/ /maɪ/ /frɛnd/"
+  },
+  {
+    "chinese": "我为了我的朋友等待",
+    "english": "I wait for my friend",
+    "soundmark": "/aɪ/ /wet/ /fɝ/ /maɪ/ /frɛnd/"
+  },
+  {
+    "chinese": "等待(ing形式)",
+    "english": "waiting",
+    "soundmark": "/'wetɪŋ/"
+  },
+  {
+    "chinese": "是；赋值(原型)",
+    "english": "be",
+    "soundmark": "/bi/"
+  },
+  {
+    "chinese": "正在等待",
+    "english": "be waiting",
+    "soundmark": "/bi/ /'wetɪŋ/"
+  },
+  {
+    "chinese": "我",
+    "english": "I",
+    "soundmark": "/aɪ/ /(I，现在时)be am/ /æm/"
+  },
+  {
+    "chinese": "我(现在)正在等待",
+    "english": "I am waiting",
+    "soundmark": "/aɪ/ /æm/ /'wetɪŋ/"
+  },
+  {
+    "chinese": "为了我的朋友",
+    "english": "for my friend",
+    "soundmark": "/fɝ/ /maɪ/ /frɛnd/"
+  },
+  {
+    "chinese": "我(现在)正在为了我的朋友等待",
+    "english": "I am waiting for my friend",
+    "soundmark": "/aɪ/ /æm/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/"
+  },
+  {
+    "chinese": "公交车",
+    "english": "the bus",
+    "soundmark": "/ðə/ /bʌs/"
+  },
+  {
+    "chinese": "停止",
+    "english": "stop",
+    "soundmark": "/stɑp/"
+  },
+  {
+    "chinese": "公交车站",
+    "english": "the bus stop",
+    "soundmark": "/ðə/ /bʌs/ /stɑp/"
+  },
+  {
+    "chinese": "在",
+    "english": "at",
+    "soundmark": "/ət/"
+  },
+  {
+    "chinese": "在公交车站",
+    "english": "at the bus stop",
+    "soundmark": "/ət/ /ðə/ /bʌs/ /stɑp/"
+  },
+  {
+    "chinese": "我在公交车站(现在)正在为了我的朋友等待",
+    "english": "I am waiting for my friend at the bus stop",
+    "soundmark": "/aɪ/ /æm/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/ /ət/ /ðə/ /bʌs/ /stɑp/"
+  },
+  {
+    "chinese": "现在",
+    "english": "now",
+    "soundmark": "/naʊ/"
+  },
+  {
+    "chinese": "我现在在公交车站正在为了我的朋友等待",
+    "english": "I am waiting for my friend at the bus stop now",
+    "soundmark": "/aɪ/ /æm/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/ /ət/ /ðə/ /bʌs/ /stɑp/ /naʊ/ /(I，过去时)be was/ /wəz/"
+  },
+  {
+    "chinese": "我在公交车站(过去)正在为了我的朋友等待",
+    "english": "I was waiting for my friend at the bus stop",
+    "soundmark": "/aɪ/ /wəz/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/ /ət/ /ðə/ /bʌs/ /stɑp/"
+  },
+  {
+    "chinese": "昨天",
+    "english": "yesterday",
+    "soundmark": "/'jɛstɚde/"
+  },
+  {
+    "chinese": "我昨天在公交车站正在为了我的朋友等待",
+    "english": "I was waiting for my friend at the bus stop yesterday",
+    "soundmark": "/aɪ/ /wəz/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/ /ət/ /ðə/ /bʌs/ /stɑp/ /'jɛstɚde/"
+  },
+  {
+    "chinese": "时间；时候",
+    "english": "time",
+    "soundmark": "/taɪm/"
+  },
+  {
+    "chinese": "这个",
+    "english": "this",
+    "soundmark": "/ðɪs/"
+  },
+  {
+    "chinese": "这个时候",
+    "english": "this time",
+    "soundmark": "/ðɪs/ /taɪm/"
+  },
+  {
+    "chinese": "在",
+    "english": "at",
+    "soundmark": "/ət/"
+  },
+  {
+    "chinese": "在这个时候",
+    "english": "at this time",
+    "soundmark": "/ət/ /ðɪs/ /taɪm/"
+  },
+  {
+    "chinese": "昨天",
+    "english": "yesterday",
+    "soundmark": "/'jɛstɚde/"
+  },
+  {
+    "chinese": "在昨天这个时候",
+    "english": "at this time yesterday",
+    "soundmark": "/ət/ /ðɪs/ /taɪm/ /'jɛstɚde/"
+  },
+  {
+    "chinese": "我在昨天这个时候在公交车站正在为了我的朋友等待",
+    "english": "I was waiting for my friend at the bus stop at this time yesterday",
+    "soundmark": "/aɪ/ /wəz/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/ /ət/ /ðə/ /bʌs/ /stɑp/ /ət/ /ðɪs/ /taɪm/ /'jɛstɚde/"
+  },
+  {
+    "chinese": "在......之前",
+    "english": "before",
+    "soundmark": "/bɪ'fɔr/"
+  },
+  {
+    "chinese": "在昨天之前",
+    "english": "before yesterday",
+    "soundmark": "/bɪ'fɔr/ /'jɛstɚde/"
+  },
+  {
+    "chinese": "那一天",
+    "english": "the day",
+    "soundmark": "/ðə/ /de/"
+  },
+  {
+    "chinese": "在昨天之前的那一天(前天)",
+    "english": "the day before yesterday",
+    "soundmark": "/ðə/ /de/ /bɪ'fɔr/ /'jɛstɚde/"
+  },
+  {
+    "chinese": "在这个时候",
+    "english": "at this time",
+    "soundmark": "/ət/ /ðɪs/ /taɪm/"
+  },
+  {
+    "chinese": "在前天这个时候",
+    "english": "at this time the day before yesterday",
+    "soundmark": "/ət/ /ðɪs/ /taɪm/ /ðə/ /de/ /bɪ'fɔr/ /'jɛstɚde/"
+  },
+  {
+    "chinese": "我在前天这个时候在公交车站正在为了我的朋友等待",
+    "english": "I was waiting for my friend at the bus stop at this time the day before yesterday",
+    "soundmark": "/aɪ/ /wəz/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/ /ət/ /ðə/ /bʌs/ /stɑp/ /ət/ /ðɪs/ /taɪm/ /ðə/ /de/ /bɪ'fɔr/ /'jɛstɚde/"
+  },
+  {
+    "chinese": "我(过去)正在为了我的朋友等待",
+    "english": "I was waiting for my friend",
+    "soundmark": "/aɪ/ /wəz/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/ /(I，现在时)be am/ /æm/"
+  },
+  {
+    "chinese": "我(现在)正在为了我的朋友等待",
+    "english": "I am waiting for my friend",
+    "soundmark": "/aɪ/ /æm/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/"
+  },
+  {
+    "chinese": "将来",
+    "english": "will",
+    "soundmark": "/wɪl/"
+  },
+  {
+    "chinese": "我将会正在为了我的朋友等待",
+    "english": "I will be waiting for my friend",
+    "soundmark": "/aɪ/ /wɪl/ /bi/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/"
+  },
+  {
+    "chinese": "公交车",
+    "english": "the bus",
+    "soundmark": "/ðə/ /bʌs/"
+  },
+  {
+    "chinese": "停止",
+    "english": "stop",
+    "soundmark": "/stɑp/"
+  },
+  {
+    "chinese": "公交车站",
+    "english": "the bus stop",
+    "soundmark": "/ðə/ /bʌs/ /stɑp/"
+  },
+  {
+    "chinese": "在公交车站",
+    "english": "at the bus stop",
+    "soundmark": "/ət/ /ðə/ /bʌs/ /stɑp/"
+  },
+  {
+    "chinese": "我将会在公交车站正在为了我的朋友等待",
+    "english": "I will be waiting for my friend at the bus stop",
+    "soundmark": "/aɪ/ /wɪl/ /bi/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/ /ət/ /ðə/ /bʌs/ /stɑp/"
+  },
+  {
+    "chinese": "在这个时候",
+    "english": "at this time",
+    "soundmark": "/ət/ /ðɪs/ /taɪm/"
+  },
+  {
+    "chinese": "明天",
+    "english": "tomorrow",
+    "soundmark": "/tə'mɔro/"
+  },
+  {
+    "chinese": "在明天这个时候",
+    "english": "at this time tomorrow",
+    "soundmark": "/ət/ /ðɪs/ /taɪm/ /tə'mɔro/"
+  },
+  {
+    "chinese": "我将会在明天这个时候在公交车站正在为了我的朋友等待",
+    "english": "I will be waiting for my friend at the bus stop at this time tomorrow",
+    "soundmark": "/aɪ/ /wɪl/ /bi/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/ /ət/ /ðə/ /bʌs/ /stɑp/ /ət/ /ðɪs/ /taɪm/ /tə'mɔro/"
+  },
+  {
+    "chinese": "在......之后",
+    "english": "after",
+    "soundmark": "/'æftɚ/"
+  },
+  {
+    "chinese": "在明天之后",
+    "english": "after tomorrow",
+    "soundmark": "/'æftɚ/ /tə'mɔro/"
+  },
+  {
+    "chinese": "那一天",
+    "english": "the day",
+    "soundmark": "/ðə/ /de/"
+  },
+  {
+    "chinese": "在明天之后的那一天(后天)",
+    "english": "the day after tomorrow",
+    "soundmark": "/ðə/ /de/ /'æftɚ/ /tə'mɔro/"
+  },
+  {
+    "chinese": "在这个时候",
+    "english": "at this time",
+    "soundmark": "/ət/ /ðɪs/ /taɪm/"
+  },
+  {
+    "chinese": "后天这个时候",
+    "english": "at this time the day after tomorrow",
+    "soundmark": "/ət/ /ðɪs/ /taɪm/ /ðə/ /de/ /'æftɚ/ /tə'mɔro/"
+  },
+  {
+    "chinese": "我将会在后天这个时候在公交车站正在为了我的朋友等待",
+    "english": "I will be waiting for my friend at the bus stop at this time the day after tomorrow",
+    "soundmark": "/aɪ/ /wɪl/ /bi/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/ /ət/ /ðə/ /bʌs/ /stɑp/ /ət/ /ðɪs/ /taɪm/ /ðə/ /de/ /'æftɚ/ /tə'mɔro/"
+  },
+  {
+    "chinese": "我将会为了我的朋友正在等待",
+    "english": "I will be waiting for my friend",
+    "soundmark": "/aɪ/ /wɪl/ /bi/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/"
+  },
+  {
+    "chinese": "他",
+    "english": "he",
+    "soundmark": "/hi/"
+  },
+  {
+    "chinese": "他将会为了我的朋友正在等待",
+    "english": "he will be waiting for my friend",
+    "soundmark": "/hi/ /wɪl/ /bi/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/"
+  },
+  {
+    "chinese": "他们",
+    "english": "they",
+    "soundmark": "/ðe/"
+  },
+  {
+    "chinese": "他们将会为了我的朋友正在等待",
+    "english": "they will be waiting for my friend",
+    "soundmark": "/ðe/ /wɪl/ /bi/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/"
+  },
+  {
+    "chinese": "我(现在)正在为了我的朋友等待",
+    "english": "I am waiting for my friend",
+    "soundmark": "/aɪ/ /æm/ /'wetɪŋ/ /fɝ/ /maɪ/ /frɛnd/"
+  },
+  {
+    "chinese": "我(现在)正在等待",
+    "english": "I am waiting",
+    "soundmark": "/aɪ/ /æm/ /'wetɪŋ/"
+  },
+  {
+    "chinese": "你",
+    "english": "you",
+    "soundmark": "/ju/"
+  },
+  {
+    "chinese": "为了",
+    "english": "for",
+    "soundmark": "/fɝ/"
+  },
+  {
+    "chinese": "为了你",
+    "english": "for you",
+    "soundmark": "/fɝ/ /ju/"
+  },
+  {
+    "chinese": "我(现在)正在为了你等待",
+    "english": "I am waiting for you",
+    "soundmark": "/aɪ/ /æm/ /'wetɪŋ/ /fɝ/ /ju/"
+  },
+  {
+    "chinese": "问",
+    "english": "to ask",
+    "soundmark": "/tə/ /æsk/"
+  },
+  {
+    "chinese": "我",
+    "english": "me",
+    "soundmark": "/mi/"
+  },
+  {
+    "chinese": "问我",
+    "english": "to ask me",
+    "soundmark": "/tə/ /æsk/ /mi/"
+  },
+  {
+    "chinese": "那个",
+    "english": "that",
+    "soundmark": "/ðæt/"
+  },
+  {
+    "chinese": "问题",
+    "english": "question",
+    "soundmark": "/'kwɛstʃən/"
+  },
+  {
+    "chinese": "那个问题",
+    "english": "that question",
+    "soundmark": "/ðæt/ /'kwɛstʃən/"
+  },
+  {
+    "chinese": "问我那个问题",
+    "english": "to ask me that question",
+    "soundmark": "/tə/ /æsk/ /mi/ /ðæt/ /'kwɛstʃən/"
+  },
+  {
+    "chinese": "我(现在)正在等你问我",
+    "english": "I am waiting for you to ask me",
+    "soundmark": "/aɪ/ /æm/ /'wetɪŋ/ /fɝ/ /ju/ /tə/ /æsk/ /mi/"
+  },
+  {
+    "chinese": "中文 原形 第三人称单数 过去式想要",
+    "english": "want wants",
+    "soundmark": "/wanted/"
+  },
+  {
+    "chinese": "喜欢",
+    "english": "like likes",
+    "soundmark": "/liked/"
+  },
+  {
+    "chinese": "有；(+to)不得不",
+    "english": "have has",
+    "soundmark": "/had/"
+  },
+  {
+    "chinese": "计划",
+    "english": "plan plans",
+    "soundmark": "/planned/"
+  },
+  {
+    "chinese": "需要",
+    "english": "need needs",
+    "soundmark": "/needed/"
+  },
+  {
+    "chinese": "做",
+    "english": "do does",
+    "soundmark": "/did/"
+  },
+  {
+    "chinese": "告诉",
+    "english": "tell tells",
+    "soundmark": "/told/"
+  },
+  {
+    "chinese": "说话",
+    "english": "talk talks",
+    "soundmark": "/talked/"
+  },
+  {
+    "chinese": "是 be（am）",
+    "english": "is",
+    "soundmark": "/was/"
+  },
+  {
+    "chinese": "是 be（is ）",
+    "english": "is",
+    "soundmark": "/was/"
+  },
+  {
+    "chinese": "是 be（are）",
+    "english": "is",
+    "soundmark": "/were/"
+  },
+  {
+    "chinese": "看到",
+    "english": "see sees",
+    "soundmark": "/saw/"
+  },
+  {
+    "chinese": "吃",
+    "english": "eat eats",
+    "soundmark": "/ate/"
+  },
+  {
+    "chinese": "喝",
+    "english": "drink drinks",
+    "soundmark": "/drank/"
+  },
+  {
+    "chinese": "知道",
+    "english": "know knows",
+    "soundmark": "/knew/"
+  },
+  {
+    "chinese": "忘记",
+    "english": "forget forgets",
+    "soundmark": "/forgot/"
+  },
+  {
+    "chinese": "失去",
+    "english": "lose loses",
+    "soundmark": "/lost/"
+  },
+  {
+    "chinese": "离开",
+    "english": "leave leaves",
+    "soundmark": "/left/"
+  },
+  {
+    "chinese": "睡觉",
+    "english": "sleep sleeps",
+    "soundmark": "/slept/"
+  },
+  {
+    "chinese": "明白",
+    "english": "understand understands",
+    "soundmark": "/understood/"
+  },
+  {
+    "chinese": "买",
+    "english": "buy buys",
+    "soundmark": "/bought/"
+  },
+  {
+    "chinese": "洗",
+    "english": "wash washes",
+    "soundmark": "/washed/"
+  },
+  {
+    "chinese": "打电话",
+    "english": "call calls",
+    "soundmark": "/called/"
+  },
+  {
+    "chinese": "帮助",
+    "english": "help helps",
+    "soundmark": "/helped/"
+  },
+  {
+    "chinese": "相信",
+    "english": "believe believes",
+    "soundmark": "/believed/"
+  },
+  {
+    "chinese": "学习",
+    "english": "study studies",
+    "soundmark": "/studied/"
+  },
+  {
+    "chinese": "解释",
+    "english": "explain explains",
+    "soundmark": "/explained/"
+  },
+  {
+    "chinese": "问",
+    "english": "ask asks",
+    "soundmark": "/asked/"
+  },
+  {
+    "chinese": "飞",
+    "english": "fly flies",
+    "soundmark": "/flew/"
+  },
+  {
+    "chinese": "问题",
+    "english": "that question",
+    "soundmark": "/ðæt/ /'kwɛstʃən/ /(I，过去时)be was/ /wəz/"
+  },
+  {
+    "chinese": "我(过去)正在等你问我那个问题",
+    "english": "I was waiting for you to ask me that question",
+    "soundmark": "/aɪ/ /wəz/ /'wetɪŋ/ /fɝ/ /ju/ /tə/ /æsk/ /mi/ /ðæt/ /'kwɛstʃən/"
+  },
+  {
+    "chinese": "将会",
+    "english": "will",
+    "soundmark": "/wɪl/"
+  },
+  {
+    "chinese": "我将会正在等你问我那个问题",
+    "english": "I will be waiting for you to ask me that question",
+    "soundmark": "/aɪ/ /wɪl/ /bi/ /'wetɪŋ/ /fɝ/ /ju/ /tə/ /æsk/ /mi/ /ðæt/ /'kwɛstʃən/"
+  },
+  {
+    "chinese": "阅读",
+    "english": "read reads",
+    "soundmark": "/read/"
+  },
+  {
+    "chinese": "走路",
+    "english": "walk walks",
+    "soundmark": "/walked/"
+  },
+  {
+    "chinese": "跳舞",
+    "english": "dance dances",
+    "soundmark": "/danced/"
+  },
+  {
+    "chinese": "回答",
+    "english": "answer answers",
+    "soundmark": "/answered/"
+  },
+  {
+    "chinese": "工作",
+    "english": "work works",
+    "soundmark": "/worked/"
+  },
+  {
+    "chinese": "待在",
+    "english": "stay stays",
+    "soundmark": "/stayed/"
+  },
+  {
+    "chinese": "支付",
+    "english": "pay pays",
+    "soundmark": "/paid/"
+  },
+  {
+    "chinese": "旅行",
+    "english": "travel travels",
+    "soundmark": "/traveled/"
+  },
+  {
+    "chinese": "给",
+    "english": "give gives",
+    "soundmark": "/gave/"
+  },
+  {
+    "chinese": "达到",
+    "english": "get gets",
+    "soundmark": "/got/"
+  },
+  {
+    "chinese": "锁",
+    "english": "lock locks",
+    "soundmark": "/locked/"
+  },
+  {
+    "chinese": "记得",
+    "english": "remember remembers",
+    "soundmark": "/Remembered/"
+  },
+  {
+    "chinese": "清理",
+    "english": "clean cleans",
+    "soundmark": "/cleaned/"
+  },
+  {
+    "chinese": "找到",
+    "english": "find finds",
+    "soundmark": "/found/"
+  },
+  {
+    "chinese": "关闭",
+    "english": "close closes",
+    "soundmark": "/closed/"
+  },
+  {
+    "chinese": "教",
+    "english": "teach teaches",
+    "soundmark": "/taught/"
+  },
+  {
+    "chinese": "展示",
+    "english": "show shows",
+    "soundmark": "/showed/"
+  },
+  {
+    "chinese": "让",
+    "english": "let lets",
+    "soundmark": "/let/"
+  },
+  {
+    "chinese": "休息",
+    "english": "rest rests",
+    "soundmark": "/rested/"
+  },
+  {
+    "chinese": "用",
+    "english": "use uses",
+    "soundmark": "/used/"
+  },
+  {
+    "chinese": "做饭",
+    "english": "cook cooks",
+    "soundmark": "/cooked/"
+  },
+  {
+    "chinese": "去",
+    "english": "go goes",
+    "soundmark": "/went/"
+  },
+  {
+    "chinese": "决定",
+    "english": "decide decides",
+    "soundmark": "/decided/"
+  },
+  {
+    "chinese": "驾驶",
+    "english": "drive drives",
+    "soundmark": "/drove/"
+  },
+  {
+    "chinese": "改变",
+    "english": "change changes",
+    "soundmark": "/changed/"
+  },
+  {
+    "chinese": "尝试",
+    "english": "try tries",
+    "soundmark": "/tried/"
+  },
+  {
+    "chinese": "停止",
+    "english": "stop stops",
+    "soundmark": "/Stopped/"
+  },
+  {
+    "chinese": "参加",
+    "english": "join joins",
+    "soundmark": "/joined/"
+  },
+  {
+    "chinese": "邀请",
+    "english": "invite invites",
+    "soundmark": "/invited/"
+  },
+  {
+    "chinese": "拒绝",
+    "english": "refuse refuses",
+    "soundmark": "/refused/"
+  },
+  {
+    "chinese": "接受",
+    "english": "accept accepts",
+    "soundmark": "/accepted/"
+  },
+  {
+    "chinese": "学习",
+    "english": "learn learns",
+    "soundmark": "/learnt/"
+  },
+  {
+    "chinese": "完成",
+    "english": "finish finishes",
+    "soundmark": "/finished/"
+  },
+  {
+    "chinese": "看",
+    "english": "watch watches",
+    "soundmark": "/watched/"
+  },
+  {
+    "chinese": "游泳",
+    "english": "swim swims",
+    "soundmark": "/swam/"
+  },
+  {
+    "chinese": "掌握",
+    "english": "master masters",
+    "soundmark": "/mastered/"
+  },
+  {
+    "chinese": "购物",
+    "english": "shop shops",
+    "soundmark": "/shopped/"
+  },
+  {
+    "chinese": "等待",
+    "english": "wait waits",
+    "soundmark": "/waited/"
+  }
 ]

--- a/scripts/courses/19.json
+++ b/scripts/courses/19.json
@@ -1,702 +1,702 @@
 [
-	{
-		"chinese": "这个问题",
-		"english": "the question",
-		"soundmark": "/ðə/ /'kwɛstʃən/"
-	},
-	{
-		"chinese": "回答",
-		"english": "to answer",
-		"soundmark": "/tə/ /'ænsɚ/"
-	},
-	{
-		"chinese": "回答这个问题",
-		"english": "to answer the question",
-		"soundmark": "/tə/ /'ænsɚ/ /ðə/ /'kwɛstʃən/"
-	},
-	{
-		"chinese": "这个问题；这个麻烦",
-		"english": "the problem",
-		"soundmark": "/ðə/ /'prɑbləm/"
-	},
-	{
-		"chinese": "解决",
-		"english": "to solve",
-		"soundmark": "/tə/ /sɑlv/"
-	},
-	{
-		"chinese": "解决这个问题",
-		"english": "to solve the problem",
-		"soundmark": "/tə/ /sɑlv/ /ðə/ /'prɑbləm/"
-	},
-	{
-		"chinese": "需要",
-		"english": "need",
-		"soundmark": "/nid/"
-	},
-	{
-		"chinese": "我们需要",
-		"english": "we need",
-		"soundmark": "/wi/ /nid/"
-	},
-	{
-		"chinese": "解决这个麻烦",
-		"english": "to solve the problem",
-		"soundmark": "/tə/ /sɑlv/ /ðə/ /'prɑbləm/"
-	},
-	{
-		"chinese": "我们需要解决这个麻烦",
-		"english": "we need to solve the problem",
-		"soundmark": "/wi/ /nid/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/"
-	},
-	{
-		"chinese": "一起",
-		"english": "together",
-		"soundmark": "/tə'ɡɛðɚ/"
-	},
-	{
-		"chinese": "我们需要一起解决这个麻烦",
-		"english": "we need to solve the problem together",
-		"soundmark": "/wi/ /nid/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
-	},
-	{
-		"chinese": "不需要",
-		"english": "don't need",
-		"soundmark": "/dont/ /nid/"
-	},
-	{
-		"chinese": "我们不需要一起解决这个麻烦",
-		"english": "we don't need to solve the problem together",
-		"soundmark": "/wi/ /dont/ /nid/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
-	},
-	{
-		"chinese": "可以",
-		"english": "can",
-		"soundmark": "/kən/"
-	},
-	{
-		"chinese": "我们可以一起解决这个麻烦",
-		"english": "we can solve the problem together",
-		"soundmark": "/wi/ /kən/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
-	},
-	{
-		"chinese": "我们不可以一起解决这个麻烦",
-		"english": "we can not solve the problem together",
-		"soundmark": "/wi/ /kən/ /nɑt/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
-	},
-	{
-		"chinese": "将会",
-		"english": "will",
-		"soundmark": "/wɪl/"
-	},
-	{
-		"chinese": "我们将会一起解决这个麻烦",
-		"english": "we will solve the problem together",
-		"soundmark": "/wi/ /wɪl/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
-	},
-	{
-		"chinese": "我们将不会一起解决这个麻烦",
-		"english": "we will not solve the problem together",
-		"soundmark": "/wi/ /wɪl/ /nɑt/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
-	},
-	{
-		"chinese": "尝试",
-		"english": "to try",
-		"soundmark": "/tə/ /traɪ/"
-	},
-	{
-		"chinese": "解决这个麻烦",
-		"english": "to solve the problem",
-		"soundmark": "/tə/ /sɑlv/ /ðə/ /'prɑbləm/"
-	},
-	{
-		"chinese": "我们尝试解决这个麻烦",
-		"english": "we try to solve the problem",
-		"soundmark": "/wi/ /traɪ/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/"
-	},
-	{
-		"chinese": "一起",
-		"english": "together",
-		"soundmark": "/tə'ɡɛðɚ/"
-	},
-	{
-		"chinese": "我们尝试一起解决这个麻烦",
-		"english": "we try to solve the problem together",
-		"soundmark": "/wi/ /traɪ/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
-	},
-	{
-		"chinese": "尝试(ing形式)",
-		"english": "trying",
-		"soundmark": "/'traɪɪŋ/"
-	},
-	{
-		"chinese": "是；赋值(原型)",
-		"english": "be",
-		"soundmark": "/bi/"
-	},
-	{
-		"chinese": "正在尝试",
-		"english": "be trying",
-		"soundmark": "/bi/ /'traɪɪŋ/"
-	},
-	{
-		"chinese": "我们",
-		"english": "we",
-		"soundmark": "/wi/ /(we，现在时)be are/ /ɚ/"
-	},
-	{
-		"chinese": "我们(现在)正在尝试",
-		"english": "we are trying",
-		"soundmark": "/wi/ /ɚ/ /'traɪɪŋ/"
-	},
-	{
-		"chinese": "解决这个麻烦",
-		"english": "to solve the problem",
-		"soundmark": "/tə/ /sɑlv/ /ðə/ /'prɑbləm/"
-	},
-	{
-		"chinese": "我们(现在)正在尝试解决这个麻烦",
-		"english": "we are trying to solve the problem",
-		"soundmark": "/wi/ /ɚ/ /'traɪɪŋ/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/"
-	},
-	{
-		"chinese": "一起",
-		"english": "together",
-		"soundmark": "/tə'ɡɛðɚ/"
-	},
-	{
-		"chinese": "我们(现在)正在尝试一起解决这个麻烦",
-		"english": "we are trying to solve the problem together",
-		"soundmark": "/wi/ /ɚ/ /'traɪɪŋ/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
-	},
-	{
-		"chinese": "脸",
-		"english": "face",
-		"soundmark": "/fes/"
-	},
-	{
-		"chinese": "面对",
-		"english": "to face",
-		"soundmark": "/tə/ /fes/"
-	},
-	{
-		"chinese": "我",
-		"english": "me",
-		"soundmark": "/mi/"
-	},
-	{
-		"chinese": "面对我",
-		"english": "to face me",
-		"soundmark": "/tə/ /fes/ /mi/"
-	},
-	{
-		"chinese": "真相；现实",
-		"english": "the truth",
-		"soundmark": "/ðə/ /trʊθ/"
-	},
-	{
-		"chinese": "面对现实",
-		"english": "to face the truth",
-		"soundmark": "/tə/ /fes/ /ðə/ /trʊθ/"
-	},
-	{
-		"chinese": "需要",
-		"english": "need",
-		"soundmark": "/nid/"
-	},
-	{
-		"chinese": "你需要面对现实",
-		"english": "you need to face the truth",
-		"soundmark": "/ju/ /nid/ /tə/ /fes/ /ðə/ /trʊθ/"
-	},
-	{
-		"chinese": "这个麻烦",
-		"english": "the problem",
-		"soundmark": "/ðə/ /'prɑbləm/"
-	},
-	{
-		"chinese": "面对这个麻烦",
-		"english": "to face the problem",
-		"soundmark": "/tə/ /fes/ /ðə/ /'prɑbləm/"
-	},
-	{
-		"chinese": "我们需要",
-		"english": "we need",
-		"soundmark": "/wi/ /nid/"
-	},
-	{
-		"chinese": "我们需要面对这个麻烦",
-		"english": "we need to face the problem",
-		"soundmark": "/wi/ /nid/ /tə/ /fes/ /ðə/ /'prɑbləm/"
-	},
-	{
-		"chinese": "我们面对这个麻烦",
-		"english": "we face the problem",
-		"soundmark": "/wi/ /fes/ /ðə/ /'prɑbləm/"
-	},
-	{
-		"chinese": "面对(ing形式)",
-		"english": "facing",
-		"soundmark": "/'fesɪŋ/"
-	},
-	{
-		"chinese": "是；赋值(原型)",
-		"english": "be",
-		"soundmark": "/bi/"
-	},
-	{
-		"chinese": "正在面对",
-		"english": "be facing",
-		"soundmark": "/bi/ /'fesɪŋ/"
-	},
-	{
-		"chinese": "我们",
-		"english": "we",
-		"soundmark": "/wi/ /(we，现在时)be are/ /ɚ/"
-	},
-	{
-		"chinese": "我们(现在)正在面对",
-		"english": "we are facing",
-		"soundmark": "/wi/ /ɚ/ /'fesɪŋ/"
-	},
-	{
-		"chinese": "一个",
-		"english": "a",
-		"soundmark": "/ə/"
-	},
-	{
-		"chinese": "一个麻烦",
-		"english": "a problem",
-		"soundmark": "/ə/ /'prɑbləm/"
-	},
-	{
-		"chinese": "大的",
-		"english": "big",
-		"soundmark": "/bɪɡ/"
-	},
-	{
-		"chinese": "一个大麻烦",
-		"english": "a big problem",
-		"soundmark": "/ə/ /bɪɡ/ /'prɑbləm/"
-	},
-	{
-		"chinese": "我们(现在)正在面对一个大麻烦",
-		"english": "we are facing a big problem",
-		"soundmark": "/wi/ /ɚ/ /'fesɪŋ/ /ə/ /bɪɡ/ /'prɑbləm/"
-	},
-	{
-		"chinese": "这个麻烦",
-		"english": "the problem",
-		"soundmark": "/ðə/ /'prɑbləm/"
-	},
-	{
-		"chinese": "解决",
-		"english": "to solve",
-		"soundmark": "/tə/ /sɑlv/"
-	},
-	{
-		"chinese": "解决这个麻烦",
-		"english": "to solve the problem",
-		"soundmark": "/tə/ /sɑlv/ /ðə/ /'prɑbləm/"
-	},
-	{
-		"chinese": "尝试",
-		"english": "to try",
-		"soundmark": "/tə/ /traɪ/"
-	},
-	{
-		"chinese": "我尝试解决这个麻烦",
-		"english": "I try to solve the problem",
-		"soundmark": "/aɪ/ /traɪ/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/"
-	},
-	{
-		"chinese": "尝试(ing形式)",
-		"english": "trying",
-		"soundmark": "/'traɪɪŋ/"
-	},
-	{
-		"chinese": "是；赋值(原型)",
-		"english": "be",
-		"soundmark": "/bi/"
-	},
-	{
-		"chinese": "正在尝试",
-		"english": "be trying",
-		"soundmark": "/bi/ /'traɪɪŋ/"
-	},
-	{
-		"chinese": "我",
-		"english": "I",
-		"soundmark": "/aɪ/ /(I，现在时)be am/ /æm/"
-	},
-	{
-		"chinese": "我(现在)正在尝试",
-		"english": "I am trying",
-		"soundmark": "/aɪ/ /æm/ /'traɪɪŋ/"
-	},
-	{
-		"chinese": "解决这个麻烦",
-		"english": "to solve the problem",
-		"soundmark": "/tə/ /sɑlv/ /ðə/ /'prɑbləm/"
-	},
-	{
-		"chinese": "我(现在)正在尝试解决这个麻烦",
-		"english": "I am trying to solve the problem",
-		"soundmark": "/aɪ/ /æm/ /'traɪɪŋ/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/"
-	},
-	{
-		"chinese": "面对(ing形式)",
-		"english": "facing",
-		"soundmark": "/'fesɪŋ/"
-	},
-	{
-		"chinese": "是；赋值(原型)",
-		"english": "be",
-		"soundmark": "/bi/"
-	},
-	{
-		"chinese": "正在面对",
-		"english": "be facing",
-		"soundmark": "/bi/ /'fesɪŋ/"
-	},
-	{
-		"chinese": "我们",
-		"english": "we",
-		"soundmark": "/wi/ /(we，现在时)be are/ /ɚ/"
-	},
-	{
-		"chinese": "我们(现在)正在面对",
-		"english": "we are facing",
-		"soundmark": "/wi/ /ɚ/ /'fesɪŋ/"
-	},
-	{
-		"chinese": "这个麻烦",
-		"english": "the problem",
-		"soundmark": "/ðə/ /'prɑbləm/"
-	},
-	{
-		"chinese": "我们(现在)正在面对的这个麻烦",
-		"english": "the problem we are facing",
-		"soundmark": "/ðə/ /'prɑbləm/ /wi/ /ɚ/ /'fesɪŋ/"
-	},
-	{
-		"chinese": "我(现在)正在尝试解决这个麻烦",
-		"english": "I am trying to solve the problem",
-		"soundmark": "/aɪ/ /æm/ /'traɪɪŋ/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/"
-	},
-	{
-		"chinese": "我(现在)正在尝试解决我们",
-		"english": "(现在)正在面对的这个麻烦 I am trying to solve the problem we are facing",
-		"soundmark": "/aɪ/ /æm/ /'traɪɪŋ/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/ /wi/ /ɚ/ /'fesɪŋ/"
-	},
-	{
-		"chinese": "现在",
-		"english": "now",
-		"soundmark": "/naʊ/"
-	},
-	{
-		"chinese": "我(现在)正在尝试解决我们现在正在面对的这个麻烦",
-		"english": "I am trying to solve the problem we are facing now",
-		"soundmark": "/aɪ/ /æm/ /'traɪɪŋ/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/ /wi/ /ɚ/ /'fesɪŋ/ /naʊ/"
-	},
-	{
-		"chinese": "解决这个麻烦",
-		"english": "to solve the problem",
-		"soundmark": "/tə/ /sɑlv/ /ðə/ /'prɑbləm/"
-	},
-	{
-		"chinese": "我解决这个麻烦",
-		"english": "I solve the problem",
-		"soundmark": "/aɪ/ /sɑlv/ /ðə/ /'prɑbləm/"
-	},
-	{
-		"chinese": "解决(ing形式)",
-		"english": "solving",
-		"soundmark": "/sɑlvɪŋ/"
-	},
-	{
-		"chinese": "是；赋值(原型)",
-		"english": "be",
-		"soundmark": "/bi/"
-	},
-	{
-		"chinese": "正在解决",
-		"english": "be solving",
-		"soundmark": "/bi/ /sɑlvɪŋ/"
-	},
-	{
-		"chinese": "我(现在)正在解决",
-		"english": "I am solving",
-		"soundmark": "/aɪ/ /æm/ /sɑlvɪŋ/"
-	},
-	{
-		"chinese": "这个麻烦",
-		"english": "the problem",
-		"soundmark": "/ðə/ /'prɑbləm/"
-	},
-	{
-		"chinese": "我(现在)正在解决这个麻烦",
-		"english": "I am solving the problem",
-		"soundmark": "/aɪ/ /æm/ /sɑlvɪŋ/ /ðə/ /'prɑbləm/"
-	},
-	{
-		"chinese": "我们(现在)正在面对",
-		"english": "we are facing",
-		"soundmark": "/wi/ /ɚ/ /'fesɪŋ/"
-	},
-	{
-		"chinese": "我们(现在)正在面对的这个麻烦",
-		"english": "the problem we are facing",
-		"soundmark": "/ðə/ /'prɑbləm/ /wi/ /ɚ/ /'fesɪŋ/"
-	},
-	{
-		"chinese": "我(现在)正在解决我们(现在)正在面对的这个麻烦",
-		"english": "I am solving the problem we are facing",
-		"soundmark": "/aɪ/ /æm/ /sɑlvɪŋ/ /ðə/ /'prɑbləm/ /wi/ /ɚ/ /'fesɪŋ/"
-	},
-	{
-		"chinese": "现在",
-		"english": "now",
-		"soundmark": "/naʊ/"
-	},
-	{
-		"chinese": "我(现在)正在解决我们现在正在面对的这个麻烦",
-		"english": "I am solving the problem we are facing now",
-		"soundmark": "/aɪ/ /æm/ /sɑlvɪŋ/ /ðə/ /'prɑbləm/ /wi/ /ɚ/ /'fesɪŋ/ /naʊ/"
-	},
-	{
-		"chinese": "疑惑",
-		"english": "to wonder",
-		"soundmark": "/tə/ /'wʌndɚ/"
-	},
-	{
-		"chinese": "我疑惑",
-		"english": "I wonder",
-		"soundmark": "/aɪ/ /'wʌndɚ/"
-	},
-	{
-		"chinese": "一起解决这个麻烦",
-		"english": "to solve the problem together",
-		"soundmark": "/tə/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
-	},
-	{
-		"chinese": "我们可以",
-		"english": "we can",
-		"soundmark": "/wi/ /kən/"
-	},
-	{
-		"chinese": "我们可以一起解决这个麻烦",
-		"english": "we can solve the problem together",
-		"soundmark": "/wi/ /kən/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
-	},
-	{
-		"chinese": "是否",
-		"english": "if",
-		"soundmark": "/ɪf/"
-	},
-	{
-		"chinese": "是否我们可以一起解决这个麻烦",
-		"english": "if we can solve the problem together",
-		"soundmark": "/ɪf/ /wi/ /kən/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
-	},
-	{
-		"chinese": "我疑惑",
-		"english": "I wonder",
-		"soundmark": "/aɪ/ /'wʌndɚ/"
-	},
-	{
-		"chinese": "我疑惑是否我们可以一起解决这个麻烦",
-		"english": "I wonder if we can solve the problem together",
-		"soundmark": "/aɪ/ /'wʌndɚ/ /ɪf/ /wi/ /kən/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
-	},
-	{
-		"chinese": "一起解决这个麻烦",
-		"english": "to solve the problem together",
-		"soundmark": "/tə/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
-	},
-	{
-		"chinese": "我们需要",
-		"english": "we need",
-		"soundmark": "/wi/ /nid/"
-	},
-	{
-		"chinese": "我们需要一起解决这个麻烦",
-		"english": "we need to solve the problem together",
-		"soundmark": "/wi/ /nid/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
-	},
-	{
-		"chinese": "为什么",
-		"english": "why",
-		"soundmark": "/waɪ/"
-	},
-	{
-		"chinese": "为什么我们需要一起解决这个麻烦",
-		"english": "why we need to solve the problem together",
-		"soundmark": "/waɪ/ /wi/ /nid/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
-	},
-	{
-		"chinese": "我疑惑",
-		"english": "I wonder",
-		"soundmark": "/aɪ/ /'wʌndɚ/"
-	},
-	{
-		"chinese": "我疑惑为什么我们需要一起解决这个麻烦",
-		"english": "I wonder why we need to solve the problem together",
-		"soundmark": "/aɪ/ /'wʌndɚ/ /waɪ/ /wi/ /nid/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
-	},
-	{
-		"chinese": "他",
-		"english": "he",
-		"soundmark": "/hi/"
-	},
-	{
-		"chinese": "他疑惑",
-		"english": "he wonders",
-		"soundmark": "/hi/ /'wʌndɚz/"
-	},
-	{
-		"chinese": "一起解决这个麻烦",
-		"english": "to solve the problem together",
-		"soundmark": "/tə/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
-	},
-	{
-		"chinese": "我们将会",
-		"english": "we will",
-		"soundmark": "/wi/ /wɪl/"
-	},
-	{
-		"chinese": "我们将会一起解决这个麻烦",
-		"english": "we will solve the problem together",
-		"soundmark": "/wi/ /wɪl/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
-	},
-	{
-		"chinese": "在什么时候",
-		"english": "when",
-		"soundmark": "/wɛn/"
-	},
-	{
-		"chinese": "我们将会在什么时候一起解决这个麻烦",
-		"english": "when we will solve the problem together",
-		"soundmark": "/wɛn/ /wi/ /wɪl/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
-	},
-	{
-		"chinese": "他疑惑我们将会在什么时候一起解决这个麻烦",
-		"english": "he wonders when we will solve the problem together",
-		"soundmark": "/hi/ /'wʌndɚz/ /wɛn/ /wi/ /wɪl/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
-	},
-	{
-		"chinese": "如何",
-		"english": "how",
-		"soundmark": "/haʊ/"
-	},
-	{
-		"chinese": "我们将会如何一起解决这个问题",
-		"english": "how we will solve the problem together",
-		"soundmark": "/haʊ/ /wi/ /wɪl/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
-	},
-	{
-		"chinese": "他疑惑我们将会如何一起解决这个麻烦",
-		"english": "he wonders how we will solve the problem together",
-		"soundmark": "/hi/ /'wʌndɚz/ /haʊ/ /wi/ /wɪl/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
-	},
-	{
-		"chinese": "疑惑(ing形式)",
-		"english": "wondering",
-		"soundmark": "/'wʌndərɪŋ/"
-	},
-	{
-		"chinese": "是；赋值(原型)",
-		"english": "be",
-		"soundmark": "/bi/"
-	},
-	{
-		"chinese": "正在疑惑",
-		"english": "be wondering",
-		"soundmark": "/bi/ /'wʌndərɪŋ/ /(I，过去时)be was/ /wəz/"
-	},
-	{
-		"chinese": "我(过去)正在疑惑",
-		"english": "I was wondering",
-		"soundmark": "/aɪ/ /wəz/ /'wʌndərɪŋ/"
-	},
-	{
-		"chinese": "是否我们可以一起解决这个麻烦",
-		"english": "if we can solve the problem together",
-		"soundmark": "/ɪf/ /wi/ /kən/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
-	},
-	{
-		"chinese": "我(过去)正在疑惑是否我们可以一起解决这个麻烦",
-		"english": "I was wondering if we can solve the problem together",
-		"soundmark": "/aɪ/ /wəz/ /'wʌndərɪŋ/ /ɪf/ /wi/ /kən/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
-	},
-	{
-		"chinese": "我(过去)正在疑惑",
-		"english": "I was wondering",
-		"soundmark": "/aɪ/ /wəz/ /'wʌndərɪŋ/"
-	},
-	{
-		"chinese": "为什么我们需要一起解决这个麻烦",
-		"english": "why we need to solve the problem together",
-		"soundmark": "/waɪ/ /wi/ /nid/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
-	},
-	{
-		"chinese": "我(过去)正在疑惑为什么我们需要一起解决这个麻烦",
-		"english": "I was wondering why we need to solve the problem together",
-		"soundmark": "/aɪ/ /wəz/ /'wʌndərɪŋ/ /waɪ/ /wi/ /nid/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
-	},
-	{
-		"chinese": "疑惑(ing形式)",
-		"english": "wondering",
-		"soundmark": "/'wʌndərɪŋ/"
-	},
-	{
-		"chinese": "是；赋值(原型)",
-		"english": "be",
-		"soundmark": "/bi/"
-	},
-	{
-		"chinese": "正在疑惑",
-		"english": "be wondering",
-		"soundmark": "/bi/ /'wʌndərɪŋ/"
-	},
-	{
-		"chinese": "他",
-		"english": "he",
-		"soundmark": "/hi/ /(he，现在时)be is/ /ɪz/"
-	},
-	{
-		"chinese": "他(现在)正在疑惑",
-		"english": "he is wondering",
-		"soundmark": "/hi/ /ɪz/ /'wʌndərɪŋ/"
-	},
-	{
-		"chinese": "我们将会在什么时候一起解决这个麻烦",
-		"english": "when we will solve the problem together",
-		"soundmark": "/wɛn/ /wi/ /wɪl/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
-	},
-	{
-		"chinese": "他(现在)正在疑惑我们将会在什么时候一起解决这个麻烦",
-		"english": "he is wondering when we will solve the problem together",
-		"soundmark": "/hi/ /ɪz/ /'wʌndərɪŋ/ /wɛn/ /wi/ /wɪl/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
-	},
-	{
-		"chinese": "如何",
-		"english": "how",
-		"soundmark": "/haʊ/"
-	},
-	{
-		"chinese": "我们将会如何一起解决这个问题",
-		"english": "how we will solve the problem together",
-		"soundmark": "/haʊ/ /wi/ /wɪl/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
-	},
-	{
-		"chinese": "他(现在)正在疑惑",
-		"english": "he is wondering",
-		"soundmark": "/hi/ /ɪz/ /'wʌndərɪŋ/"
-	},
-	{
-		"chinese": "他(现在)正在疑惑我们将会如何一起解决这个问题",
-		"english": "he is wondering how we will solve the problem together",
-		"soundmark": "/hi/ /ɪz/ /'wʌndərɪŋ/ /haʊ/ /wi/ /wɪl/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
-	}
+  {
+    "chinese": "这个问题",
+    "english": "the question",
+    "soundmark": "/ðə/ /'kwɛstʃən/"
+  },
+  {
+    "chinese": "回答",
+    "english": "to answer",
+    "soundmark": "/tə/ /'ænsɚ/"
+  },
+  {
+    "chinese": "回答这个问题",
+    "english": "to answer the question",
+    "soundmark": "/tə/ /'ænsɚ/ /ðə/ /'kwɛstʃən/"
+  },
+  {
+    "chinese": "这个问题；这个麻烦",
+    "english": "the problem",
+    "soundmark": "/ðə/ /'prɑbləm/"
+  },
+  {
+    "chinese": "解决",
+    "english": "to solve",
+    "soundmark": "/tə/ /sɑlv/"
+  },
+  {
+    "chinese": "解决这个问题",
+    "english": "to solve the problem",
+    "soundmark": "/tə/ /sɑlv/ /ðə/ /'prɑbləm/"
+  },
+  {
+    "chinese": "需要",
+    "english": "need",
+    "soundmark": "/nid/"
+  },
+  {
+    "chinese": "我们需要",
+    "english": "we need",
+    "soundmark": "/wi/ /nid/"
+  },
+  {
+    "chinese": "解决这个麻烦",
+    "english": "to solve the problem",
+    "soundmark": "/tə/ /sɑlv/ /ðə/ /'prɑbləm/"
+  },
+  {
+    "chinese": "我们需要解决这个麻烦",
+    "english": "we need to solve the problem",
+    "soundmark": "/wi/ /nid/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/"
+  },
+  {
+    "chinese": "一起",
+    "english": "together",
+    "soundmark": "/tə'ɡɛðɚ/"
+  },
+  {
+    "chinese": "我们需要一起解决这个麻烦",
+    "english": "we need to solve the problem together",
+    "soundmark": "/wi/ /nid/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
+  },
+  {
+    "chinese": "不需要",
+    "english": "don't need",
+    "soundmark": "/dont/ /nid/"
+  },
+  {
+    "chinese": "我们不需要一起解决这个麻烦",
+    "english": "we don't need to solve the problem together",
+    "soundmark": "/wi/ /dont/ /nid/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
+  },
+  {
+    "chinese": "可以",
+    "english": "can",
+    "soundmark": "/kən/"
+  },
+  {
+    "chinese": "我们可以一起解决这个麻烦",
+    "english": "we can solve the problem together",
+    "soundmark": "/wi/ /kən/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
+  },
+  {
+    "chinese": "我们不可以一起解决这个麻烦",
+    "english": "we can not solve the problem together",
+    "soundmark": "/wi/ /kən/ /nɑt/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
+  },
+  {
+    "chinese": "将会",
+    "english": "will",
+    "soundmark": "/wɪl/"
+  },
+  {
+    "chinese": "我们将会一起解决这个麻烦",
+    "english": "we will solve the problem together",
+    "soundmark": "/wi/ /wɪl/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
+  },
+  {
+    "chinese": "我们将不会一起解决这个麻烦",
+    "english": "we will not solve the problem together",
+    "soundmark": "/wi/ /wɪl/ /nɑt/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
+  },
+  {
+    "chinese": "尝试",
+    "english": "to try",
+    "soundmark": "/tə/ /traɪ/"
+  },
+  {
+    "chinese": "解决这个麻烦",
+    "english": "to solve the problem",
+    "soundmark": "/tə/ /sɑlv/ /ðə/ /'prɑbləm/"
+  },
+  {
+    "chinese": "我们尝试解决这个麻烦",
+    "english": "we try to solve the problem",
+    "soundmark": "/wi/ /traɪ/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/"
+  },
+  {
+    "chinese": "一起",
+    "english": "together",
+    "soundmark": "/tə'ɡɛðɚ/"
+  },
+  {
+    "chinese": "我们尝试一起解决这个麻烦",
+    "english": "we try to solve the problem together",
+    "soundmark": "/wi/ /traɪ/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
+  },
+  {
+    "chinese": "尝试(ing形式)",
+    "english": "trying",
+    "soundmark": "/'traɪɪŋ/"
+  },
+  {
+    "chinese": "是；赋值(原型)",
+    "english": "be",
+    "soundmark": "/bi/"
+  },
+  {
+    "chinese": "正在尝试",
+    "english": "be trying",
+    "soundmark": "/bi/ /'traɪɪŋ/"
+  },
+  {
+    "chinese": "我们",
+    "english": "we",
+    "soundmark": "/wi/ /(we，现在时)be are/ /ɚ/"
+  },
+  {
+    "chinese": "我们(现在)正在尝试",
+    "english": "we are trying",
+    "soundmark": "/wi/ /ɚ/ /'traɪɪŋ/"
+  },
+  {
+    "chinese": "解决这个麻烦",
+    "english": "to solve the problem",
+    "soundmark": "/tə/ /sɑlv/ /ðə/ /'prɑbləm/"
+  },
+  {
+    "chinese": "我们(现在)正在尝试解决这个麻烦",
+    "english": "we are trying to solve the problem",
+    "soundmark": "/wi/ /ɚ/ /'traɪɪŋ/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/"
+  },
+  {
+    "chinese": "一起",
+    "english": "together",
+    "soundmark": "/tə'ɡɛðɚ/"
+  },
+  {
+    "chinese": "我们(现在)正在尝试一起解决这个麻烦",
+    "english": "we are trying to solve the problem together",
+    "soundmark": "/wi/ /ɚ/ /'traɪɪŋ/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
+  },
+  {
+    "chinese": "脸",
+    "english": "face",
+    "soundmark": "/fes/"
+  },
+  {
+    "chinese": "面对",
+    "english": "to face",
+    "soundmark": "/tə/ /fes/"
+  },
+  {
+    "chinese": "我",
+    "english": "me",
+    "soundmark": "/mi/"
+  },
+  {
+    "chinese": "面对我",
+    "english": "to face me",
+    "soundmark": "/tə/ /fes/ /mi/"
+  },
+  {
+    "chinese": "真相；现实",
+    "english": "the truth",
+    "soundmark": "/ðə/ /trʊθ/"
+  },
+  {
+    "chinese": "面对现实",
+    "english": "to face the truth",
+    "soundmark": "/tə/ /fes/ /ðə/ /trʊθ/"
+  },
+  {
+    "chinese": "需要",
+    "english": "need",
+    "soundmark": "/nid/"
+  },
+  {
+    "chinese": "你需要面对现实",
+    "english": "you need to face the truth",
+    "soundmark": "/ju/ /nid/ /tə/ /fes/ /ðə/ /trʊθ/"
+  },
+  {
+    "chinese": "这个麻烦",
+    "english": "the problem",
+    "soundmark": "/ðə/ /'prɑbləm/"
+  },
+  {
+    "chinese": "面对这个麻烦",
+    "english": "to face the problem",
+    "soundmark": "/tə/ /fes/ /ðə/ /'prɑbləm/"
+  },
+  {
+    "chinese": "我们需要",
+    "english": "we need",
+    "soundmark": "/wi/ /nid/"
+  },
+  {
+    "chinese": "我们需要面对这个麻烦",
+    "english": "we need to face the problem",
+    "soundmark": "/wi/ /nid/ /tə/ /fes/ /ðə/ /'prɑbləm/"
+  },
+  {
+    "chinese": "我们面对这个麻烦",
+    "english": "we face the problem",
+    "soundmark": "/wi/ /fes/ /ðə/ /'prɑbləm/"
+  },
+  {
+    "chinese": "面对(ing形式)",
+    "english": "facing",
+    "soundmark": "/'fesɪŋ/"
+  },
+  {
+    "chinese": "是；赋值(原型)",
+    "english": "be",
+    "soundmark": "/bi/"
+  },
+  {
+    "chinese": "正在面对",
+    "english": "be facing",
+    "soundmark": "/bi/ /'fesɪŋ/"
+  },
+  {
+    "chinese": "我们",
+    "english": "we",
+    "soundmark": "/wi/ /(we，现在时)be are/ /ɚ/"
+  },
+  {
+    "chinese": "我们(现在)正在面对",
+    "english": "we are facing",
+    "soundmark": "/wi/ /ɚ/ /'fesɪŋ/"
+  },
+  {
+    "chinese": "一个",
+    "english": "a",
+    "soundmark": "/ə/"
+  },
+  {
+    "chinese": "一个麻烦",
+    "english": "a problem",
+    "soundmark": "/ə/ /'prɑbləm/"
+  },
+  {
+    "chinese": "大的",
+    "english": "big",
+    "soundmark": "/bɪɡ/"
+  },
+  {
+    "chinese": "一个大麻烦",
+    "english": "a big problem",
+    "soundmark": "/ə/ /bɪɡ/ /'prɑbləm/"
+  },
+  {
+    "chinese": "我们(现在)正在面对一个大麻烦",
+    "english": "we are facing a big problem",
+    "soundmark": "/wi/ /ɚ/ /'fesɪŋ/ /ə/ /bɪɡ/ /'prɑbləm/"
+  },
+  {
+    "chinese": "这个麻烦",
+    "english": "the problem",
+    "soundmark": "/ðə/ /'prɑbləm/"
+  },
+  {
+    "chinese": "解决",
+    "english": "to solve",
+    "soundmark": "/tə/ /sɑlv/"
+  },
+  {
+    "chinese": "解决这个麻烦",
+    "english": "to solve the problem",
+    "soundmark": "/tə/ /sɑlv/ /ðə/ /'prɑbləm/"
+  },
+  {
+    "chinese": "尝试",
+    "english": "to try",
+    "soundmark": "/tə/ /traɪ/"
+  },
+  {
+    "chinese": "我尝试解决这个麻烦",
+    "english": "I try to solve the problem",
+    "soundmark": "/aɪ/ /traɪ/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/"
+  },
+  {
+    "chinese": "尝试(ing形式)",
+    "english": "trying",
+    "soundmark": "/'traɪɪŋ/"
+  },
+  {
+    "chinese": "是；赋值(原型)",
+    "english": "be",
+    "soundmark": "/bi/"
+  },
+  {
+    "chinese": "正在尝试",
+    "english": "be trying",
+    "soundmark": "/bi/ /'traɪɪŋ/"
+  },
+  {
+    "chinese": "我",
+    "english": "I",
+    "soundmark": "/aɪ/ /(I，现在时)be am/ /æm/"
+  },
+  {
+    "chinese": "我(现在)正在尝试",
+    "english": "I am trying",
+    "soundmark": "/aɪ/ /æm/ /'traɪɪŋ/"
+  },
+  {
+    "chinese": "解决这个麻烦",
+    "english": "to solve the problem",
+    "soundmark": "/tə/ /sɑlv/ /ðə/ /'prɑbləm/"
+  },
+  {
+    "chinese": "我(现在)正在尝试解决这个麻烦",
+    "english": "I am trying to solve the problem",
+    "soundmark": "/aɪ/ /æm/ /'traɪɪŋ/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/"
+  },
+  {
+    "chinese": "面对(ing形式)",
+    "english": "facing",
+    "soundmark": "/'fesɪŋ/"
+  },
+  {
+    "chinese": "是；赋值(原型)",
+    "english": "be",
+    "soundmark": "/bi/"
+  },
+  {
+    "chinese": "正在面对",
+    "english": "be facing",
+    "soundmark": "/bi/ /'fesɪŋ/"
+  },
+  {
+    "chinese": "我们",
+    "english": "we",
+    "soundmark": "/wi/ /(we，现在时)be are/ /ɚ/"
+  },
+  {
+    "chinese": "我们(现在)正在面对",
+    "english": "we are facing",
+    "soundmark": "/wi/ /ɚ/ /'fesɪŋ/"
+  },
+  {
+    "chinese": "这个麻烦",
+    "english": "the problem",
+    "soundmark": "/ðə/ /'prɑbləm/"
+  },
+  {
+    "chinese": "我们(现在)正在面对的这个麻烦",
+    "english": "the problem we are facing",
+    "soundmark": "/ðə/ /'prɑbləm/ /wi/ /ɚ/ /'fesɪŋ/"
+  },
+  {
+    "chinese": "我(现在)正在尝试解决这个麻烦",
+    "english": "I am trying to solve the problem",
+    "soundmark": "/aɪ/ /æm/ /'traɪɪŋ/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/"
+  },
+  {
+    "chinese": "我(现在)正在尝试解决我们面对的这个麻烦",
+    "english": "I am trying to solve the problem we are facing",
+    "soundmark": "/aɪ/ /æm/ /'traɪɪŋ/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/ /wi/ /ɚ/ /'fesɪŋ/"
+  },
+  {
+    "chinese": "现在",
+    "english": "now",
+    "soundmark": "/naʊ/"
+  },
+  {
+    "chinese": "我(现在)正在尝试解决我们现在正在面对的这个麻烦",
+    "english": "I am trying to solve the problem we are facing now",
+    "soundmark": "/aɪ/ /æm/ /'traɪɪŋ/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/ /wi/ /ɚ/ /'fesɪŋ/ /naʊ/"
+  },
+  {
+    "chinese": "解决这个麻烦",
+    "english": "to solve the problem",
+    "soundmark": "/tə/ /sɑlv/ /ðə/ /'prɑbləm/"
+  },
+  {
+    "chinese": "我解决这个麻烦",
+    "english": "I solve the problem",
+    "soundmark": "/aɪ/ /sɑlv/ /ðə/ /'prɑbləm/"
+  },
+  {
+    "chinese": "解决(ing形式)",
+    "english": "solving",
+    "soundmark": "/sɑlvɪŋ/"
+  },
+  {
+    "chinese": "是；赋值(原型)",
+    "english": "be",
+    "soundmark": "/bi/"
+  },
+  {
+    "chinese": "正在解决",
+    "english": "be solving",
+    "soundmark": "/bi/ /sɑlvɪŋ/"
+  },
+  {
+    "chinese": "我(现在)正在解决",
+    "english": "I am solving",
+    "soundmark": "/aɪ/ /æm/ /sɑlvɪŋ/"
+  },
+  {
+    "chinese": "这个麻烦",
+    "english": "the problem",
+    "soundmark": "/ðə/ /'prɑbləm/"
+  },
+  {
+    "chinese": "我(现在)正在解决这个麻烦",
+    "english": "I am solving the problem",
+    "soundmark": "/aɪ/ /æm/ /sɑlvɪŋ/ /ðə/ /'prɑbləm/"
+  },
+  {
+    "chinese": "我们(现在)正在面对",
+    "english": "we are facing",
+    "soundmark": "/wi/ /ɚ/ /'fesɪŋ/"
+  },
+  {
+    "chinese": "我们(现在)正在面对的这个麻烦",
+    "english": "the problem we are facing",
+    "soundmark": "/ðə/ /'prɑbləm/ /wi/ /ɚ/ /'fesɪŋ/"
+  },
+  {
+    "chinese": "我(现在)正在解决我们(现在)正在面对的这个麻烦",
+    "english": "I am solving the problem we are facing",
+    "soundmark": "/aɪ/ /æm/ /sɑlvɪŋ/ /ðə/ /'prɑbləm/ /wi/ /ɚ/ /'fesɪŋ/"
+  },
+  {
+    "chinese": "现在",
+    "english": "now",
+    "soundmark": "/naʊ/"
+  },
+  {
+    "chinese": "我(现在)正在解决我们现在正在面对的这个麻烦",
+    "english": "I am solving the problem we are facing now",
+    "soundmark": "/aɪ/ /æm/ /sɑlvɪŋ/ /ðə/ /'prɑbləm/ /wi/ /ɚ/ /'fesɪŋ/ /naʊ/"
+  },
+  {
+    "chinese": "疑惑",
+    "english": "to wonder",
+    "soundmark": "/tə/ /'wʌndɚ/"
+  },
+  {
+    "chinese": "我疑惑",
+    "english": "I wonder",
+    "soundmark": "/aɪ/ /'wʌndɚ/"
+  },
+  {
+    "chinese": "一起解决这个麻烦",
+    "english": "to solve the problem together",
+    "soundmark": "/tə/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
+  },
+  {
+    "chinese": "我们可以",
+    "english": "we can",
+    "soundmark": "/wi/ /kən/"
+  },
+  {
+    "chinese": "我们可以一起解决这个麻烦",
+    "english": "we can solve the problem together",
+    "soundmark": "/wi/ /kən/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
+  },
+  {
+    "chinese": "是否",
+    "english": "if",
+    "soundmark": "/ɪf/"
+  },
+  {
+    "chinese": "是否我们可以一起解决这个麻烦",
+    "english": "if we can solve the problem together",
+    "soundmark": "/ɪf/ /wi/ /kən/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
+  },
+  {
+    "chinese": "我疑惑",
+    "english": "I wonder",
+    "soundmark": "/aɪ/ /'wʌndɚ/"
+  },
+  {
+    "chinese": "我疑惑是否我们可以一起解决这个麻烦",
+    "english": "I wonder if we can solve the problem together",
+    "soundmark": "/aɪ/ /'wʌndɚ/ /ɪf/ /wi/ /kən/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
+  },
+  {
+    "chinese": "一起解决这个麻烦",
+    "english": "to solve the problem together",
+    "soundmark": "/tə/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
+  },
+  {
+    "chinese": "我们需要",
+    "english": "we need",
+    "soundmark": "/wi/ /nid/"
+  },
+  {
+    "chinese": "我们需要一起解决这个麻烦",
+    "english": "we need to solve the problem together",
+    "soundmark": "/wi/ /nid/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
+  },
+  {
+    "chinese": "为什么",
+    "english": "why",
+    "soundmark": "/waɪ/"
+  },
+  {
+    "chinese": "为什么我们需要一起解决这个麻烦",
+    "english": "why we need to solve the problem together",
+    "soundmark": "/waɪ/ /wi/ /nid/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
+  },
+  {
+    "chinese": "我疑惑",
+    "english": "I wonder",
+    "soundmark": "/aɪ/ /'wʌndɚ/"
+  },
+  {
+    "chinese": "我疑惑为什么我们需要一起解决这个麻烦",
+    "english": "I wonder why we need to solve the problem together",
+    "soundmark": "/aɪ/ /'wʌndɚ/ /waɪ/ /wi/ /nid/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
+  },
+  {
+    "chinese": "他",
+    "english": "he",
+    "soundmark": "/hi/"
+  },
+  {
+    "chinese": "他疑惑",
+    "english": "he wonders",
+    "soundmark": "/hi/ /'wʌndɚz/"
+  },
+  {
+    "chinese": "一起解决这个麻烦",
+    "english": "to solve the problem together",
+    "soundmark": "/tə/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
+  },
+  {
+    "chinese": "我们将会",
+    "english": "we will",
+    "soundmark": "/wi/ /wɪl/"
+  },
+  {
+    "chinese": "我们将会一起解决这个麻烦",
+    "english": "we will solve the problem together",
+    "soundmark": "/wi/ /wɪl/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
+  },
+  {
+    "chinese": "在什么时候",
+    "english": "when",
+    "soundmark": "/wɛn/"
+  },
+  {
+    "chinese": "我们将会在什么时候一起解决这个麻烦",
+    "english": "when we will solve the problem together",
+    "soundmark": "/wɛn/ /wi/ /wɪl/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
+  },
+  {
+    "chinese": "他疑惑我们将会在什么时候一起解决这个麻烦",
+    "english": "he wonders when we will solve the problem together",
+    "soundmark": "/hi/ /'wʌndɚz/ /wɛn/ /wi/ /wɪl/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
+  },
+  {
+    "chinese": "如何",
+    "english": "how",
+    "soundmark": "/haʊ/"
+  },
+  {
+    "chinese": "我们将会如何一起解决这个问题",
+    "english": "how we will solve the problem together",
+    "soundmark": "/haʊ/ /wi/ /wɪl/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
+  },
+  {
+    "chinese": "他疑惑我们将会如何一起解决这个麻烦",
+    "english": "he wonders how we will solve the problem together",
+    "soundmark": "/hi/ /'wʌndɚz/ /haʊ/ /wi/ /wɪl/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
+  },
+  {
+    "chinese": "疑惑(ing形式)",
+    "english": "wondering",
+    "soundmark": "/'wʌndərɪŋ/"
+  },
+  {
+    "chinese": "是；赋值(原型)",
+    "english": "be",
+    "soundmark": "/bi/"
+  },
+  {
+    "chinese": "正在疑惑",
+    "english": "be wondering",
+    "soundmark": "/bi/ /'wʌndərɪŋ/ /(I，过去时)be was/ /wəz/"
+  },
+  {
+    "chinese": "我(过去)正在疑惑",
+    "english": "I was wondering",
+    "soundmark": "/aɪ/ /wəz/ /'wʌndərɪŋ/"
+  },
+  {
+    "chinese": "是否我们可以一起解决这个麻烦",
+    "english": "if we can solve the problem together",
+    "soundmark": "/ɪf/ /wi/ /kən/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
+  },
+  {
+    "chinese": "我(过去)正在疑惑是否我们可以一起解决这个麻烦",
+    "english": "I was wondering if we can solve the problem together",
+    "soundmark": "/aɪ/ /wəz/ /'wʌndərɪŋ/ /ɪf/ /wi/ /kən/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
+  },
+  {
+    "chinese": "我(过去)正在疑惑",
+    "english": "I was wondering",
+    "soundmark": "/aɪ/ /wəz/ /'wʌndərɪŋ/"
+  },
+  {
+    "chinese": "为什么我们需要一起解决这个麻烦",
+    "english": "why we need to solve the problem together",
+    "soundmark": "/waɪ/ /wi/ /nid/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
+  },
+  {
+    "chinese": "我(过去)正在疑惑为什么我们需要一起解决这个麻烦",
+    "english": "I was wondering why we need to solve the problem together",
+    "soundmark": "/aɪ/ /wəz/ /'wʌndərɪŋ/ /waɪ/ /wi/ /nid/ /tə/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
+  },
+  {
+    "chinese": "疑惑(ing形式)",
+    "english": "wondering",
+    "soundmark": "/'wʌndərɪŋ/"
+  },
+  {
+    "chinese": "是；赋值(原型)",
+    "english": "be",
+    "soundmark": "/bi/"
+  },
+  {
+    "chinese": "正在疑惑",
+    "english": "be wondering",
+    "soundmark": "/bi/ /'wʌndərɪŋ/"
+  },
+  {
+    "chinese": "他",
+    "english": "he",
+    "soundmark": "/hi/ /(he，现在时)be is/ /ɪz/"
+  },
+  {
+    "chinese": "他(现在)正在疑惑",
+    "english": "he is wondering",
+    "soundmark": "/hi/ /ɪz/ /'wʌndərɪŋ/"
+  },
+  {
+    "chinese": "我们将会在什么时候一起解决这个麻烦",
+    "english": "when we will solve the problem together",
+    "soundmark": "/wɛn/ /wi/ /wɪl/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
+  },
+  {
+    "chinese": "他(现在)正在疑惑我们将会在什么时候一起解决这个麻烦",
+    "english": "he is wondering when we will solve the problem together",
+    "soundmark": "/hi/ /ɪz/ /'wʌndərɪŋ/ /wɛn/ /wi/ /wɪl/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
+  },
+  {
+    "chinese": "如何",
+    "english": "how",
+    "soundmark": "/haʊ/"
+  },
+  {
+    "chinese": "我们将会如何一起解决这个问题",
+    "english": "how we will solve the problem together",
+    "soundmark": "/haʊ/ /wi/ /wɪl/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
+  },
+  {
+    "chinese": "他(现在)正在疑惑",
+    "english": "he is wondering",
+    "soundmark": "/hi/ /ɪz/ /'wʌndərɪŋ/"
+  },
+  {
+    "chinese": "他(现在)正在疑惑我们将会如何一起解决这个问题",
+    "english": "he is wondering how we will solve the problem together",
+    "soundmark": "/hi/ /ɪz/ /'wʌndərɪŋ/ /haʊ/ /wi/ /wɪl/ /sɑlv/ /ðə/ /'prɑbləm/ /tə'ɡɛðɚ/"
+  }
 ]

--- a/scripts/courses/29.json
+++ b/scripts/courses/29.json
@@ -1,667 +1,667 @@
 [
-	{
-		"chinese": "这里",
-		"english": "here",
-		"soundmark": "/hɪr/"
-	},
-	{
-		"chinese": "我",
-		"english": "I",
-		"soundmark": "/aɪ/ /(I，现在时)be am/ /æm/"
-	},
-	{
-		"chinese": "我在这里",
-		"english": "I am here",
-		"soundmark": "/aɪ/ /æm/ /hɪr/"
-	},
-	{
-		"chinese": "想要",
-		"english": "want",
-		"soundmark": "/wɑnt/"
-	},
-	{
-		"chinese": "我在这里",
-		"english": "I am here",
-		"soundmark": "/aɪ/ /æm/ /hɪr/"
-	},
-	{
-		"chinese": "我想要在这里",
-		"english": "I want to be here",
-		"soundmark": "/aɪ/ /wɑnt/ /tə/ /bi/ /hɪr/"
-	},
-	{
-		"chinese": "不",
-		"english": "don't",
-		"soundmark": "/dont/"
-	},
-	{
-		"chinese": "我不想在这里",
-		"english": "I don't want to be here",
-		"soundmark": "/aɪ/ /dont/ /wɑnt/ /tə/ /bi/ /hɪr/"
-	},
-	{
-		"chinese": "那里",
-		"english": "there",
-		"soundmark": "/ðɛr/"
-	},
-	{
-		"chinese": "我不想去那里",
-		"english": "I don't want to be there",
-		"soundmark": "/aɪ/ /dont/ /wɑnt/ /tə/ /bi/ /ðɛr/"
-	},
-	{
-		"chinese": "我想要去那里",
-		"english": "I want to be there",
-		"soundmark": "/aɪ/ /wɑnt/ /tə/ /bi/ /ðɛr/"
-	},
-	{
-		"chinese": "我不想在这里我想要去那里",
-		"english": "I don't want to be here, I want to be there",
-		"soundmark": "/aɪ/ /dont/ /wɑnt/ /tə/ /bi/ /hɪr/ /aɪ/ /wɑnt/ /tə/ /bi/ /ðɛr/"
-	},
-	{
-		"chinese": "我在这里",
-		"english": "I am here",
-		"soundmark": "/aɪ/ /æm/ /hɪr/"
-	},
-	{
-		"chinese": "当......时候",
-		"english": "when",
-		"soundmark": "/wɛn/"
-	},
-	{
-		"chinese": "当我在这里的时候",
-		"english": "when I am here",
-		"soundmark": "/wɛn/ /aɪ/ /æm/ /hɪr/"
-	},
-	{
-		"chinese": "我想要去那里",
-		"english": "I want to be there",
-		"soundmark": "/aɪ/ /wɑnt/ /tə/ /bi/ /ðɛr/"
-	},
-	{
-		"chinese": "当我在这里的时候我想要去那里",
-		"english": "when I am here, I want to be there",
-		"soundmark": "/wɛn/ /aɪ/ /æm/ /hɪr/ /aɪ/ /wɑnt/ /tə/ /bi/ /ðɛr/"
-	},
-	{
-		"chinese": "当我(过去)在这里的时候我",
-		"english": "(过去)想要去那里 when I was here, I wanted to be there",
-		"soundmark": "/wɛn/ /aɪ/ /wəz/ /hɪr/ /aɪ/ /wɑntɪd/ /tə/ /bi/ /ðɛr/"
-	},
-	{
-		"chinese": "老师",
-		"english": "teacher",
-		"soundmark": "/'titʃɚ/"
-	},
-	{
-		"chinese": "我是一名老师",
-		"english": "I am a teacher",
-		"soundmark": "/aɪ/ /æm/ /ə/ /'titʃɚ/"
-	},
-	{
-		"chinese": "想要",
-		"english": "want",
-		"soundmark": "/wɑnt/"
-	},
-	{
-		"chinese": "我想要成为一名老师",
-		"english": "I want to be a teacher",
-		"soundmark": "/aɪ/ /wɑnt/ /tə/ /bi/ /ə/ /'titʃɚ/"
-	},
-	{
-		"chinese": "富有的",
-		"english": "rich",
-		"soundmark": "/rɪtʃ/"
-	},
-	{
-		"chinese": "我是富有的",
-		"english": "I am rich",
-		"soundmark": "/aɪ/ /æm/ /rɪtʃ/"
-	},
-	{
-		"chinese": "想要",
-		"english": "want",
-		"soundmark": "/wɑnt/"
-	},
-	{
-		"chinese": "我想要变得富有",
-		"english": "I want to be rich",
-		"soundmark": "/aɪ/ /wɑnt/ /tə/ /bi/ /rɪtʃ/"
-	},
-	{
-		"chinese": "我在这里",
-		"english": "I am here",
-		"soundmark": "/aɪ/ /æm/ /hɪr/ /(I，过去时)be was/ /wəz/"
-	},
-	{
-		"chinese": "我(过去)在这里",
-		"english": "I was here",
-		"soundmark": "/aɪ/ /wəz/ /hɪr/"
-	},
-	{
-		"chinese": "当......时候",
-		"english": "when",
-		"soundmark": "/wɛn/"
-	},
-	{
-		"chinese": "当我(过去)在这里的时候",
-		"english": "when I was here",
-		"soundmark": "/wɛn/ /aɪ/ /wəz/ /hɪr/"
-	},
-	{
-		"chinese": "在......之前；以前",
-		"english": "before",
-		"soundmark": "/bɪ'fɔr/"
-	},
-	{
-		"chinese": "当我以前在这里的时候",
-		"english": "when I was here before",
-		"soundmark": "/wɛn/ /aɪ/ /wəz/ /hɪr/ /bɪ'fɔr/"
-	},
-	{
-		"chinese": "注意到；察觉到",
-		"english": "to notice",
-		"soundmark": "/tə/ /ˈnotɪs/"
-	},
-	{
-		"chinese": "我",
-		"english": "I",
-		"soundmark": "/aɪ/"
-	},
-	{
-		"chinese": "我注意到",
-		"english": "I notice",
-		"soundmark": "/aɪ/ /ˈnotɪs/"
-	},
-	{
-		"chinese": "那个",
-		"english": "that",
-		"soundmark": "/ðæt/"
-	},
-	{
-		"chinese": "我注意到那个",
-		"english": "I notice that",
-		"soundmark": "/aɪ/ /ˈnotɪs/ /ðæt/ /(过去)注意到 noticed/ /ˈnotɪst/"
-	},
-	{
-		"chinese": "我(过去)注意到那个",
-		"english": "I noticed that",
-		"soundmark": "/aɪ/ /ˈnotɪst/ /ðæt/ /(过去)没有 didn't/ /ˈdɪdnt/"
-	},
-	{
-		"chinese": "我(过去)没有注意到那个",
-		"english": "I didn't notice that",
-		"soundmark": "/aɪ/ /ˈdɪdnt/ /ˈnotɪs/ /ðæt/"
-	},
-	{
-		"chinese": "当我以前在这里的时候",
-		"english": "when I was here before",
-		"soundmark": "/wɛn/ /aɪ/ /wəz/ /hɪr/ /bɪ'fɔr/"
-	},
-	{
-		"chinese": "我(过去)没有注意那个当我以前在这里的时候",
-		"english": "I didn't notice that when I was here before",
-		"soundmark": "/aɪ/ /ˈdɪdnt/ /ˈnotɪs/ /ðæt/ /wɛn/ /aɪ/ /wəz/ /hɪr/ /bɪ'fɔr/"
-	},
-	{
-		"chinese": "我(过去)注意到",
-		"english": "I noticed",
-		"soundmark": "/aɪ/ /ˈnotɪst/"
-	},
-	{
-		"chinese": "某个东西",
-		"english": "something",
-		"soundmark": "/'sʌmθɪŋ/"
-	},
-	{
-		"chinese": "错误的",
-		"english": "wrong",
-		"soundmark": "/rɔŋ/"
-	},
-	{
-		"chinese": "错误的某个东西",
-		"english": "something wrong",
-		"soundmark": "/'sʌmθɪŋ/ /rɔŋ/"
-	},
-	{
-		"chinese": "那里",
-		"english": "there",
-		"soundmark": "/ðɛr/"
-	},
-	{
-		"chinese": "错误的某个东西在那里",
-		"english": "something wrong is there",
-		"soundmark": "/'sʌmθɪŋ/ /rɔŋ/ /ɪz/ /ðɛr/"
-	},
-	{
-		"chinese": "存在",
-		"english": "there is",
-		"soundmark": "/ðɛr/ /ɪz/"
-	},
-	{
-		"chinese": "存在错误的某个东西",
-		"english": "there is something wrong",
-		"soundmark": "/ðɛr/ /ɪz/ /'sʌmθɪŋ/ /rɔŋ/"
-	},
-	{
-		"chinese": "这里",
-		"english": "here",
-		"soundmark": "/hɪr/"
-	},
-	{
-		"chinese": "这里有错误的某个东西",
-		"english": "there is something wrong here",
-		"soundmark": "/ðɛr/ /ɪz/ /'sʌmθɪŋ/ /rɔŋ/ /hɪr/ /(过去)存在 there was/ /ðɛr/ /wəz/"
-	},
-	{
-		"chinese": "这里(过去)有错误的某个东西",
-		"english": "there was something wrong here",
-		"soundmark": "/ðɛr/ /wəz/ /'sʌmθɪŋ/ /rɔŋ/ /hɪr/"
-	},
-	{
-		"chinese": "我(过去)注意到",
-		"english": "I noticed",
-		"soundmark": "/aɪ/ /ˈnotɪst/"
-	},
-	{
-		"chinese": "我(过去)注意到这里(过去)有错误的某个东西",
-		"english": "I noticed there was something wrong here",
-		"soundmark": "/aɪ/ /ˈnotɪst/ /ðɛr/ /wəz/ /'sʌmθɪŋ/ /rɔŋ/ /hɪr/"
-	},
-	{
-		"chinese": "那个",
-		"english": "that",
-		"soundmark": "/ðæt/"
-	},
-	{
-		"chinese": "我(过去)注意到(那个)这里(过去)有错误的某个东西",
-		"english": "I noticed that there was something wrong here",
-		"soundmark": "/aɪ/ /ˈnotɪst/ /ðæt/ /ðɛr/ /wəz/ /'sʌmθɪŋ/ /rɔŋ/ /hɪr/"
-	},
-	{
-		"chinese": "不同的",
-		"english": "different",
-		"soundmark": "/'dɪfrənt/"
-	},
-	{
-		"chinese": "某个东西",
-		"english": "something",
-		"soundmark": "/'sʌmθɪŋ/"
-	},
-	{
-		"chinese": "不同的某个东西",
-		"english": "something different",
-		"soundmark": "/'sʌmθɪŋ/ /'dɪfrənt/"
-	},
-	{
-		"chinese": "存在不同的某个东西",
-		"english": "there is something different",
-		"soundmark": "/ðɛr/ /ɪz/ /'sʌmθɪŋ/ /'dɪfrənt/"
-	},
-	{
-		"chinese": "这里",
-		"english": "here",
-		"soundmark": "/hɪr/"
-	},
-	{
-		"chinese": "这里有不同的某个东西",
-		"english": "there is something different here",
-		"soundmark": "/ðɛr/ /ɪz/ /'sʌmθɪŋ/ /'dɪfrənt/ /hɪr/ /(过去)存在 there was/ /ðɛr/ /wəz/"
-	},
-	{
-		"chinese": "这里(过去)有不同的某个东西",
-		"english": "there was something different here",
-		"soundmark": "/ðɛr/ /wəz/ /'sʌmθɪŋ/ /'dɪfrənt/ /hɪr/"
-	},
-	{
-		"chinese": "我(过去)注意到",
-		"english": "I noticed",
-		"soundmark": "/aɪ/ /ˈnotɪst/"
-	},
-	{
-		"chinese": "我(过去)注意到这里(过去)存在不同的某个东西",
-		"english": "I noticed there was something different here",
-		"soundmark": "/aɪ/ /ˈnotɪst/ /ðɛr/ /wəz/ /'sʌmθɪŋ/ /'dɪfrənt/ /hɪr/"
-	},
-	{
-		"chinese": "那个",
-		"english": "that",
-		"soundmark": "/ðæt/"
-	},
-	{
-		"chinese": "我(过去)注意到(那个)这里(过去)存在不同的某个东西",
-		"english": "I noticed that there was something different here",
-		"soundmark": "/aɪ/ /ˈnotɪst/ /ðæt/ /ðɛr/ /wəz/ /'sʌmθɪŋ/ /'dɪfrənt/ /hɪr/"
-	},
-	{
-		"chinese": "不同的",
-		"english": "different",
-		"soundmark": "/'dɪfrənt/"
-	},
-	{
-		"chinese": "不同之处",
-		"english": "difference",
-		"soundmark": "/'dɪfrəns/"
-	},
-	{
-		"chinese": "在......之间",
-		"english": "between",
-		"soundmark": "/bɪ'twin/"
-	},
-	{
-		"chinese": "和",
-		"english": "and",
-		"soundmark": "/ənd/"
-	},
-	{
-		"chinese": "你和我",
-		"english": "you and me",
-		"soundmark": "/ju/ /ənd/ /mi/"
-	},
-	{
-		"chinese": "在你和我之间",
-		"english": "between you and me",
-		"soundmark": "/bɪ'twin/ /ju/ /ənd/ /mi/"
-	},
-	{
-		"chinese": "在你和我之间的不同",
-		"english": "difference between you and me",
-		"soundmark": "/'dɪfrəns/ /bɪ'twin/ /ju/ /ənd/ /mi/"
-	},
-	{
-		"chinese": "大的",
-		"english": "big",
-		"soundmark": "/bɪɡ/"
-	},
-	{
-		"chinese": "一个大的不同",
-		"english": "a big difference",
-		"soundmark": "/ə/ /bɪɡ/ /'dɪfrəns/"
-	},
-	{
-		"chinese": "在你和我之间的一个大的不同",
-		"english": "a big difference between you and me",
-		"soundmark": "/ə/ /bɪɡ/ /'dɪfrəns/ /bɪ'twin/ /ju/ /ənd/ /mi/"
-	},
-	{
-		"chinese": "那里",
-		"english": "there",
-		"soundmark": "/ðɛr/"
-	},
-	{
-		"chinese": "在你和我之间的一个大的不同在那里",
-		"english": "a big difference between you and me is there",
-		"soundmark": "/ə/ /bɪɡ/ /'dɪfrəns/ /bɪ'twin/ /ju/ /ənd/ /mi/ /ɪz/ /ðɛr/"
-	},
-	{
-		"chinese": "存在",
-		"english": "there is",
-		"soundmark": "/ðɛr/ /ɪz/"
-	},
-	{
-		"chinese": "存在在你和我之间的一个大的不同",
-		"english": "there is a big difference between you and me",
-		"soundmark": "/ðɛr/ /ɪz/ /ə/ /bɪɡ/ /'dɪfrəns/ /bɪ'twin/ /ju/ /ənd/ /mi/"
-	},
-	{
-		"chinese": "武器",
-		"english": "weapon",
-		"soundmark": "/ˈwɛpən/"
-	},
-	{
-		"chinese": "工具",
-		"english": "tool",
-		"soundmark": "/tul/"
-	},
-	{
-		"chinese": "一个武器和一个工具",
-		"english": "a weapon and a tool",
-		"soundmark": "/ə/ /ˈwɛpən/ /ənd/ /ə/ /tul/"
-	},
-	{
-		"chinese": "在......之间",
-		"english": "between",
-		"soundmark": "/bɪ'twin/"
-	},
-	{
-		"chinese": "在一个武器和一个工具之间",
-		"english": "between a weapon and a tool",
-		"soundmark": "/bɪ'twin/ /ə/ /ˈwɛpən/ /ənd/ /ə/ /tul/"
-	},
-	{
-		"chinese": "存在一个大的不同",
-		"english": "there is a big difference",
-		"soundmark": "/ðɛr/ /ɪz/ /ə/ /bɪɡ/ /'dɪfrəns/"
-	},
-	{
-		"chinese": "存在在一个武器和一个工具之间的一个大的不同",
-		"english": "there is a big difference between a weapon and a tool",
-		"soundmark": "/ðɛr/ /ɪz/ /ə/ /bɪɡ/ /'dɪfrəns/ /bɪ'twin/ /ə/ /ˈwɛpən/ /ənd/ /ə/ /tul/"
-	},
-	{
-		"chinese": "正确",
-		"english": "right",
-		"soundmark": "/raɪt/"
-	},
-	{
-		"chinese": "错误",
-		"english": "wrong",
-		"soundmark": "/rɔŋ/"
-	},
-	{
-		"chinese": "正确和错误",
-		"english": "right and wrong",
-		"soundmark": "/raɪt/ /ənd/ /rɔŋ/"
-	},
-	{
-		"chinese": "在......之间",
-		"english": "between",
-		"soundmark": "/bɪ'twin/"
-	},
-	{
-		"chinese": "在对和错之间",
-		"english": "between right and wrong",
-		"soundmark": "/bɪ'twin/ /raɪt/ /ənd/ /rɔŋ/"
-	},
-	{
-		"chinese": "不同之处",
-		"english": "difference",
-		"soundmark": "/'dɪfrəns/"
-	},
-	{
-		"chinese": "那个不同之处(区别)",
-		"english": "the difference",
-		"soundmark": "/ðə/ /'dɪfrəns/"
-	},
-	{
-		"chinese": "在对和错之间的区别",
-		"english": "the difference between right and wrong",
-		"soundmark": "/ðə/ /'dɪfrəns/ /bɪ'twin/ /raɪt/ /ənd/ /rɔŋ/"
-	},
-	{
-		"chinese": "知道",
-		"english": "to know",
-		"soundmark": "/tə/ /no/"
-	},
-	{
-		"chinese": "知道对与错的区别",
-		"english": "to know the difference between right and wrong",
-		"soundmark": "/tə/ /no/ /ðə/ /'dɪfrəns/ /bɪ'twin/ /raɪt/ /ənd/ /rɔŋ/"
-	},
-	{
-		"chinese": "我们",
-		"english": "we",
-		"soundmark": "/wi/"
-	},
-	{
-		"chinese": "我们知道",
-		"english": "we know",
-		"soundmark": "/wi/ /no/"
-	},
-	{
-		"chinese": "所有；全部",
-		"english": "all",
-		"soundmark": "/ɔl/"
-	},
-	{
-		"chinese": "我们都知道",
-		"english": "we all know",
-		"soundmark": "/wi/ /ɔl/ /no/"
-	},
-	{
-		"chinese": "我们都知道对与错的区别",
-		"english": "we all know the difference between right and wrong",
-		"soundmark": "/wi/ /ɔl/ /no/ /ðə/ /'dɪfrəns/ /bɪ'twin/ /raɪt/ /ənd/ /rɔŋ/"
-	},
-	{
-		"chinese": "你必须知道",
-		"english": "you have to know",
-		"soundmark": "/ju/ /hæv/ /tə/ /no/"
-	},
-	{
-		"chinese": "你必须知道对与错的区别",
-		"english": "you have to know the difference between right and wrong",
-		"soundmark": "/ju/ /hæv/ /tə/ /no/ /ðə/ /'dɪfrəns/ /bɪ'twin/ /raɪt/ /ənd/ /rɔŋ/"
-	},
-	{
-		"chinese": "告诉",
-		"english": "to tell",
-		"soundmark": "/tə/ /tɛl/"
-	},
-	{
-		"chinese": "区别",
-		"english": "the difference",
-		"soundmark": "/ðə/ /'dɪfrəns/"
-	},
-	{
-		"chinese": "分辨区别",
-		"english": "to tell the difference",
-		"soundmark": "/tə/ /tɛl/ /ðə/ /'dɪfrəns/"
-	},
-	{
-		"chinese": "在......之间",
-		"english": "between",
-		"soundmark": "/bɪ'twin/"
-	},
-	{
-		"chinese": "正确和错误",
-		"english": "right and wrong",
-		"soundmark": "/raɪt/ /ənd/ /rɔŋ/"
-	},
-	{
-		"chinese": "在对和错之间",
-		"english": "between right and wrong",
-		"soundmark": "/bɪ'twin/ /raɪt/ /ənd/ /rɔŋ/"
-	},
-	{
-		"chinese": "对与错的区别",
-		"english": "the difference between right and wrong",
-		"soundmark": "/ðə/ /'dɪfrəns/ /bɪ'twin/ /raɪt/ /ənd/ /rɔŋ/"
-	},
-	{
-		"chinese": "分辨是非",
-		"english": "to tell the difference between right and wrong",
-		"soundmark": "/tə/ /tɛl/ /ðə/ /'dɪfrəns/ /bɪ'twin/ /raɪt/ /ənd/ /rɔŋ/"
-	},
-	{
-		"chinese": "年龄大的；老的",
-		"english": "old",
-		"soundmark": "/old/"
-	},
-	{
-		"chinese": "足够",
-		"english": "enough",
-		"soundmark": "/ɪ'nʌf/"
-	},
-	{
-		"chinese": "足够年龄大",
-		"english": "old enough",
-		"soundmark": "/old/ /ɪ'nʌf/"
-	},
-	{
-		"chinese": "你是",
-		"english": "you are",
-		"soundmark": "/ju/ /ɚ/"
-	},
-	{
-		"chinese": "你是足够年龄大的",
-		"english": "you are old enough",
-		"soundmark": "/ju/ /ɚ/ /old/ /ɪ'nʌf/"
-	},
-	{
-		"chinese": "你是年龄大的足够分辨是非",
-		"english": "you are old enough to tell the difference between right and wrong",
-		"soundmark": "/ju/ /ɚ/ /old/ /ɪ'nʌf/ /tə/ /tɛl/ /ðə/ /'dɪfrəns/ /bɪ'twin/ /raɪt/ /ənd/ /rɔŋ/"
-	},
-	{
-		"chinese": "孩子",
-		"english": "child",
-		"soundmark": "/tʃaɪld/"
-	},
-	{
-		"chinese": "孩子们",
-		"english": "children",
-		"soundmark": "/'tʃɪldrən/"
-	},
-	{
-		"chinese": "我们的",
-		"english": "our",
-		"soundmark": "/'aʊɚ/"
-	},
-	{
-		"chinese": "我们的孩子们",
-		"english": "our children",
-		"soundmark": "/'aʊɚ/ /'tʃɪldrən/"
-	},
-	{
-		"chinese": "教",
-		"english": "to teach",
-		"soundmark": "/tə/ /titʃ/"
-	},
-	{
-		"chinese": "我们需要",
-		"english": "we need",
-		"soundmark": "/wi/ /nid/"
-	},
-	{
-		"chinese": "我们需要教",
-		"english": "we need to teach",
-		"soundmark": "/wi/ /nid/ /tə/ /titʃ/"
-	},
-	{
-		"chinese": "我们需要教我们的孩子们",
-		"english": "we need to teach our children",
-		"soundmark": "/wi/ /nid/ /tə/ /titʃ/ /'aʊɚ/ /'tʃɪldrən/"
-	},
-	{
-		"chinese": "分辨区别",
-		"english": "to tell the difference",
-		"soundmark": "/tə/ /tɛl/ /ðə/ /'dɪfrəns/"
-	},
-	{
-		"chinese": "在对和错之间",
-		"english": "between right and wrong",
-		"soundmark": "/bɪ'twin/ /raɪt/ /ənd/ /rɔŋ/"
-	},
-	{
-		"chinese": "辨别是非",
-		"english": "to tell the difference between right and wrong",
-		"soundmark": "/tə/ /tɛl/ /ðə/ /'dɪfrəns/ /bɪ'twin/ /raɪt/ /ənd/ /rɔŋ/"
-	},
-	{
-		"chinese": "如何",
-		"english": "how",
-		"soundmark": "/haʊ/"
-	},
-	{
-		"chinese": "如何辨别是非",
-		"english": "how to tell the difference between right and wrong",
-		"soundmark": "/haʊ/ /tə/ /tɛl/ /ðə/ /'dɪfrəns/ /bɪ'twin/ /raɪt/ /ənd/ /rɔŋ/"
-	},
-	{
-		"chinese": "我们需要教我们的孩子们如何辨别是非",
-		"english": "we need to teach our children how to tell the difference between right and wrong",
-		"soundmark": "/wi/ /nid/ /tə/ /titʃ/ /'aʊɚ/ /'tʃɪldrən/ /haʊ/ /tə/ /tɛl/ /ðə/ /'dɪfrəns/ /bɪ'twin/ /raɪt/ /ənd/ /rɔŋ/"
-	}
+  {
+    "chinese": "这里",
+    "english": "here",
+    "soundmark": "/hɪr/"
+  },
+  {
+    "chinese": "我",
+    "english": "I",
+    "soundmark": "/aɪ/ /(I，现在时)be am/ /æm/"
+  },
+  {
+    "chinese": "我在这里",
+    "english": "I am here",
+    "soundmark": "/aɪ/ /æm/ /hɪr/"
+  },
+  {
+    "chinese": "想要",
+    "english": "want",
+    "soundmark": "/wɑnt/"
+  },
+  {
+    "chinese": "我在这里",
+    "english": "I am here",
+    "soundmark": "/aɪ/ /æm/ /hɪr/"
+  },
+  {
+    "chinese": "我想要在这里",
+    "english": "I want to be here",
+    "soundmark": "/aɪ/ /wɑnt/ /tə/ /bi/ /hɪr/"
+  },
+  {
+    "chinese": "不",
+    "english": "don't",
+    "soundmark": "/dont/"
+  },
+  {
+    "chinese": "我不想在这里",
+    "english": "I don't want to be here",
+    "soundmark": "/aɪ/ /dont/ /wɑnt/ /tə/ /bi/ /hɪr/"
+  },
+  {
+    "chinese": "那里",
+    "english": "there",
+    "soundmark": "/ðɛr/"
+  },
+  {
+    "chinese": "我不想去那里",
+    "english": "I don't want to be there",
+    "soundmark": "/aɪ/ /dont/ /wɑnt/ /tə/ /bi/ /ðɛr/"
+  },
+  {
+    "chinese": "我想要去那里",
+    "english": "I want to be there",
+    "soundmark": "/aɪ/ /wɑnt/ /tə/ /bi/ /ðɛr/"
+  },
+  {
+    "chinese": "我不想在这里我想要去那里",
+    "english": "I don't want to be here, I want to be there",
+    "soundmark": "/aɪ/ /dont/ /wɑnt/ /tə/ /bi/ /hɪr/ /aɪ/ /wɑnt/ /tə/ /bi/ /ðɛr/"
+  },
+  {
+    "chinese": "我在这里",
+    "english": "I am here",
+    "soundmark": "/aɪ/ /æm/ /hɪr/"
+  },
+  {
+    "chinese": "当......时候",
+    "english": "when",
+    "soundmark": "/wɛn/"
+  },
+  {
+    "chinese": "当我在这里的时候",
+    "english": "when I am here",
+    "soundmark": "/wɛn/ /aɪ/ /æm/ /hɪr/"
+  },
+  {
+    "chinese": "我想要去那里",
+    "english": "I want to be there",
+    "soundmark": "/aɪ/ /wɑnt/ /tə/ /bi/ /ðɛr/"
+  },
+  {
+    "chinese": "当我在这里的时候我想要去那里",
+    "english": "when I am here, I want to be there",
+    "soundmark": "/wɛn/ /aɪ/ /æm/ /hɪr/ /aɪ/ /wɑnt/ /tə/ /bi/ /ðɛr/"
+  },
+  {
+    "chinese": "当我(过去)在这里的时候我",
+    "english": "when I was here, I wanted to be there",
+    "soundmark": "/wɛn/ /aɪ/ /wəz/ /hɪr/ /aɪ/ /wɑntɪd/ /tə/ /bi/ /ðɛr/"
+  },
+  {
+    "chinese": "老师",
+    "english": "teacher",
+    "soundmark": "/'titʃɚ/"
+  },
+  {
+    "chinese": "我是一名老师",
+    "english": "I am a teacher",
+    "soundmark": "/aɪ/ /æm/ /ə/ /'titʃɚ/"
+  },
+  {
+    "chinese": "想要",
+    "english": "want",
+    "soundmark": "/wɑnt/"
+  },
+  {
+    "chinese": "我想要成为一名老师",
+    "english": "I want to be a teacher",
+    "soundmark": "/aɪ/ /wɑnt/ /tə/ /bi/ /ə/ /'titʃɚ/"
+  },
+  {
+    "chinese": "富有的",
+    "english": "rich",
+    "soundmark": "/rɪtʃ/"
+  },
+  {
+    "chinese": "我是富有的",
+    "english": "I am rich",
+    "soundmark": "/aɪ/ /æm/ /rɪtʃ/"
+  },
+  {
+    "chinese": "想要",
+    "english": "want",
+    "soundmark": "/wɑnt/"
+  },
+  {
+    "chinese": "我想要变得富有",
+    "english": "I want to be rich",
+    "soundmark": "/aɪ/ /wɑnt/ /tə/ /bi/ /rɪtʃ/"
+  },
+  {
+    "chinese": "我在这里",
+    "english": "I am here",
+    "soundmark": "/aɪ/ /æm/ /hɪr/ /(I，过去时)be was/ /wəz/"
+  },
+  {
+    "chinese": "我(过去)在这里",
+    "english": "I was here",
+    "soundmark": "/aɪ/ /wəz/ /hɪr/"
+  },
+  {
+    "chinese": "当......时候",
+    "english": "when",
+    "soundmark": "/wɛn/"
+  },
+  {
+    "chinese": "当我(过去)在这里的时候",
+    "english": "when I was here",
+    "soundmark": "/wɛn/ /aɪ/ /wəz/ /hɪr/"
+  },
+  {
+    "chinese": "在......之前；以前",
+    "english": "before",
+    "soundmark": "/bɪ'fɔr/"
+  },
+  {
+    "chinese": "当我以前在这里的时候",
+    "english": "when I was here before",
+    "soundmark": "/wɛn/ /aɪ/ /wəz/ /hɪr/ /bɪ'fɔr/"
+  },
+  {
+    "chinese": "注意到；察觉到",
+    "english": "to notice",
+    "soundmark": "/tə/ /ˈnotɪs/"
+  },
+  {
+    "chinese": "我",
+    "english": "I",
+    "soundmark": "/aɪ/"
+  },
+  {
+    "chinese": "我注意到",
+    "english": "I notice",
+    "soundmark": "/aɪ/ /ˈnotɪs/"
+  },
+  {
+    "chinese": "那个",
+    "english": "that",
+    "soundmark": "/ðæt/"
+  },
+  {
+    "chinese": "我注意到那个",
+    "english": "I notice that",
+    "soundmark": "/aɪ/ /ˈnotɪs/ /ðæt/ /(过去)注意到 noticed/ /ˈnotɪst/"
+  },
+  {
+    "chinese": "我(过去)注意到那个",
+    "english": "I noticed that",
+    "soundmark": "/aɪ/ /ˈnotɪst/ /ðæt/ /(过去)没有 didn't/ /ˈdɪdnt/"
+  },
+  {
+    "chinese": "我(过去)没有注意到那个",
+    "english": "I didn't notice that",
+    "soundmark": "/aɪ/ /ˈdɪdnt/ /ˈnotɪs/ /ðæt/"
+  },
+  {
+    "chinese": "当我以前在这里的时候",
+    "english": "when I was here before",
+    "soundmark": "/wɛn/ /aɪ/ /wəz/ /hɪr/ /bɪ'fɔr/"
+  },
+  {
+    "chinese": "我(过去)没有注意那个当我以前在这里的时候",
+    "english": "I didn't notice that when I was here before",
+    "soundmark": "/aɪ/ /ˈdɪdnt/ /ˈnotɪs/ /ðæt/ /wɛn/ /aɪ/ /wəz/ /hɪr/ /bɪ'fɔr/"
+  },
+  {
+    "chinese": "我(过去)注意到",
+    "english": "I noticed",
+    "soundmark": "/aɪ/ /ˈnotɪst/"
+  },
+  {
+    "chinese": "某个东西",
+    "english": "something",
+    "soundmark": "/'sʌmθɪŋ/"
+  },
+  {
+    "chinese": "错误的",
+    "english": "wrong",
+    "soundmark": "/rɔŋ/"
+  },
+  {
+    "chinese": "错误的某个东西",
+    "english": "something wrong",
+    "soundmark": "/'sʌmθɪŋ/ /rɔŋ/"
+  },
+  {
+    "chinese": "那里",
+    "english": "there",
+    "soundmark": "/ðɛr/"
+  },
+  {
+    "chinese": "错误的某个东西在那里",
+    "english": "something wrong is there",
+    "soundmark": "/'sʌmθɪŋ/ /rɔŋ/ /ɪz/ /ðɛr/"
+  },
+  {
+    "chinese": "存在",
+    "english": "there is",
+    "soundmark": "/ðɛr/ /ɪz/"
+  },
+  {
+    "chinese": "存在错误的某个东西",
+    "english": "there is something wrong",
+    "soundmark": "/ðɛr/ /ɪz/ /'sʌmθɪŋ/ /rɔŋ/"
+  },
+  {
+    "chinese": "这里",
+    "english": "here",
+    "soundmark": "/hɪr/"
+  },
+  {
+    "chinese": "这里有错误的某个东西",
+    "english": "there is something wrong here",
+    "soundmark": "/ðɛr/ /ɪz/ /'sʌmθɪŋ/ /rɔŋ/ /hɪr/ /(过去)存在 there was/ /ðɛr/ /wəz/"
+  },
+  {
+    "chinese": "这里(过去)有错误的某个东西",
+    "english": "there was something wrong here",
+    "soundmark": "/ðɛr/ /wəz/ /'sʌmθɪŋ/ /rɔŋ/ /hɪr/"
+  },
+  {
+    "chinese": "我(过去)注意到",
+    "english": "I noticed",
+    "soundmark": "/aɪ/ /ˈnotɪst/"
+  },
+  {
+    "chinese": "我(过去)注意到这里(过去)有错误的某个东西",
+    "english": "I noticed there was something wrong here",
+    "soundmark": "/aɪ/ /ˈnotɪst/ /ðɛr/ /wəz/ /'sʌmθɪŋ/ /rɔŋ/ /hɪr/"
+  },
+  {
+    "chinese": "那个",
+    "english": "that",
+    "soundmark": "/ðæt/"
+  },
+  {
+    "chinese": "我(过去)注意到(那个)这里(过去)有错误的某个东西",
+    "english": "I noticed that there was something wrong here",
+    "soundmark": "/aɪ/ /ˈnotɪst/ /ðæt/ /ðɛr/ /wəz/ /'sʌmθɪŋ/ /rɔŋ/ /hɪr/"
+  },
+  {
+    "chinese": "不同的",
+    "english": "different",
+    "soundmark": "/'dɪfrənt/"
+  },
+  {
+    "chinese": "某个东西",
+    "english": "something",
+    "soundmark": "/'sʌmθɪŋ/"
+  },
+  {
+    "chinese": "不同的某个东西",
+    "english": "something different",
+    "soundmark": "/'sʌmθɪŋ/ /'dɪfrənt/"
+  },
+  {
+    "chinese": "存在不同的某个东西",
+    "english": "there is something different",
+    "soundmark": "/ðɛr/ /ɪz/ /'sʌmθɪŋ/ /'dɪfrənt/"
+  },
+  {
+    "chinese": "这里",
+    "english": "here",
+    "soundmark": "/hɪr/"
+  },
+  {
+    "chinese": "这里有不同的某个东西",
+    "english": "there is something different here",
+    "soundmark": "/ðɛr/ /ɪz/ /'sʌmθɪŋ/ /'dɪfrənt/ /hɪr/ /(过去)存在 there was/ /ðɛr/ /wəz/"
+  },
+  {
+    "chinese": "这里(过去)有不同的某个东西",
+    "english": "there was something different here",
+    "soundmark": "/ðɛr/ /wəz/ /'sʌmθɪŋ/ /'dɪfrənt/ /hɪr/"
+  },
+  {
+    "chinese": "我(过去)注意到",
+    "english": "I noticed",
+    "soundmark": "/aɪ/ /ˈnotɪst/"
+  },
+  {
+    "chinese": "我(过去)注意到这里(过去)存在不同的某个东西",
+    "english": "I noticed there was something different here",
+    "soundmark": "/aɪ/ /ˈnotɪst/ /ðɛr/ /wəz/ /'sʌmθɪŋ/ /'dɪfrənt/ /hɪr/"
+  },
+  {
+    "chinese": "那个",
+    "english": "that",
+    "soundmark": "/ðæt/"
+  },
+  {
+    "chinese": "我(过去)注意到(那个)这里(过去)存在不同的某个东西",
+    "english": "I noticed that there was something different here",
+    "soundmark": "/aɪ/ /ˈnotɪst/ /ðæt/ /ðɛr/ /wəz/ /'sʌmθɪŋ/ /'dɪfrənt/ /hɪr/"
+  },
+  {
+    "chinese": "不同的",
+    "english": "different",
+    "soundmark": "/'dɪfrənt/"
+  },
+  {
+    "chinese": "不同之处",
+    "english": "difference",
+    "soundmark": "/'dɪfrəns/"
+  },
+  {
+    "chinese": "在......之间",
+    "english": "between",
+    "soundmark": "/bɪ'twin/"
+  },
+  {
+    "chinese": "和",
+    "english": "and",
+    "soundmark": "/ənd/"
+  },
+  {
+    "chinese": "你和我",
+    "english": "you and me",
+    "soundmark": "/ju/ /ənd/ /mi/"
+  },
+  {
+    "chinese": "在你和我之间",
+    "english": "between you and me",
+    "soundmark": "/bɪ'twin/ /ju/ /ənd/ /mi/"
+  },
+  {
+    "chinese": "在你和我之间的不同",
+    "english": "difference between you and me",
+    "soundmark": "/'dɪfrəns/ /bɪ'twin/ /ju/ /ənd/ /mi/"
+  },
+  {
+    "chinese": "大的",
+    "english": "big",
+    "soundmark": "/bɪɡ/"
+  },
+  {
+    "chinese": "一个大的不同",
+    "english": "a big difference",
+    "soundmark": "/ə/ /bɪɡ/ /'dɪfrəns/"
+  },
+  {
+    "chinese": "在你和我之间的一个大的不同",
+    "english": "a big difference between you and me",
+    "soundmark": "/ə/ /bɪɡ/ /'dɪfrəns/ /bɪ'twin/ /ju/ /ənd/ /mi/"
+  },
+  {
+    "chinese": "那里",
+    "english": "there",
+    "soundmark": "/ðɛr/"
+  },
+  {
+    "chinese": "在你和我之间的一个大的不同在那里",
+    "english": "a big difference between you and me is there",
+    "soundmark": "/ə/ /bɪɡ/ /'dɪfrəns/ /bɪ'twin/ /ju/ /ənd/ /mi/ /ɪz/ /ðɛr/"
+  },
+  {
+    "chinese": "存在",
+    "english": "there is",
+    "soundmark": "/ðɛr/ /ɪz/"
+  },
+  {
+    "chinese": "存在在你和我之间的一个大的不同",
+    "english": "there is a big difference between you and me",
+    "soundmark": "/ðɛr/ /ɪz/ /ə/ /bɪɡ/ /'dɪfrəns/ /bɪ'twin/ /ju/ /ənd/ /mi/"
+  },
+  {
+    "chinese": "武器",
+    "english": "weapon",
+    "soundmark": "/ˈwɛpən/"
+  },
+  {
+    "chinese": "工具",
+    "english": "tool",
+    "soundmark": "/tul/"
+  },
+  {
+    "chinese": "一个武器和一个工具",
+    "english": "a weapon and a tool",
+    "soundmark": "/ə/ /ˈwɛpən/ /ənd/ /ə/ /tul/"
+  },
+  {
+    "chinese": "在......之间",
+    "english": "between",
+    "soundmark": "/bɪ'twin/"
+  },
+  {
+    "chinese": "在一个武器和一个工具之间",
+    "english": "between a weapon and a tool",
+    "soundmark": "/bɪ'twin/ /ə/ /ˈwɛpən/ /ənd/ /ə/ /tul/"
+  },
+  {
+    "chinese": "存在一个大的不同",
+    "english": "there is a big difference",
+    "soundmark": "/ðɛr/ /ɪz/ /ə/ /bɪɡ/ /'dɪfrəns/"
+  },
+  {
+    "chinese": "存在在一个武器和一个工具之间的一个大的不同",
+    "english": "there is a big difference between a weapon and a tool",
+    "soundmark": "/ðɛr/ /ɪz/ /ə/ /bɪɡ/ /'dɪfrəns/ /bɪ'twin/ /ə/ /ˈwɛpən/ /ənd/ /ə/ /tul/"
+  },
+  {
+    "chinese": "正确",
+    "english": "right",
+    "soundmark": "/raɪt/"
+  },
+  {
+    "chinese": "错误",
+    "english": "wrong",
+    "soundmark": "/rɔŋ/"
+  },
+  {
+    "chinese": "正确和错误",
+    "english": "right and wrong",
+    "soundmark": "/raɪt/ /ənd/ /rɔŋ/"
+  },
+  {
+    "chinese": "在......之间",
+    "english": "between",
+    "soundmark": "/bɪ'twin/"
+  },
+  {
+    "chinese": "在对和错之间",
+    "english": "between right and wrong",
+    "soundmark": "/bɪ'twin/ /raɪt/ /ənd/ /rɔŋ/"
+  },
+  {
+    "chinese": "不同之处",
+    "english": "difference",
+    "soundmark": "/'dɪfrəns/"
+  },
+  {
+    "chinese": "那个不同之处(区别)",
+    "english": "the difference",
+    "soundmark": "/ðə/ /'dɪfrəns/"
+  },
+  {
+    "chinese": "在对和错之间的区别",
+    "english": "the difference between right and wrong",
+    "soundmark": "/ðə/ /'dɪfrəns/ /bɪ'twin/ /raɪt/ /ənd/ /rɔŋ/"
+  },
+  {
+    "chinese": "知道",
+    "english": "to know",
+    "soundmark": "/tə/ /no/"
+  },
+  {
+    "chinese": "知道对与错的区别",
+    "english": "to know the difference between right and wrong",
+    "soundmark": "/tə/ /no/ /ðə/ /'dɪfrəns/ /bɪ'twin/ /raɪt/ /ənd/ /rɔŋ/"
+  },
+  {
+    "chinese": "我们",
+    "english": "we",
+    "soundmark": "/wi/"
+  },
+  {
+    "chinese": "我们知道",
+    "english": "we know",
+    "soundmark": "/wi/ /no/"
+  },
+  {
+    "chinese": "所有；全部",
+    "english": "all",
+    "soundmark": "/ɔl/"
+  },
+  {
+    "chinese": "我们都知道",
+    "english": "we all know",
+    "soundmark": "/wi/ /ɔl/ /no/"
+  },
+  {
+    "chinese": "我们都知道对与错的区别",
+    "english": "we all know the difference between right and wrong",
+    "soundmark": "/wi/ /ɔl/ /no/ /ðə/ /'dɪfrəns/ /bɪ'twin/ /raɪt/ /ənd/ /rɔŋ/"
+  },
+  {
+    "chinese": "你必须知道",
+    "english": "you have to know",
+    "soundmark": "/ju/ /hæv/ /tə/ /no/"
+  },
+  {
+    "chinese": "你必须知道对与错的区别",
+    "english": "you have to know the difference between right and wrong",
+    "soundmark": "/ju/ /hæv/ /tə/ /no/ /ðə/ /'dɪfrəns/ /bɪ'twin/ /raɪt/ /ənd/ /rɔŋ/"
+  },
+  {
+    "chinese": "告诉",
+    "english": "to tell",
+    "soundmark": "/tə/ /tɛl/"
+  },
+  {
+    "chinese": "区别",
+    "english": "the difference",
+    "soundmark": "/ðə/ /'dɪfrəns/"
+  },
+  {
+    "chinese": "分辨区别",
+    "english": "to tell the difference",
+    "soundmark": "/tə/ /tɛl/ /ðə/ /'dɪfrəns/"
+  },
+  {
+    "chinese": "在......之间",
+    "english": "between",
+    "soundmark": "/bɪ'twin/"
+  },
+  {
+    "chinese": "正确和错误",
+    "english": "right and wrong",
+    "soundmark": "/raɪt/ /ənd/ /rɔŋ/"
+  },
+  {
+    "chinese": "在对和错之间",
+    "english": "between right and wrong",
+    "soundmark": "/bɪ'twin/ /raɪt/ /ənd/ /rɔŋ/"
+  },
+  {
+    "chinese": "对与错的区别",
+    "english": "the difference between right and wrong",
+    "soundmark": "/ðə/ /'dɪfrəns/ /bɪ'twin/ /raɪt/ /ənd/ /rɔŋ/"
+  },
+  {
+    "chinese": "分辨是非",
+    "english": "to tell the difference between right and wrong",
+    "soundmark": "/tə/ /tɛl/ /ðə/ /'dɪfrəns/ /bɪ'twin/ /raɪt/ /ənd/ /rɔŋ/"
+  },
+  {
+    "chinese": "年龄大的；老的",
+    "english": "old",
+    "soundmark": "/old/"
+  },
+  {
+    "chinese": "足够",
+    "english": "enough",
+    "soundmark": "/ɪ'nʌf/"
+  },
+  {
+    "chinese": "足够年龄大",
+    "english": "old enough",
+    "soundmark": "/old/ /ɪ'nʌf/"
+  },
+  {
+    "chinese": "你是",
+    "english": "you are",
+    "soundmark": "/ju/ /ɚ/"
+  },
+  {
+    "chinese": "你是足够年龄大的",
+    "english": "you are old enough",
+    "soundmark": "/ju/ /ɚ/ /old/ /ɪ'nʌf/"
+  },
+  {
+    "chinese": "你是年龄大的足够分辨是非",
+    "english": "you are old enough to tell the difference between right and wrong",
+    "soundmark": "/ju/ /ɚ/ /old/ /ɪ'nʌf/ /tə/ /tɛl/ /ðə/ /'dɪfrəns/ /bɪ'twin/ /raɪt/ /ənd/ /rɔŋ/"
+  },
+  {
+    "chinese": "孩子",
+    "english": "child",
+    "soundmark": "/tʃaɪld/"
+  },
+  {
+    "chinese": "孩子们",
+    "english": "children",
+    "soundmark": "/'tʃɪldrən/"
+  },
+  {
+    "chinese": "我们的",
+    "english": "our",
+    "soundmark": "/'aʊɚ/"
+  },
+  {
+    "chinese": "我们的孩子们",
+    "english": "our children",
+    "soundmark": "/'aʊɚ/ /'tʃɪldrən/"
+  },
+  {
+    "chinese": "教",
+    "english": "to teach",
+    "soundmark": "/tə/ /titʃ/"
+  },
+  {
+    "chinese": "我们需要",
+    "english": "we need",
+    "soundmark": "/wi/ /nid/"
+  },
+  {
+    "chinese": "我们需要教",
+    "english": "we need to teach",
+    "soundmark": "/wi/ /nid/ /tə/ /titʃ/"
+  },
+  {
+    "chinese": "我们需要教我们的孩子们",
+    "english": "we need to teach our children",
+    "soundmark": "/wi/ /nid/ /tə/ /titʃ/ /'aʊɚ/ /'tʃɪldrən/"
+  },
+  {
+    "chinese": "分辨区别",
+    "english": "to tell the difference",
+    "soundmark": "/tə/ /tɛl/ /ðə/ /'dɪfrəns/"
+  },
+  {
+    "chinese": "在对和错之间",
+    "english": "between right and wrong",
+    "soundmark": "/bɪ'twin/ /raɪt/ /ənd/ /rɔŋ/"
+  },
+  {
+    "chinese": "辨别是非",
+    "english": "to tell the difference between right and wrong",
+    "soundmark": "/tə/ /tɛl/ /ðə/ /'dɪfrəns/ /bɪ'twin/ /raɪt/ /ənd/ /rɔŋ/"
+  },
+  {
+    "chinese": "如何",
+    "english": "how",
+    "soundmark": "/haʊ/"
+  },
+  {
+    "chinese": "如何辨别是非",
+    "english": "how to tell the difference between right and wrong",
+    "soundmark": "/haʊ/ /tə/ /tɛl/ /ðə/ /'dɪfrəns/ /bɪ'twin/ /raɪt/ /ənd/ /rɔŋ/"
+  },
+  {
+    "chinese": "我们需要教我们的孩子们如何辨别是非",
+    "english": "we need to teach our children how to tell the difference between right and wrong",
+    "soundmark": "/wi/ /nid/ /tə/ /titʃ/ /'aʊɚ/ /'tʃɪldrən/ /haʊ/ /tə/ /tɛl/ /ðə/ /'dɪfrəns/ /bɪ'twin/ /raɪt/ /ənd/ /rɔŋ/"
+  }
 ]

--- a/scripts/courses/36.json
+++ b/scripts/courses/36.json
@@ -1,777 +1,777 @@
 [
-	{
-		"chinese": "保持",
-		"english": "to keep",
-		"soundmark": "/tə/ /kip/"
-	},
-	{
-		"chinese": "他需要",
-		"english": "he needs",
-		"soundmark": "/hi/ /nidz/"
-	},
-	{
-		"chinese": "他需要保持",
-		"english": "he needs to keep",
-		"soundmark": "/hi/ /nidz/ /tə/ /kip/"
-	},
-	{
-		"chinese": "练习",
-		"english": "to practice",
-		"soundmark": "/tə/ /ˈpræktɪs/"
-	},
-	{
-		"chinese": "练习(ing形式)",
-		"english": "practicing",
-		"soundmark": "/ˈpræktɪsɪŋ/"
-	},
-	{
-		"chinese": "他需要保持练习",
-		"english": "he needs to keep practicing",
-		"soundmark": "/hi/ /nidz/ /tə/ /kip/ /ˈpræktɪsɪŋ/"
-	},
-	{
-		"chinese": "技术",
-		"english": "skills",
-		"soundmark": "/'skɪlz/"
-	},
-	{
-		"chinese": "他的技术",
-		"english": "his skills",
-		"soundmark": "/hɪz/ /'skɪlz/"
-	},
-	{
-		"chinese": "提升",
-		"english": "to improve",
-		"soundmark": "/tə/ /ɪmˈpruv/"
-	},
-	{
-		"chinese": "提升他的技术",
-		"english": "to improve his skills",
-		"soundmark": "/tə/ /ɪmˈpruv/ /hɪz/ /'skɪlz/"
-	},
-	{
-		"chinese": "他需要保持练习",
-		"english": "he needs to keep practicing",
-		"soundmark": "/hi/ /nidz/ /tə/ /kip/ /ˈpræktɪsɪŋ/"
-	},
-	{
-		"chinese": "他需要保持练习来提升他的技术",
-		"english": "he needs to keep practicing to improve his skills",
-		"soundmark": "/hi/ /nidz/ /tə/ /kip/ /ˈpræktɪsɪŋ/ /tə/ /ɪmˈpruv/ /hɪz/ /'skɪlz/"
-	},
-	{
-		"chinese": "掌握",
-		"english": "to master",
-		"soundmark": "/'mæstɚ/"
-	},
-	{
-		"chinese": "你将会",
-		"english": "you will",
-		"soundmark": "/ju/ /wɪl/"
-	},
-	{
-		"chinese": "你将会掌握",
-		"english": "you will master",
-		"soundmark": "/ju/ /wɪl/ /'mæstɚ/"
-	},
-	{
-		"chinese": "那个技术",
-		"english": "the skill",
-		"soundmark": "/ðə/ /'skɪl/"
-	},
-	{
-		"chinese": "你将会掌握那个技术",
-		"english": "you will master the skill",
-		"soundmark": "/ju/ /wɪl/ /'mæstɚ/ /ðə/ /'skɪl/"
-	},
-	{
-		"chinese": "你保持",
-		"english": "you keep",
-		"soundmark": "/ju/ /kip/"
-	},
-	{
-		"chinese": "练习",
-		"english": "to practice",
-		"soundmark": "/tə/ /ˈpræktɪs/"
-	},
-	{
-		"chinese": "练习(ing形式)",
-		"english": "practicing",
-		"soundmark": "/ˈpræktɪsɪŋ/"
-	},
-	{
-		"chinese": "你保持练习",
-		"english": "you keep practicing",
-		"soundmark": "/ju/ /kip/ /ˈpræktɪsɪŋ/"
-	},
-	{
-		"chinese": "你保持练习那么你将会掌握那个技术",
-		"english": "you keep practicing and you will master the skill",
-		"soundmark": "/ju/ /kip/ /ˈpræktɪsɪŋ/ /ənd/ /ju/ /wɪl/ /'mæstɚ/ /ðə/ /'skɪl/"
-	},
-	{
-		"chinese": "保持练习那么你将会掌握那个技术",
-		"english": "keep practicing and you will master the skill",
-		"soundmark": "/kip/ /ˈpræktɪsɪŋ/ /ənd/ /ju/ /wɪl/ /'mæstɚ/ /ðə/ /'skɪl/"
-	},
-	{
-		"chinese": "新的",
-		"english": "new",
-		"soundmark": "/nu/"
-	},
-	{
-		"chinese": "新的技术",
-		"english": "new skills",
-		"soundmark": "/nu/ /'skɪlz/"
-	},
-	{
-		"chinese": "学习",
-		"english": "to learn",
-		"soundmark": "/tə/ /lɝn/"
-	},
-	{
-		"chinese": "学习新的技术",
-		"english": "to learn new skills",
-		"soundmark": "/tə/ /lɝn/ /nu/ /'skɪlz/"
-	},
-	{
-		"chinese": "学习新的技术(ing形式)",
-		"english": "learning new skills",
-		"soundmark": "/'lɝnɪŋ/ /nu/ /'skɪlz/"
-	},
-	{
-		"chinese": "保持",
-		"english": "to keep",
-		"soundmark": "/tə/ /kip/"
-	},
-	{
-		"chinese": "她保持",
-		"english": "she keeps",
-		"soundmark": "/ʃi/ /kips/"
-	},
-	{
-		"chinese": "她一直学习新的技术",
-		"english": "she keeps learning new skills",
-		"soundmark": "/ʃi/ /kips/ /'lɝnɪŋ/ /nu/ /'skɪlz/"
-	},
-	{
-		"chinese": "提升",
-		"english": "to improve",
-		"soundmark": "/tə/ /ɪmˈpruv/"
-	},
-	{
-		"chinese": "她自己",
-		"english": "herself",
-		"soundmark": "/hɝ'sɛlf/"
-	},
-	{
-		"chinese": "提升她自己",
-		"english": "to improve herself",
-		"soundmark": "/tə/ /ɪmˈpruv/ /hɝ'sɛlf/"
-	},
-	{
-		"chinese": "她一直学习新的技术来提升她自己",
-		"english": "she keeps learning new skills to improve herself",
-		"soundmark": "/ʃi/ /kips/ /'lɝnɪŋ/ /nu/ /'skɪlz/ /tə/ /ɪmˈpruv/ /hɝ'sɛlf/"
-	},
-	{
-		"chinese": "锁",
-		"english": "to lock",
-		"soundmark": "/tə/ /lɑk/"
-	},
-	{
-		"chinese": "门",
-		"english": "the door",
-		"soundmark": "/ðə/ /dɔr/"
-	},
-	{
-		"chinese": "锁门",
-		"english": "to lock the door",
-		"soundmark": "/tə/ /lɑk/ /ðə/ /dɔr/"
-	},
-	{
-		"chinese": "忘记",
-		"english": "to forget",
-		"soundmark": "/tə/ /fɚ'ɡɛt/"
-	},
-	{
-		"chinese": "忘记锁门",
-		"english": "to forget to lock the door",
-		"soundmark": "/tə/ /fɚ'ɡɛt/ /tə/ /lɑk/ /ðə/ /dɔr/"
-	},
-	{
-		"chinese": "忘记锁门(ing形式)",
-		"english": "forgetting to lock the door",
-		"soundmark": "/fɚ'ɡɛtɪŋ/ /tə/ /lɑk/ /ðə/ /dɔr/"
-	},
-	{
-		"chinese": "保持",
-		"english": "to keep",
-		"soundmark": "/tə/ /kip/"
-	},
-	{
-		"chinese": "她保持",
-		"english": "she keeps",
-		"soundmark": "/ʃi/ /kips/"
-	},
-	{
-		"chinese": "她总是忘记锁门",
-		"english": "she keeps forgetting to lock the door",
-		"soundmark": "/ʃi/ /kips/ /fɚ'ɡɛtɪŋ/ /tə/ /lɑk/ /ðə/ /dɔr/"
-	},
-	{
-		"chinese": "离开",
-		"english": "to leave",
-		"soundmark": "/tə/ /liv/"
-	},
-	{
-		"chinese": "她离开",
-		"english": "she leaves",
-		"soundmark": "/ʃi/ /livz/"
-	},
-	{
-		"chinese": "当......的时候",
-		"english": "when",
-		"soundmark": "/wɛn/"
-	},
-	{
-		"chinese": "当她离开的时候",
-		"english": "when she leaves",
-		"soundmark": "/wɛn/ /ʃi/ /livz/"
-	},
-	{
-		"chinese": "她总是忘记锁门",
-		"english": "she keeps forgetting to lock the door",
-		"soundmark": "/ʃi/ /kips/ /fɚ'ɡɛtɪŋ/ /tə/ /lɑk/ /ðə/ /dɔr/"
-	},
-	{
-		"chinese": "他总是忘记锁门当她离开的时候",
-		"english": "she keeps forgetting to lock the door when she leaves",
-		"soundmark": "/ʃi/ /kips/ /fɚ'ɡɛtɪŋ/ /tə/ /lɑk/ /ðə/ /dɔr/ /wɛn/ /ʃi/ /livz/"
-	},
-	{
-		"chinese": "钥匙",
-		"english": "keys",
-		"soundmark": "/kiz/"
-	},
-	{
-		"chinese": "他的钥匙",
-		"english": "his keys",
-		"soundmark": "/hɪz/ /kiz/"
-	},
-	{
-		"chinese": "忘记",
-		"english": "to forget",
-		"soundmark": "/tə/ /fɚ'ɡɛt/"
-	},
-	{
-		"chinese": "忘记他的钥匙",
-		"english": "to forget his keys",
-		"soundmark": "/tə/ /fɚ'ɡɛt/ /hɪz/ /kiz/"
-	},
-	{
-		"chinese": "家",
-		"english": "home",
-		"soundmark": "/hom/"
-	},
-	{
-		"chinese": "在家",
-		"english": "at home",
-		"soundmark": "/ət/ /hom/"
-	},
-	{
-		"chinese": "忘记他的钥匙在家里",
-		"english": "to forget his keys at home",
-		"soundmark": "/tə/ /fɚ'ɡɛt/ /hɪz/ /kiz/ /ət/ /hom/"
-	},
-	{
-		"chinese": "忘记他的钥匙在家里(ing形式)",
-		"english": "forgetting his keys at home",
-		"soundmark": "/fɚ'ɡɛtɪŋ/ /hɪz/ /kiz/ /ət/ /hom/"
-	},
-	{
-		"chinese": "保持",
-		"english": "to keep",
-		"soundmark": "/tə/ /kip/"
-	},
-	{
-		"chinese": "他保持",
-		"english": "he keeps",
-		"soundmark": "/hi/ /kips/"
-	},
-	{
-		"chinese": "他总是忘记他的钥匙在家里",
-		"english": "he keeps forgetting his keys at home",
-		"soundmark": "/hi/ /kips/ /fɚ'ɡɛtɪŋ/ /hɪz/ /kiz/ /ət/ /hom/"
-	},
-	{
-		"chinese": "想法",
-		"english": "mind",
-		"soundmark": "/maɪnd/"
-	},
-	{
-		"chinese": "他的想法",
-		"english": "his mind",
-		"soundmark": "/hɪz/ /maɪnd/"
-	},
-	{
-		"chinese": "改变",
-		"english": "to change",
-		"soundmark": "/tə/ /tʃendʒ/"
-	},
-	{
-		"chinese": "改变他的想法",
-		"english": "to change his mind",
-		"soundmark": "/tə/ /tʃendʒ/ /hɪz/ /maɪnd/"
-	},
-	{
-		"chinese": "改变他的想法(ing形式)",
-		"english": "changing his mind",
-		"soundmark": "/'tʃendʒɪŋ/ /hɪz/ /maɪnd/"
-	},
-	{
-		"chinese": "保持",
-		"english": "to keep",
-		"soundmark": "/tə/ /kip/"
-	},
-	{
-		"chinese": "他保持",
-		"english": "he keeps",
-		"soundmark": "/hi/ /kips/"
-	},
-	{
-		"chinese": "他总是改变他的想法",
-		"english": "he keeps changing his mind",
-		"soundmark": "/hi/ /kips/ /'tʃendʒɪŋ/ /hɪz/ /maɪnd/"
-	},
-	{
-		"chinese": "时间",
-		"english": "time",
-		"soundmark": "/taɪm/"
-	},
-	{
-		"chinese": "所有的时间",
-		"english": "all the time",
-		"soundmark": "/ɔl/ /ðə/ /taɪm/"
-	},
-	{
-		"chinese": "他(一直)总是改变他的想法",
-		"english": "he keeps changing his mind all the time",
-		"soundmark": "/hi/ /kips/ /'tʃendʒɪŋ/ /hɪz/ /maɪnd/ /ɔl/ /ðə/ /taɪm/"
-	},
-	{
-		"chinese": "想法",
-		"english": "mind",
-		"soundmark": "/maɪnd/"
-	},
-	{
-		"chinese": "介意",
-		"english": "to mind",
-		"soundmark": "/tə/ /maɪnd/"
-	},
-	{
-		"chinese": "我介意",
-		"english": "I mind",
-		"soundmark": "/aɪ/ /maɪnd/"
-	},
-	{
-		"chinese": "打开",
-		"english": "to open",
-		"soundmark": "/tə/ /'opən/"
-	},
-	{
-		"chinese": "这个窗户",
-		"english": "the window",
-		"soundmark": "/ðə/ /'wɪndo/"
-	},
-	{
-		"chinese": "打开这个窗户",
-		"english": "to open the window",
-		"soundmark": "/tə/ /'opən/ /ðə/ /'wɪndo/"
-	},
-	{
-		"chinese": "打开这个窗户(ing形式)",
-		"english": "opening the window",
-		"soundmark": "/'opənɪŋ/ /ðə/ /'wɪndo/"
-	},
-	{
-		"chinese": "我介意打开这个窗户",
-		"english": "I mind opening the window",
-		"soundmark": "/aɪ/ /maɪnd/ /'opənɪŋ/ /ðə/ /'wɪndo/"
-	},
-	{
-		"chinese": "我不介意打开这个窗户",
-		"english": "I don't mind opening the window",
-		"soundmark": "/aɪ/ /dont/ /maɪnd/ /'opənɪŋ/ /ðə/ /'wɪndo/"
-	},
-	{
-		"chinese": "支付",
-		"english": "to pay",
-		"soundmark": "/tə/ /pe/"
-	},
-	{
-		"chinese": "账单",
-		"english": "the bill",
-		"soundmark": "/ðə/ /bɪl/"
-	},
-	{
-		"chinese": "支付账单",
-		"english": "to pay the bill",
-		"soundmark": "/tə/ /pe/ /ðə/ /bɪl/"
-	},
-	{
-		"chinese": "支付账单(ing形式)",
-		"english": "paying the bill",
-		"soundmark": "/'peɪŋ/ /ðə/ /bɪl/"
-	},
-	{
-		"chinese": "介意",
-		"english": "to mind",
-		"soundmark": "/tə/ /maɪnd/"
-	},
-	{
-		"chinese": "他介意",
-		"english": "he minds",
-		"soundmark": "/hi/ /maɪndz/"
-	},
-	{
-		"chinese": "他介意支付账单",
-		"english": "he minds paying the bill",
-		"soundmark": "/hi/ /maɪndz/ /'peɪŋ/ /ðə/ /bɪl/"
-	},
-	{
-		"chinese": "他不介意支付账单",
-		"english": "he doesn't mind paying the bill",
-		"soundmark": "/hi/ /ˈdʌznt/ /maɪnd/ /'peɪŋ/ /ðə/ /bɪl/"
-	},
-	{
-		"chinese": "玩具",
-		"english": "toy",
-		"soundmark": "/tɔɪ/"
-	},
-	{
-		"chinese": "他的玩具",
-		"english": "his toys",
-		"soundmark": "/hɪz/ /tɔɪz/"
-	},
-	{
-		"chinese": "分享",
-		"english": "to share",
-		"soundmark": "/tə/ /ʃɛr/"
-	},
-	{
-		"chinese": "分享他的玩具",
-		"english": "to share his toys",
-		"soundmark": "/tə/ /ʃɛr/ /hɪz/ /tɔɪz/"
-	},
-	{
-		"chinese": "朋友",
-		"english": "friend",
-		"soundmark": "/frɛnd/"
-	},
-	{
-		"chinese": "他的朋友们",
-		"english": "his friends",
-		"soundmark": "/hɪz/ /frɛndz/"
-	},
-	{
-		"chinese": "和",
-		"english": "with",
-		"soundmark": "/wɪð/"
-	},
-	{
-		"chinese": "和他的朋友们",
-		"english": "with his friends",
-		"soundmark": "/wɪð/ /hɪz/ /frɛndz/"
-	},
-	{
-		"chinese": "和他的朋友们分享他的玩具",
-		"english": "to share his toys with his friends",
-		"soundmark": "/tə/ /ʃɛr/ /hɪz/ /tɔɪz/ /wɪð/ /hɪz/ /frɛndz/"
-	},
-	{
-		"chinese": "和他的朋友们分享他的玩具",
-		"english": "(ing形式) sharing his toys with his friends",
-		"soundmark": "/'ʃɛriŋ/ /hɪz/ /tɔɪz/ /wɪð/ /hɪz/ /frɛndz/"
-	},
-	{
-		"chinese": "他介意",
-		"english": "he minds",
-		"soundmark": "/hi/ /maɪndz/"
-	},
-	{
-		"chinese": "他介意和他的朋友们分享他的玩具",
-		"english": "he minds sharing his toys with his friends",
-		"soundmark": "/hi/ /maɪndz/ /'ʃɛəriŋ/ /hɪz/ /tɔɪz/ /wɪð/ /hɪz/ /frɛndz/"
-	},
-	{
-		"chinese": "他不介意和他的朋友们分享他的玩具",
-		"english": "he doesn't mind sharing his toys with his friends",
-		"soundmark": "/hi/ /ˈdʌznt/ /maɪnd/ /'ʃɛəriŋ/ /hɪz/ /tɔɪz/ /wɪð/ /hɪz/ /frɛndz/"
-	},
-	{
-		"chinese": "他不介意",
-		"english": "he doesn't mind",
-		"soundmark": "/hi/ /ˈdʌznt/ /maɪnd/"
-	},
-	{
-		"chinese": "他的食物",
-		"english": "his food",
-		"soundmark": "/hɪz/ /fud/"
-	},
-	{
-		"chinese": "分享",
-		"english": "to share",
-		"soundmark": "/tə/ /ʃɛr/"
-	},
-	{
-		"chinese": "分享他的食物",
-		"english": "to share his food",
-		"soundmark": "/tə/ /ʃɛr/ /hɪz/ /fud/"
-	},
-	{
-		"chinese": "别人",
-		"english": "others",
-		"soundmark": "/'ʌðɚz/"
-	},
-	{
-		"chinese": "和",
-		"english": "with",
-		"soundmark": "/wɪð/"
-	},
-	{
-		"chinese": "和别人",
-		"english": "with others",
-		"soundmark": "/wɪð/ /'ʌðɚz/"
-	},
-	{
-		"chinese": "和别人分享他的食物",
-		"english": "to share his food with others",
-		"soundmark": "/tə/ /ʃɛr/ /hɪz/ /fud/ /wɪð/ /'ʌðɚz/"
-	},
-	{
-		"chinese": "和别人分享他的食物(ing形式)",
-		"english": "sharing his food with others",
-		"soundmark": "/'ʃɛriŋ/ /hɪz/ /fud/ /wɪð/ /'ʌðɚz/"
-	},
-	{
-		"chinese": "介意",
-		"english": "to mind",
-		"soundmark": "/tə/ /maɪnd/"
-	},
-	{
-		"chinese": "他介意",
-		"english": "he minds",
-		"soundmark": "/hi/ /maɪndz/"
-	},
-	{
-		"chinese": "他不介意",
-		"english": "he doesn't mind",
-		"soundmark": "/hi/ /ˈdʌznt/ /maɪnd/"
-	},
-	{
-		"chinese": "他不介意和别人分享他的食物",
-		"english": "he doesn't mind sharing his toys with his friends",
-		"soundmark": "/hi/ /ˈdʌznt/ /maɪnd/ /'ʃɛriŋ/ /hɪz/ /fud/ /wɪð/ /'ʌðɚz/"
-	},
-	{
-		"chinese": "等",
-		"english": "to wait",
-		"soundmark": "/tə/ /wet/"
-	},
-	{
-		"chinese": "她",
-		"english": "her",
-		"soundmark": "/hɚ/"
-	},
-	{
-		"chinese": "等她",
-		"english": "to wait for her",
-		"soundmark": "/tə/ /wet/ /fɚ/ /hɚ/"
-	},
-	{
-		"chinese": "机场",
-		"english": "airport",
-		"soundmark": "/'ɛrpɔrt/"
-	},
-	{
-		"chinese": "在机场",
-		"english": "at the airport",
-		"soundmark": "/ət/ /ði/ /'ɛrpɔrt/"
-	},
-	{
-		"chinese": "在机场等她",
-		"english": "to wait for her at the airport",
-		"soundmark": "/tə/ /wet/ /fɚ/ /hɚ/ /ət/ /ði/ /'ɛrpɔrt/"
-	},
-	{
-		"chinese": "在机场等她(ing形式)",
-		"english": "waiting for her at the airport",
-		"soundmark": "/'wetɪŋ/ /fɚ/ /hɚ/ /ət/ /ði/ /'ɛrpɔrt/"
-	},
-	{
-		"chinese": "他不介意",
-		"english": "he doesn't mind",
-		"soundmark": "/hi/ /ˈdʌznt/ /maɪnd/"
-	},
-	{
-		"chinese": "他不介意在机场等她",
-		"english": "he doesn't mind waiting for her at the airport",
-		"soundmark": "/hi/ /ˈdʌznt/ /maɪnd/ /'wetɪŋ/ /fɚ/ /hɚ/ /ət/ /ði/ /'ɛrpɔrt/"
-	},
-	{
-		"chinese": "介意",
-		"english": "to mind",
-		"soundmark": "/tə/ /maɪnd/"
-	},
-	{
-		"chinese": "他们介意",
-		"english": "they mind",
-		"soundmark": "/ðe/ /maɪnd/"
-	},
-	{
-		"chinese": "秘密",
-		"english": "secret",
-		"soundmark": "/'sikrət/"
-	},
-	{
-		"chinese": "他们的秘密",
-		"english": "their secrets",
-		"soundmark": "/ðɛr/ /'sikrəts/"
-	},
-	{
-		"chinese": "分享",
-		"english": "to share",
-		"soundmark": "/tə/ /ʃɛr/"
-	},
-	{
-		"chinese": "分享他们的秘密",
-		"english": "to share their secrets",
-		"soundmark": "/tə/ /ʃɛr/ /ðɛr/ /'sikrəts/"
-	},
-	{
-		"chinese": "任何人",
-		"english": "anyone",
-		"soundmark": "/'ɛnɪwʌn/"
-	},
-	{
-		"chinese": "和",
-		"english": "with",
-		"soundmark": "/wɪð/"
-	},
-	{
-		"chinese": "和任何人",
-		"english": "with anyone",
-		"soundmark": "/wɪð/ /'ɛnɪwʌn/"
-	},
-	{
-		"chinese": "和任何人分享他们的秘密",
-		"english": "to share their secrets with anyone",
-		"soundmark": "/tə/ /ʃɛr/ /ðɛr/ /'sikrəts/ /wɪð/ /'ɛnɪwʌn/"
-	},
-	{
-		"chinese": "和任何人分享他们的秘密(ing形式)",
-		"english": "sharing their secrets with anyone",
-		"soundmark": "/'ʃɛriŋ/ /ðɛr/ /'sikrəts/ /wɪð/ /'ɛnɪwʌn/"
-	},
-	{
-		"chinese": "他们介意",
-		"english": "they mind",
-		"soundmark": "/ðe/ /maɪnd/"
-	},
-	{
-		"chinese": "他们不介意",
-		"english": "they don't mind",
-		"soundmark": "/ðe/ /dont/ /maɪnd/"
-	},
-	{
-		"chinese": "他们不介意和任何人分享他们的秘密",
-		"english": "they don't mind sharing their secrets with anyone",
-		"soundmark": "/ðe/ /dont/ /maɪnd/ /'ʃɛriŋ/ /ðɛr/ /'sikrəts/ /wɪð/ /'ɛnɪwʌn/"
-	},
-	{
-		"chinese": "他介意",
-		"english": "he minds",
-		"soundmark": "/hi/ /maɪndz/"
-	},
-	{
-		"chinese": "建议",
-		"english": "advice",
-		"soundmark": "/əd'vaɪs/"
-	},
-	{
-		"chinese": "一些",
-		"english": "some",
-		"soundmark": "/səm/"
-	},
-	{
-		"chinese": "一些建议",
-		"english": "some advice",
-		"soundmark": "/səm/ /əd'vaɪs/"
-	},
-	{
-		"chinese": "问题",
-		"english": "problem",
-		"soundmark": "/'prɑbləm/"
-	},
-	{
-		"chinese": "这个问题",
-		"english": "this promblem",
-		"soundmark": "/ðɪs/ /'prɑbləm/"
-	},
-	{
-		"chinese": "关于",
-		"english": "about",
-		"soundmark": "/ə'baʊt/"
-	},
-	{
-		"chinese": "关于这个问题",
-		"english": "about this problem",
-		"soundmark": "/ə'baʊt/ /ðɪs/ /'prɑbləm/"
-	},
-	{
-		"chinese": "关于这个问题的一些建议",
-		"english": "some advice about this problem",
-		"soundmark": "/səm/ /əd'vaɪs/ /ə'baʊt/ /ðɪs/ /'prɑbləm/"
-	},
-	{
-		"chinese": "给",
-		"english": "to give",
-		"soundmark": "/tə/ /ɡɪv/"
-	},
-	{
-		"chinese": "给我",
-		"english": "to give me",
-		"soundmark": "/tə/ /ɡɪv/ /mi/"
-	},
-	{
-		"chinese": "给我一些建议",
-		"english": "to give me some advice",
-		"soundmark": "/tə/ /ɡɪv/ /mi/ /səm/ /əd'vaɪs/"
-	},
-	{
-		"chinese": "给我关于这个问题的一些建议",
-		"english": "to give me some advice about this problem",
-		"soundmark": "/tə/ /ɡɪv/ /mi/ /səm/ /əd'vaɪs/ /ə'baʊt/ /ðɪs/ /'prɑbləm/"
-	},
-	{
-		"chinese": "给我关于这个问题的一些建议",
-		"english": "(ing形式) giving me some advice about this problem",
-		"soundmark": "/ɡɪviŋ/ /mi/ /səm/ /əd'vaɪs/ /ə'baʊt/ /ðɪs/ /'prɑbləm/"
-	},
-	{
-		"chinese": "他介意",
-		"english": "he minds",
-		"soundmark": "/hi/ /maɪndz/"
-	},
-	{
-		"chinese": "他不介意",
-		"english": "he doesn't mind",
-		"soundmark": "/hi/ /ˈdʌznt/ /maɪnd/"
-	},
-	{
-		"chinese": "他不介意给我关于这个问题的一些建议",
-		"english": "he doesn't mind giving me some advice about this problem",
-		"soundmark": "/hi/ /ˈdʌznt/ /maɪnd/ /ɡɪviŋ/ /mi/ /səm/ /əd'vaɪs/ /ə'baʊt/ /ðɪs/ /'prɑbləm/"
-	}
+  {
+    "chinese": "保持",
+    "english": "to keep",
+    "soundmark": "/tə/ /kip/"
+  },
+  {
+    "chinese": "他需要",
+    "english": "he needs",
+    "soundmark": "/hi/ /nidz/"
+  },
+  {
+    "chinese": "他需要保持",
+    "english": "he needs to keep",
+    "soundmark": "/hi/ /nidz/ /tə/ /kip/"
+  },
+  {
+    "chinese": "练习",
+    "english": "to practice",
+    "soundmark": "/tə/ /ˈpræktɪs/"
+  },
+  {
+    "chinese": "练习(ing形式)",
+    "english": "practicing",
+    "soundmark": "/ˈpræktɪsɪŋ/"
+  },
+  {
+    "chinese": "他需要保持练习",
+    "english": "he needs to keep practicing",
+    "soundmark": "/hi/ /nidz/ /tə/ /kip/ /ˈpræktɪsɪŋ/"
+  },
+  {
+    "chinese": "技术",
+    "english": "skills",
+    "soundmark": "/'skɪlz/"
+  },
+  {
+    "chinese": "他的技术",
+    "english": "his skills",
+    "soundmark": "/hɪz/ /'skɪlz/"
+  },
+  {
+    "chinese": "提升",
+    "english": "to improve",
+    "soundmark": "/tə/ /ɪmˈpruv/"
+  },
+  {
+    "chinese": "提升他的技术",
+    "english": "to improve his skills",
+    "soundmark": "/tə/ /ɪmˈpruv/ /hɪz/ /'skɪlz/"
+  },
+  {
+    "chinese": "他需要保持练习",
+    "english": "he needs to keep practicing",
+    "soundmark": "/hi/ /nidz/ /tə/ /kip/ /ˈpræktɪsɪŋ/"
+  },
+  {
+    "chinese": "他需要保持练习来提升他的技术",
+    "english": "he needs to keep practicing to improve his skills",
+    "soundmark": "/hi/ /nidz/ /tə/ /kip/ /ˈpræktɪsɪŋ/ /tə/ /ɪmˈpruv/ /hɪz/ /'skɪlz/"
+  },
+  {
+    "chinese": "掌握",
+    "english": "to master",
+    "soundmark": "/'mæstɚ/"
+  },
+  {
+    "chinese": "你将会",
+    "english": "you will",
+    "soundmark": "/ju/ /wɪl/"
+  },
+  {
+    "chinese": "你将会掌握",
+    "english": "you will master",
+    "soundmark": "/ju/ /wɪl/ /'mæstɚ/"
+  },
+  {
+    "chinese": "那个技术",
+    "english": "the skill",
+    "soundmark": "/ðə/ /'skɪl/"
+  },
+  {
+    "chinese": "你将会掌握那个技术",
+    "english": "you will master the skill",
+    "soundmark": "/ju/ /wɪl/ /'mæstɚ/ /ðə/ /'skɪl/"
+  },
+  {
+    "chinese": "你保持",
+    "english": "you keep",
+    "soundmark": "/ju/ /kip/"
+  },
+  {
+    "chinese": "练习",
+    "english": "to practice",
+    "soundmark": "/tə/ /ˈpræktɪs/"
+  },
+  {
+    "chinese": "练习(ing形式)",
+    "english": "practicing",
+    "soundmark": "/ˈpræktɪsɪŋ/"
+  },
+  {
+    "chinese": "你保持练习",
+    "english": "you keep practicing",
+    "soundmark": "/ju/ /kip/ /ˈpræktɪsɪŋ/"
+  },
+  {
+    "chinese": "你保持练习那么你将会掌握那个技术",
+    "english": "you keep practicing and you will master the skill",
+    "soundmark": "/ju/ /kip/ /ˈpræktɪsɪŋ/ /ənd/ /ju/ /wɪl/ /'mæstɚ/ /ðə/ /'skɪl/"
+  },
+  {
+    "chinese": "保持练习那么你将会掌握那个技术",
+    "english": "keep practicing and you will master the skill",
+    "soundmark": "/kip/ /ˈpræktɪsɪŋ/ /ənd/ /ju/ /wɪl/ /'mæstɚ/ /ðə/ /'skɪl/"
+  },
+  {
+    "chinese": "新的",
+    "english": "new",
+    "soundmark": "/nu/"
+  },
+  {
+    "chinese": "新的技术",
+    "english": "new skills",
+    "soundmark": "/nu/ /'skɪlz/"
+  },
+  {
+    "chinese": "学习",
+    "english": "to learn",
+    "soundmark": "/tə/ /lɝn/"
+  },
+  {
+    "chinese": "学习新的技术",
+    "english": "to learn new skills",
+    "soundmark": "/tə/ /lɝn/ /nu/ /'skɪlz/"
+  },
+  {
+    "chinese": "学习新的技术(ing形式)",
+    "english": "learning new skills",
+    "soundmark": "/'lɝnɪŋ/ /nu/ /'skɪlz/"
+  },
+  {
+    "chinese": "保持",
+    "english": "to keep",
+    "soundmark": "/tə/ /kip/"
+  },
+  {
+    "chinese": "她保持",
+    "english": "she keeps",
+    "soundmark": "/ʃi/ /kips/"
+  },
+  {
+    "chinese": "她一直学习新的技术",
+    "english": "she keeps learning new skills",
+    "soundmark": "/ʃi/ /kips/ /'lɝnɪŋ/ /nu/ /'skɪlz/"
+  },
+  {
+    "chinese": "提升",
+    "english": "to improve",
+    "soundmark": "/tə/ /ɪmˈpruv/"
+  },
+  {
+    "chinese": "她自己",
+    "english": "herself",
+    "soundmark": "/hɝ'sɛlf/"
+  },
+  {
+    "chinese": "提升她自己",
+    "english": "to improve herself",
+    "soundmark": "/tə/ /ɪmˈpruv/ /hɝ'sɛlf/"
+  },
+  {
+    "chinese": "她一直学习新的技术来提升她自己",
+    "english": "she keeps learning new skills to improve herself",
+    "soundmark": "/ʃi/ /kips/ /'lɝnɪŋ/ /nu/ /'skɪlz/ /tə/ /ɪmˈpruv/ /hɝ'sɛlf/"
+  },
+  {
+    "chinese": "锁",
+    "english": "to lock",
+    "soundmark": "/tə/ /lɑk/"
+  },
+  {
+    "chinese": "门",
+    "english": "the door",
+    "soundmark": "/ðə/ /dɔr/"
+  },
+  {
+    "chinese": "锁门",
+    "english": "to lock the door",
+    "soundmark": "/tə/ /lɑk/ /ðə/ /dɔr/"
+  },
+  {
+    "chinese": "忘记",
+    "english": "to forget",
+    "soundmark": "/tə/ /fɚ'ɡɛt/"
+  },
+  {
+    "chinese": "忘记锁门",
+    "english": "to forget to lock the door",
+    "soundmark": "/tə/ /fɚ'ɡɛt/ /tə/ /lɑk/ /ðə/ /dɔr/"
+  },
+  {
+    "chinese": "忘记锁门(ing形式)",
+    "english": "forgetting to lock the door",
+    "soundmark": "/fɚ'ɡɛtɪŋ/ /tə/ /lɑk/ /ðə/ /dɔr/"
+  },
+  {
+    "chinese": "保持",
+    "english": "to keep",
+    "soundmark": "/tə/ /kip/"
+  },
+  {
+    "chinese": "她保持",
+    "english": "she keeps",
+    "soundmark": "/ʃi/ /kips/"
+  },
+  {
+    "chinese": "她总是忘记锁门",
+    "english": "she keeps forgetting to lock the door",
+    "soundmark": "/ʃi/ /kips/ /fɚ'ɡɛtɪŋ/ /tə/ /lɑk/ /ðə/ /dɔr/"
+  },
+  {
+    "chinese": "离开",
+    "english": "to leave",
+    "soundmark": "/tə/ /liv/"
+  },
+  {
+    "chinese": "她离开",
+    "english": "she leaves",
+    "soundmark": "/ʃi/ /livz/"
+  },
+  {
+    "chinese": "当......的时候",
+    "english": "when",
+    "soundmark": "/wɛn/"
+  },
+  {
+    "chinese": "当她离开的时候",
+    "english": "when she leaves",
+    "soundmark": "/wɛn/ /ʃi/ /livz/"
+  },
+  {
+    "chinese": "她总是忘记锁门",
+    "english": "she keeps forgetting to lock the door",
+    "soundmark": "/ʃi/ /kips/ /fɚ'ɡɛtɪŋ/ /tə/ /lɑk/ /ðə/ /dɔr/"
+  },
+  {
+    "chinese": "他总是忘记锁门当她离开的时候",
+    "english": "she keeps forgetting to lock the door when she leaves",
+    "soundmark": "/ʃi/ /kips/ /fɚ'ɡɛtɪŋ/ /tə/ /lɑk/ /ðə/ /dɔr/ /wɛn/ /ʃi/ /livz/"
+  },
+  {
+    "chinese": "钥匙",
+    "english": "keys",
+    "soundmark": "/kiz/"
+  },
+  {
+    "chinese": "他的钥匙",
+    "english": "his keys",
+    "soundmark": "/hɪz/ /kiz/"
+  },
+  {
+    "chinese": "忘记",
+    "english": "to forget",
+    "soundmark": "/tə/ /fɚ'ɡɛt/"
+  },
+  {
+    "chinese": "忘记他的钥匙",
+    "english": "to forget his keys",
+    "soundmark": "/tə/ /fɚ'ɡɛt/ /hɪz/ /kiz/"
+  },
+  {
+    "chinese": "家",
+    "english": "home",
+    "soundmark": "/hom/"
+  },
+  {
+    "chinese": "在家",
+    "english": "at home",
+    "soundmark": "/ət/ /hom/"
+  },
+  {
+    "chinese": "忘记他的钥匙在家里",
+    "english": "to forget his keys at home",
+    "soundmark": "/tə/ /fɚ'ɡɛt/ /hɪz/ /kiz/ /ət/ /hom/"
+  },
+  {
+    "chinese": "忘记他的钥匙在家里(ing形式)",
+    "english": "forgetting his keys at home",
+    "soundmark": "/fɚ'ɡɛtɪŋ/ /hɪz/ /kiz/ /ət/ /hom/"
+  },
+  {
+    "chinese": "保持",
+    "english": "to keep",
+    "soundmark": "/tə/ /kip/"
+  },
+  {
+    "chinese": "他保持",
+    "english": "he keeps",
+    "soundmark": "/hi/ /kips/"
+  },
+  {
+    "chinese": "他总是忘记他的钥匙在家里",
+    "english": "he keeps forgetting his keys at home",
+    "soundmark": "/hi/ /kips/ /fɚ'ɡɛtɪŋ/ /hɪz/ /kiz/ /ət/ /hom/"
+  },
+  {
+    "chinese": "想法",
+    "english": "mind",
+    "soundmark": "/maɪnd/"
+  },
+  {
+    "chinese": "他的想法",
+    "english": "his mind",
+    "soundmark": "/hɪz/ /maɪnd/"
+  },
+  {
+    "chinese": "改变",
+    "english": "to change",
+    "soundmark": "/tə/ /tʃendʒ/"
+  },
+  {
+    "chinese": "改变他的想法",
+    "english": "to change his mind",
+    "soundmark": "/tə/ /tʃendʒ/ /hɪz/ /maɪnd/"
+  },
+  {
+    "chinese": "改变他的想法(ing形式)",
+    "english": "changing his mind",
+    "soundmark": "/'tʃendʒɪŋ/ /hɪz/ /maɪnd/"
+  },
+  {
+    "chinese": "保持",
+    "english": "to keep",
+    "soundmark": "/tə/ /kip/"
+  },
+  {
+    "chinese": "他保持",
+    "english": "he keeps",
+    "soundmark": "/hi/ /kips/"
+  },
+  {
+    "chinese": "他总是改变他的想法",
+    "english": "he keeps changing his mind",
+    "soundmark": "/hi/ /kips/ /'tʃendʒɪŋ/ /hɪz/ /maɪnd/"
+  },
+  {
+    "chinese": "时间",
+    "english": "time",
+    "soundmark": "/taɪm/"
+  },
+  {
+    "chinese": "所有的时间",
+    "english": "all the time",
+    "soundmark": "/ɔl/ /ðə/ /taɪm/"
+  },
+  {
+    "chinese": "他(一直)总是改变他的想法",
+    "english": "he keeps changing his mind all the time",
+    "soundmark": "/hi/ /kips/ /'tʃendʒɪŋ/ /hɪz/ /maɪnd/ /ɔl/ /ðə/ /taɪm/"
+  },
+  {
+    "chinese": "想法",
+    "english": "mind",
+    "soundmark": "/maɪnd/"
+  },
+  {
+    "chinese": "介意",
+    "english": "to mind",
+    "soundmark": "/tə/ /maɪnd/"
+  },
+  {
+    "chinese": "我介意",
+    "english": "I mind",
+    "soundmark": "/aɪ/ /maɪnd/"
+  },
+  {
+    "chinese": "打开",
+    "english": "to open",
+    "soundmark": "/tə/ /'opən/"
+  },
+  {
+    "chinese": "这个窗户",
+    "english": "the window",
+    "soundmark": "/ðə/ /'wɪndo/"
+  },
+  {
+    "chinese": "打开这个窗户",
+    "english": "to open the window",
+    "soundmark": "/tə/ /'opən/ /ðə/ /'wɪndo/"
+  },
+  {
+    "chinese": "打开这个窗户(ing形式)",
+    "english": "opening the window",
+    "soundmark": "/'opənɪŋ/ /ðə/ /'wɪndo/"
+  },
+  {
+    "chinese": "我介意打开这个窗户",
+    "english": "I mind opening the window",
+    "soundmark": "/aɪ/ /maɪnd/ /'opənɪŋ/ /ðə/ /'wɪndo/"
+  },
+  {
+    "chinese": "我不介意打开这个窗户",
+    "english": "I don't mind opening the window",
+    "soundmark": "/aɪ/ /dont/ /maɪnd/ /'opənɪŋ/ /ðə/ /'wɪndo/"
+  },
+  {
+    "chinese": "支付",
+    "english": "to pay",
+    "soundmark": "/tə/ /pe/"
+  },
+  {
+    "chinese": "账单",
+    "english": "the bill",
+    "soundmark": "/ðə/ /bɪl/"
+  },
+  {
+    "chinese": "支付账单",
+    "english": "to pay the bill",
+    "soundmark": "/tə/ /pe/ /ðə/ /bɪl/"
+  },
+  {
+    "chinese": "支付账单(ing形式)",
+    "english": "paying the bill",
+    "soundmark": "/'peɪŋ/ /ðə/ /bɪl/"
+  },
+  {
+    "chinese": "介意",
+    "english": "to mind",
+    "soundmark": "/tə/ /maɪnd/"
+  },
+  {
+    "chinese": "他介意",
+    "english": "he minds",
+    "soundmark": "/hi/ /maɪndz/"
+  },
+  {
+    "chinese": "他介意支付账单",
+    "english": "he minds paying the bill",
+    "soundmark": "/hi/ /maɪndz/ /'peɪŋ/ /ðə/ /bɪl/"
+  },
+  {
+    "chinese": "他不介意支付账单",
+    "english": "he doesn't mind paying the bill",
+    "soundmark": "/hi/ /ˈdʌznt/ /maɪnd/ /'peɪŋ/ /ðə/ /bɪl/"
+  },
+  {
+    "chinese": "玩具",
+    "english": "toy",
+    "soundmark": "/tɔɪ/"
+  },
+  {
+    "chinese": "他的玩具",
+    "english": "his toys",
+    "soundmark": "/hɪz/ /tɔɪz/"
+  },
+  {
+    "chinese": "分享",
+    "english": "to share",
+    "soundmark": "/tə/ /ʃɛr/"
+  },
+  {
+    "chinese": "分享他的玩具",
+    "english": "to share his toys",
+    "soundmark": "/tə/ /ʃɛr/ /hɪz/ /tɔɪz/"
+  },
+  {
+    "chinese": "朋友",
+    "english": "friend",
+    "soundmark": "/frɛnd/"
+  },
+  {
+    "chinese": "他的朋友们",
+    "english": "his friends",
+    "soundmark": "/hɪz/ /frɛndz/"
+  },
+  {
+    "chinese": "和",
+    "english": "with",
+    "soundmark": "/wɪð/"
+  },
+  {
+    "chinese": "和他的朋友们",
+    "english": "with his friends",
+    "soundmark": "/wɪð/ /hɪz/ /frɛndz/"
+  },
+  {
+    "chinese": "和他的朋友们分享他的玩具",
+    "english": "to share his toys with his friends",
+    "soundmark": "/tə/ /ʃɛr/ /hɪz/ /tɔɪz/ /wɪð/ /hɪz/ /frɛndz/"
+  },
+  {
+    "chinese": "和他的朋友们分享他的玩具",
+    "english": "sharing his toys with his friends",
+    "soundmark": "/'ʃɛriŋ/ /hɪz/ /tɔɪz/ /wɪð/ /hɪz/ /frɛndz/"
+  },
+  {
+    "chinese": "他介意",
+    "english": "he minds",
+    "soundmark": "/hi/ /maɪndz/"
+  },
+  {
+    "chinese": "他介意和他的朋友们分享他的玩具",
+    "english": "he minds sharing his toys with his friends",
+    "soundmark": "/hi/ /maɪndz/ /'ʃɛəriŋ/ /hɪz/ /tɔɪz/ /wɪð/ /hɪz/ /frɛndz/"
+  },
+  {
+    "chinese": "他不介意和他的朋友们分享他的玩具",
+    "english": "he doesn't mind sharing his toys with his friends",
+    "soundmark": "/hi/ /ˈdʌznt/ /maɪnd/ /'ʃɛəriŋ/ /hɪz/ /tɔɪz/ /wɪð/ /hɪz/ /frɛndz/"
+  },
+  {
+    "chinese": "他不介意",
+    "english": "he doesn't mind",
+    "soundmark": "/hi/ /ˈdʌznt/ /maɪnd/"
+  },
+  {
+    "chinese": "他的食物",
+    "english": "his food",
+    "soundmark": "/hɪz/ /fud/"
+  },
+  {
+    "chinese": "分享",
+    "english": "to share",
+    "soundmark": "/tə/ /ʃɛr/"
+  },
+  {
+    "chinese": "分享他的食物",
+    "english": "to share his food",
+    "soundmark": "/tə/ /ʃɛr/ /hɪz/ /fud/"
+  },
+  {
+    "chinese": "别人",
+    "english": "others",
+    "soundmark": "/'ʌðɚz/"
+  },
+  {
+    "chinese": "和",
+    "english": "with",
+    "soundmark": "/wɪð/"
+  },
+  {
+    "chinese": "和别人",
+    "english": "with others",
+    "soundmark": "/wɪð/ /'ʌðɚz/"
+  },
+  {
+    "chinese": "和别人分享他的食物",
+    "english": "to share his food with others",
+    "soundmark": "/tə/ /ʃɛr/ /hɪz/ /fud/ /wɪð/ /'ʌðɚz/"
+  },
+  {
+    "chinese": "和别人分享他的食物(ing形式)",
+    "english": "sharing his food with others",
+    "soundmark": "/'ʃɛriŋ/ /hɪz/ /fud/ /wɪð/ /'ʌðɚz/"
+  },
+  {
+    "chinese": "介意",
+    "english": "to mind",
+    "soundmark": "/tə/ /maɪnd/"
+  },
+  {
+    "chinese": "他介意",
+    "english": "he minds",
+    "soundmark": "/hi/ /maɪndz/"
+  },
+  {
+    "chinese": "他不介意",
+    "english": "he doesn't mind",
+    "soundmark": "/hi/ /ˈdʌznt/ /maɪnd/"
+  },
+  {
+    "chinese": "他不介意和别人分享他的食物",
+    "english": "he doesn't mind sharing his toys with his friends",
+    "soundmark": "/hi/ /ˈdʌznt/ /maɪnd/ /'ʃɛriŋ/ /hɪz/ /fud/ /wɪð/ /'ʌðɚz/"
+  },
+  {
+    "chinese": "等",
+    "english": "to wait",
+    "soundmark": "/tə/ /wet/"
+  },
+  {
+    "chinese": "她",
+    "english": "her",
+    "soundmark": "/hɚ/"
+  },
+  {
+    "chinese": "等她",
+    "english": "to wait for her",
+    "soundmark": "/tə/ /wet/ /fɚ/ /hɚ/"
+  },
+  {
+    "chinese": "机场",
+    "english": "airport",
+    "soundmark": "/'ɛrpɔrt/"
+  },
+  {
+    "chinese": "在机场",
+    "english": "at the airport",
+    "soundmark": "/ət/ /ði/ /'ɛrpɔrt/"
+  },
+  {
+    "chinese": "在机场等她",
+    "english": "to wait for her at the airport",
+    "soundmark": "/tə/ /wet/ /fɚ/ /hɚ/ /ət/ /ði/ /'ɛrpɔrt/"
+  },
+  {
+    "chinese": "在机场等她(ing形式)",
+    "english": "waiting for her at the airport",
+    "soundmark": "/'wetɪŋ/ /fɚ/ /hɚ/ /ət/ /ði/ /'ɛrpɔrt/"
+  },
+  {
+    "chinese": "他不介意",
+    "english": "he doesn't mind",
+    "soundmark": "/hi/ /ˈdʌznt/ /maɪnd/"
+  },
+  {
+    "chinese": "他不介意在机场等她",
+    "english": "he doesn't mind waiting for her at the airport",
+    "soundmark": "/hi/ /ˈdʌznt/ /maɪnd/ /'wetɪŋ/ /fɚ/ /hɚ/ /ət/ /ði/ /'ɛrpɔrt/"
+  },
+  {
+    "chinese": "介意",
+    "english": "to mind",
+    "soundmark": "/tə/ /maɪnd/"
+  },
+  {
+    "chinese": "他们介意",
+    "english": "they mind",
+    "soundmark": "/ðe/ /maɪnd/"
+  },
+  {
+    "chinese": "秘密",
+    "english": "secret",
+    "soundmark": "/'sikrət/"
+  },
+  {
+    "chinese": "他们的秘密",
+    "english": "their secrets",
+    "soundmark": "/ðɛr/ /'sikrəts/"
+  },
+  {
+    "chinese": "分享",
+    "english": "to share",
+    "soundmark": "/tə/ /ʃɛr/"
+  },
+  {
+    "chinese": "分享他们的秘密",
+    "english": "to share their secrets",
+    "soundmark": "/tə/ /ʃɛr/ /ðɛr/ /'sikrəts/"
+  },
+  {
+    "chinese": "任何人",
+    "english": "anyone",
+    "soundmark": "/'ɛnɪwʌn/"
+  },
+  {
+    "chinese": "和",
+    "english": "with",
+    "soundmark": "/wɪð/"
+  },
+  {
+    "chinese": "和任何人",
+    "english": "with anyone",
+    "soundmark": "/wɪð/ /'ɛnɪwʌn/"
+  },
+  {
+    "chinese": "和任何人分享他们的秘密",
+    "english": "to share their secrets with anyone",
+    "soundmark": "/tə/ /ʃɛr/ /ðɛr/ /'sikrəts/ /wɪð/ /'ɛnɪwʌn/"
+  },
+  {
+    "chinese": "和任何人分享他们的秘密(ing形式)",
+    "english": "sharing their secrets with anyone",
+    "soundmark": "/'ʃɛriŋ/ /ðɛr/ /'sikrəts/ /wɪð/ /'ɛnɪwʌn/"
+  },
+  {
+    "chinese": "他们介意",
+    "english": "they mind",
+    "soundmark": "/ðe/ /maɪnd/"
+  },
+  {
+    "chinese": "他们不介意",
+    "english": "they don't mind",
+    "soundmark": "/ðe/ /dont/ /maɪnd/"
+  },
+  {
+    "chinese": "他们不介意和任何人分享他们的秘密",
+    "english": "they don't mind sharing their secrets with anyone",
+    "soundmark": "/ðe/ /dont/ /maɪnd/ /'ʃɛriŋ/ /ðɛr/ /'sikrəts/ /wɪð/ /'ɛnɪwʌn/"
+  },
+  {
+    "chinese": "他介意",
+    "english": "he minds",
+    "soundmark": "/hi/ /maɪndz/"
+  },
+  {
+    "chinese": "建议",
+    "english": "advice",
+    "soundmark": "/əd'vaɪs/"
+  },
+  {
+    "chinese": "一些",
+    "english": "some",
+    "soundmark": "/səm/"
+  },
+  {
+    "chinese": "一些建议",
+    "english": "some advice",
+    "soundmark": "/səm/ /əd'vaɪs/"
+  },
+  {
+    "chinese": "问题",
+    "english": "problem",
+    "soundmark": "/'prɑbləm/"
+  },
+  {
+    "chinese": "这个问题",
+    "english": "this problem",
+    "soundmark": "/ðɪs/ /'prɑbləm/"
+  },
+  {
+    "chinese": "关于",
+    "english": "about",
+    "soundmark": "/ə'baʊt/"
+  },
+  {
+    "chinese": "关于这个问题",
+    "english": "about this problem",
+    "soundmark": "/ə'baʊt/ /ðɪs/ /'prɑbləm/"
+  },
+  {
+    "chinese": "关于这个问题的一些建议",
+    "english": "some advice about this problem",
+    "soundmark": "/səm/ /əd'vaɪs/ /ə'baʊt/ /ðɪs/ /'prɑbləm/"
+  },
+  {
+    "chinese": "给",
+    "english": "to give",
+    "soundmark": "/tə/ /ɡɪv/"
+  },
+  {
+    "chinese": "给我",
+    "english": "to give me",
+    "soundmark": "/tə/ /ɡɪv/ /mi/"
+  },
+  {
+    "chinese": "给我一些建议",
+    "english": "to give me some advice",
+    "soundmark": "/tə/ /ɡɪv/ /mi/ /səm/ /əd'vaɪs/"
+  },
+  {
+    "chinese": "给我关于这个问题的一些建议",
+    "english": "to give me some advice about this problem",
+    "soundmark": "/tə/ /ɡɪv/ /mi/ /səm/ /əd'vaɪs/ /ə'baʊt/ /ðɪs/ /'prɑbləm/"
+  },
+  {
+    "chinese": "给我关于这个问题的一些建议",
+    "english": "giving me some advice about this problem",
+    "soundmark": "/ɡɪviŋ/ /mi/ /səm/ /əd'vaɪs/ /ə'baʊt/ /ðɪs/ /'prɑbləm/"
+  },
+  {
+    "chinese": "他介意",
+    "english": "he minds",
+    "soundmark": "/hi/ /maɪndz/"
+  },
+  {
+    "chinese": "他不介意",
+    "english": "he doesn't mind",
+    "soundmark": "/hi/ /ˈdʌznt/ /maɪnd/"
+  },
+  {
+    "chinese": "他不介意给我关于这个问题的一些建议",
+    "english": "he doesn't mind giving me some advice about this problem",
+    "soundmark": "/hi/ /ˈdʌznt/ /maɪnd/ /ɡɪviŋ/ /mi/ /səm/ /əd'vaɪs/ /ə'baʊt/ /ðɪs/ /'prɑbləm/"
+  }
 ]

--- a/scripts/courses/38.json
+++ b/scripts/courses/38.json
@@ -1,712 +1,712 @@
 [
-	{
-		"chinese": "锁",
-		"english": "to lock",
-		"soundmark": "/tə/ /lɑk/"
-	},
-	{
-		"chinese": "门",
-		"english": "the door",
-		"soundmark": "/ðə/ /dɔr/"
-	},
-	{
-		"chinese": "锁门",
-		"english": "to lock the door tə/",
-		"soundmark": "/lɑk/ /ðə/ /dɔr/"
-	},
-	{
-		"chinese": "忘记",
-		"english": "to forget",
-		"soundmark": "/tə/ /fɚ'ɡɛt/"
-	},
-	{
-		"chinese": "忘记锁门",
-		"english": "to forget to lock the door",
-		"soundmark": "/tə/ /fɚ'ɡɛt/ /tə/ /lɑk/ /ðə/ /dɔr/"
-	},
-	{
-		"chinese": "忘记锁门(ing形式)",
-		"english": "forgetting to lock the door",
-		"soundmark": "/fɚ'ɡɛtɪŋ/ /tə/ /lɑk/ /ðə/ /dɔr/"
-	},
-	{
-		"chinese": "承认",
-		"english": "to admit",
-		"soundmark": "/tə/ /ədˈmɪt/"
-	},
-	{
-		"chinese": "他们承认",
-		"english": "they admit",
-		"soundmark": "/ðe/ /ədˈmɪt/"
-	},
-	{
-		"chinese": "他们(过去)承认",
-		"english": "they admitted",
-		"soundmark": "/ðe/ /ədˈmɪtɪd/"
-	},
-	{
-		"chinese": "他们(过去)承认忘记锁门",
-		"english": "they admitted forgetting to lock the door",
-		"soundmark": "/ðe/ /ədˈmɪtɪd/ /fɚ'ɡɛtɪŋ/ /tə/ /lɑk/ /ðə/ /dɔr/"
-	},
-	{
-		"chinese": "灯",
-		"english": "light",
-		"soundmark": "/laɪt/"
-	},
-	{
-		"chinese": "红色",
-		"english": "red",
-		"soundmark": "/rɛd/"
-	},
-	{
-		"chinese": "一个红灯",
-		"english": "a red light",
-		"soundmark": "/ə/ /rɛd/ /laɪt/"
-	},
-	{
-		"chinese": "跑",
-		"english": "to run",
-		"soundmark": "/tə/ /rʌn/"
-	},
-	{
-		"chinese": "闯一个红灯",
-		"english": "to run a red light",
-		"soundmark": "/tə/ /rʌn/ /ə/ /rɛd/ /laɪt/"
-	},
-	{
-		"chinese": "闯一个红灯(ing形式)",
-		"english": "running a red light",
-		"soundmark": "/'rʌnɪŋ/ /ə/ /rɛd/ /laɪt/ /(过去)承认 admitted/ /ədˈmɪtɪd/"
-	},
-	{
-		"chinese": "驾驶",
-		"english": "to drive",
-		"soundmark": "/tə/ /draɪv/"
-	},
-	{
-		"chinese": "司机",
-		"english": "the driver",
-		"soundmark": "/ðə/ /'draɪvɚ/"
-	},
-	{
-		"chinese": "司机(过去)承认",
-		"english": "the driver admitted",
-		"soundmark": "/ðə/ /'draɪvɚ/ /ədˈmɪtɪd/"
-	},
-	{
-		"chinese": "司机(过去)承认闯一个红灯",
-		"english": "the driver admitted running a red light",
-		"soundmark": "/ðə/ /'draɪvɚ/ /ədˈmɪtɪd/ /'rʌnɪŋ/ /ə/ /rɛd/ /laɪt/"
-	},
-	{
-		"chinese": "答案",
-		"english": "the answers",
-		"soundmark": "/ði/ /'ænsɚz/"
-	},
-	{
-		"chinese": "复制",
-		"english": "to copy",
-		"soundmark": "/tə/ /ˈkɑpɪ/"
-	},
-	{
-		"chinese": "抄答案",
-		"english": "to copy the answers",
-		"soundmark": "/tə/ /ˈkɑpɪ/ /ði/ /'ænsɚz/"
-	},
-	{
-		"chinese": "同学",
-		"english": "classmate",
-		"soundmark": "/'klæsmet/"
-	},
-	{
-		"chinese": "从......那里",
-		"english": "from",
-		"soundmark": "/frʌm/"
-	},
-	{
-		"chinese": "从一个同学那里",
-		"english": "from a classmate",
-		"soundmark": "/frʌm/ /ə/ /'klæsmet/"
-	},
-	{
-		"chinese": "从一个同学那里抄答案",
-		"english": "to copy the answers from a classmate",
-		"soundmark": "/tə/ /ˈkɑpɪ/ /ði/ /'ænsɚz/ /frʌm/ /ə/ /'klæsmet/"
-	},
-	{
-		"chinese": "从一个同学那里抄答案(ing形式)",
-		"english": "copying the answers from a classmate",
-		"soundmark": "/ˈkɑpɪɪŋ/ /ði/ /'ænsɚz/ /frʌm/ /ə/ /'klæsmet/ /(过去)承认 admitted/ /ədˈmɪtɪd/"
-	},
-	{
-		"chinese": "那个学生",
-		"english": "the student",
-		"soundmark": "/ðə/ /'studnt/"
-	},
-	{
-		"chinese": "那个学生(过去)承认",
-		"english": "the student admitted",
-		"soundmark": "/ðə/ /'studnt/ /ədˈmɪtɪd/"
-	},
-	{
-		"chinese": "那个学生(过去)承认从一个学生那里抄答案",
-		"english": "the student admitted copying the answers from a classmate",
-		"soundmark": "/ðə/ /'studnt/ /ədˈmɪtɪd/ /ˈkɑpɪɪŋ/ /ði/ /'ænsɚz/ /frʌm/ /ə/ /'klæsmet/"
-	},
-	{
-		"chinese": "迟到的",
-		"english": "late",
-		"soundmark": "/let/"
-	},
-	{
-		"chinese": "她是迟到的",
-		"english": "she is late",
-		"soundmark": "/ʃi/ /ɪz/ /let/"
-	},
-	{
-		"chinese": "碰面；见到",
-		"english": "to meet",
-		"soundmark": "/tə/ /mit/"
-	},
-	{
-		"chinese": "会议",
-		"english": "meeting",
-		"soundmark": "/'mitɪŋ/"
-	},
-	{
-		"chinese": "为了；对于",
-		"english": "for",
-		"soundmark": "/fɚ/"
-	},
-	{
-		"chinese": "对于这个会议",
-		"english": "for the meeting",
-		"soundmark": "/fɚ/ /ðə/ /'mitɪŋ/"
-	},
-	{
-		"chinese": "她是迟到的对于这个会议",
-		"english": "she is late for the meeting",
-		"soundmark": "/ʃi/ /ɪz/ /let/ /fɚ/ /ðə/ /'mitɪŋ/ /(过去)承认 admitted/ /ədˈmɪtɪd/"
-	},
-	{
-		"chinese": "是(ing形式)",
-		"english": "being",
-		"soundmark": "/ˈbiɪŋ/"
-	},
-	{
-		"chinese": "她(过去)承认是迟到的对于这个会议",
-		"english": "she admitted being late for the metting",
-		"soundmark": "/ʃi/ /ədˈmɪtɪd/ /ˈbiɪŋ/ /let/ /fɚ/ /ðə/ /'mitɪŋ/"
-	},
-	{
-		"chinese": "说话",
-		"english": "to speak",
-		"soundmark": "/tə/ /spik/"
-	},
-	{
-		"chinese": "演讲",
-		"english": "speaking",
-		"soundmark": "/'spikɪŋ/"
-	},
-	{
-		"chinese": "公开的",
-		"english": "public",
-		"soundmark": "/ˈpʌblɪk/"
-	},
-	{
-		"chinese": "公开演讲",
-		"english": "public speaking",
-		"soundmark": "/ˈpʌblɪk/ /'spikɪŋ/"
-	},
-	{
-		"chinese": "害怕的",
-		"english": "afraid",
-		"soundmark": "/ə'fred/"
-	},
-	{
-		"chinese": "她是害怕的",
-		"english": "she is afraid",
-		"soundmark": "/ʃi/ /ɪz/ /ə'fred/"
-	},
-	{
-		"chinese": "她害怕公开演讲",
-		"english": "she is afraid of public speaking",
-		"soundmark": "/ʃi/ /ɪz/ /ə'fred/ /əv/ /ˈpʌblɪk/ /'spikɪŋ/ /(过去)承认 admitted/ /ədˈmɪtɪd/"
-	},
-	{
-		"chinese": "是(ing形式)",
-		"english": "being",
-		"soundmark": "/ˈbiɪŋ/"
-	},
-	{
-		"chinese": "她(过去)承认",
-		"english": "she admitted",
-		"soundmark": "/ʃi/ /ədˈmɪtɪd/"
-	},
-	{
-		"chinese": "她(过去)承认害怕公开演讲",
-		"english": "she admitted being afraid of public speaking",
-		"soundmark": "/ʃi/ /ədˈmɪtɪd/ /ˈbiɪŋ/ /ə'fred/ /əv/ /ˈpʌblɪk/ /'spikɪŋ/"
-	},
-	{
-		"chinese": "食物",
-		"english": "food",
-		"soundmark": "/fud/"
-	},
-	{
-		"chinese": "垃圾",
-		"english": "junk",
-		"soundmark": "/dʒʌŋk/"
-	},
-	{
-		"chinese": "垃圾食物",
-		"english": "junk food",
-		"soundmark": "/dʒʌŋk/ /fud/"
-	},
-	{
-		"chinese": "吃",
-		"english": "to eat",
-		"soundmark": "/tə/ /it/"
-	},
-	{
-		"chinese": "吃垃圾食物",
-		"english": "to eat junk food",
-		"soundmark": "/tə/ /it/ /dʒʌŋk/ /fud/"
-	},
-	{
-		"chinese": "吃垃圾食物(ing形式)",
-		"english": "eating junk food",
-		"soundmark": "/'itɪŋ/ /dʒʌŋk/ /fud/"
-	},
-	{
-		"chinese": "避免",
-		"english": "to avoid",
-		"soundmark": "/tə/ /əˈvɔɪd/"
-	},
-	{
-		"chinese": "她避免",
-		"english": "she avoids",
-		"soundmark": "/ʃi/ /əˈvɔɪdz/"
-	},
-	{
-		"chinese": "她避免吃垃圾食物",
-		"english": "she avoids eating junk food",
-		"soundmark": "/ʃi/ /əˈvɔɪdz/ /'itɪŋ/ /dʒʌŋk/ /fud/"
-	},
-	{
-		"chinese": "生活",
-		"english": "life",
-		"soundmark": "/laɪf/"
-	},
-	{
-		"chinese": "方式",
-		"english": "style",
-		"soundmark": "/staɪl/"
-	},
-	{
-		"chinese": "生活方式",
-		"english": "lifestyle",
-		"soundmark": "/'laɪfstaɪl/"
-	},
-	{
-		"chinese": "健康的",
-		"english": "healthy",
-		"soundmark": "/'hɛlθi/"
-	},
-	{
-		"chinese": "一个健康的生活方式",
-		"english": "a healthy lifestyle",
-		"soundmark": "/ə/ /'hɛlθi/ /'laɪfstaɪl/"
-	},
-	{
-		"chinese": "保持",
-		"english": "to maintain",
-		"soundmark": "/tə/ /menˈten/"
-	},
-	{
-		"chinese": "保持一个健康的生活方式",
-		"english": "to maintain a healthy lifestyle",
-		"soundmark": "/tə/ /menˈten/ /ə/ /'hɛlθi/ /'laɪfstaɪl/"
-	},
-	{
-		"chinese": "她避免吃垃圾食物",
-		"english": "she avoids eating junk food",
-		"soundmark": "/ʃi/ /əˈvɔɪdz/ /'itɪŋ/ /dʒʌŋk/ /fud/"
-	},
-	{
-		"chinese": "她避免吃垃圾食物来保持一个健康的生活方式",
-		"english": "she avoids eating junk food to maintain a healthy lifestyle",
-		"soundmark": "/ʃi/ /əˈvɔɪdz/ /'itɪŋ/ /dʒʌŋk/ /fud/ /tə/ /menˈten/ /ə/ /'hɛlθi/ /'laɪfstaɪl/"
-	},
-	{
-		"chinese": "告诉",
-		"english": "to tell",
-		"soundmark": "/tə/ /tɛl/"
-	},
-	{
-		"chinese": "事实",
-		"english": "the truth",
-		"soundmark": "/ðə/ /trʊθ/"
-	},
-	{
-		"chinese": "告诉事实",
-		"english": "to tell the truth",
-		"soundmark": "/tə/ /tɛl/ /ðə/ /trʊθ/"
-	},
-	{
-		"chinese": "告诉事实(ing形式)",
-		"english": "telling the truth",
-		"soundmark": "/ˈtɛlɪŋ/ /ðə/ /trʊθ/"
-	},
-	{
-		"chinese": "避免",
-		"english": "to avoid",
-		"soundmark": "/tə/ /əˈvɔɪd/"
-	},
-	{
-		"chinese": "她(过去)避免",
-		"english": "she avoided",
-		"soundmark": "/ʃi/ /əˈvɔɪdɪd/"
-	},
-	{
-		"chinese": "她(过去)避免告诉事实",
-		"english": "she avoided telling the truth",
-		"soundmark": "/ʃi/ /əˈvɔɪdɪd/ /ˈtɛlɪŋ/ /ðə/ /trʊθ/"
-	},
-	{
-		"chinese": "说谎",
-		"english": "to lie",
-		"soundmark": "/tə/ /laɪ/"
-	},
-	{
-		"chinese": "说谎(ing形式)",
-		"english": "lying",
-		"soundmark": "/'laɪɪŋ/"
-	},
-	{
-		"chinese": "父母",
-		"english": "parents",
-		"soundmark": "/'pɛrənts/"
-	},
-	{
-		"chinese": "她的父母",
-		"english": "her parents",
-		"soundmark": "/hɚ/ /'pɛrənts/"
-	},
-	{
-		"chinese": "向她的父母说谎(ing形式)",
-		"english": "lying to her parents",
-		"soundmark": "/'laɪɪŋ/ /tə/ /hɚ/ /'pɛrənts/"
-	},
-	{
-		"chinese": "通过",
-		"english": "by",
-		"soundmark": "/baɪ/"
-	},
-	{
-		"chinese": "通过向她的父母说谎",
-		"english": "by lying to her parents",
-		"soundmark": "/baɪ/ /'laɪɪŋ/ /tə/ /hɚ/ /'pɛrənts/"
-	},
-	{
-		"chinese": "她(过去)避免告诉事实",
-		"english": "she avoided telling the truth",
-		"soundmark": "/ʃi/ /əˈvɔɪdɪd/ /ˈtɛlɪŋ/ /ðə/ /trʊθ/"
-	},
-	{
-		"chinese": "她通过向她的父母说谎来(过去)避免告诉事实",
-		"english": "she avoided telling the truth by lying to her parents",
-		"soundmark": "/ʃi/ /əˈvɔɪdɪd/ /ˈtɛlɪŋ/ /ðə/ /trʊθ/ /baɪ/ /'laɪɪŋ/ /tə/ /hɚ/ /'pɛrənts/"
-	},
-	{
-		"chinese": "伤害",
-		"english": "to hurt",
-		"soundmark": "/tə/ /hɝt/"
-	},
-	{
-		"chinese": "她",
-		"english": "her",
-		"soundmark": "/hɚ/"
-	},
-	{
-		"chinese": "伤害她",
-		"english": "to hurt her",
-		"soundmark": "/tə/ /hɝt/ /hɚ/"
-	},
-	{
-		"chinese": "伤害她(ing形式)",
-		"english": "hurting her",
-		"soundmark": "/ˈhɝtɪŋ/ /hɚ/"
-	},
-	{
-		"chinese": "避免",
-		"english": "to avoid",
-		"soundmark": "/tə/ /əˈvɔɪd/"
-	},
-	{
-		"chinese": "我(过去)避免",
-		"english": "I avoided",
-		"soundmark": "/aɪ/ /əˈvɔɪdɪd/"
-	},
-	{
-		"chinese": "我(过去)避免伤害她",
-		"english": "I avoided hurting her",
-		"soundmark": "/aɪ/ /əˈvɔɪdɪd/ /ˈhɝtɪŋ/ /hɚ/"
-	},
-	{
-		"chinese": "保持",
-		"english": "to keep",
-		"soundmark": "/tə/ /kip/"
-	},
-	{
-		"chinese": "沉默",
-		"english": "silent",
-		"soundmark": "/'saɪlənt/"
-	},
-	{
-		"chinese": "保持沉默",
-		"english": "to keep silent",
-		"soundmark": "/tə/ /kip/ /'saɪlənt/"
-	},
-	{
-		"chinese": "保持沉默(ing形式)",
-		"english": "keeping silent",
-		"soundmark": "/'kipɪŋ/ /'saɪlənt/"
-	},
-	{
-		"chinese": "通过",
-		"english": "by",
-		"soundmark": "/baɪ/"
-	},
-	{
-		"chinese": "通过保持沉默",
-		"english": "by keeping silent",
-		"soundmark": "/baɪ/ /'kipɪŋ/ /'saɪlənt/"
-	},
-	{
-		"chinese": "我通过保持沉默来(过去)避免伤害她",
-		"english": "I avoided hurting her by keeping silent",
-		"soundmark": "/aɪ/ /əˈvɔɪdɪd/ /ˈhɝtɪŋ/ /hɚ/ /baɪ/ /'kipɪŋ/ /'saɪlənt/"
-	},
-	{
-		"chinese": "迟到的",
-		"english": "late",
-		"soundmark": "/let/"
-	},
-	{
-		"chinese": "我是迟到的",
-		"english": "I am late",
-		"soundmark": "/aɪ/ /æm/ /let/ /(过去)避免 avoided/ /əˈvɔɪdɪd/"
-	},
-	{
-		"chinese": "是(ing形式)",
-		"english": "being",
-		"soundmark": "/ˈbiɪŋ/"
-	},
-	{
-		"chinese": "我(过去)避免迟到",
-		"english": "I avoided being late",
-		"soundmark": "/aɪ/ /əˈvɔɪdɪd/ /ˈbiɪŋ/ /let/"
-	},
-	{
-		"chinese": "出租车",
-		"english": "taxi",
-		"soundmark": "/'tæksi/"
-	},
-	{
-		"chinese": "乘坐",
-		"english": "to take",
-		"soundmark": "/tə/ /tek/"
-	},
-	{
-		"chinese": "乘坐一辆出租车",
-		"english": "to take a taxi",
-		"soundmark": "/tə/ /tek/ /ə/ /'tæksi/"
-	},
-	{
-		"chinese": "乘坐一辆出租车(ing形式)",
-		"english": "taking a taxi",
-		"soundmark": "/ˈtekɪŋ/ /ə/ /'tæksi/"
-	},
-	{
-		"chinese": "通过",
-		"english": "by",
-		"soundmark": "/baɪ/"
-	},
-	{
-		"chinese": "通过乘坐一辆出租车",
-		"english": "by taking a taxi",
-		"soundmark": "/baɪ/ /ˈtekɪŋ/ /ə/ /'tæksi/"
-	},
-	{
-		"chinese": "我(过去)避免迟到",
-		"english": "I avoided being late",
-		"soundmark": "/aɪ/ /əˈvɔɪdɪd/ /ˈbiɪŋ/ /let/"
-	},
-	{
-		"chinese": "我通过乘坐一辆出租车来(过去)避免迟到",
-		"english": "I avoided being late by taking a taxi",
-		"soundmark": "/aɪ/ /əˈvɔɪdɪd/ /ˈbiɪŋ/ /let/ /baɪ/ /ˈtekɪŋ/ /ə/ /'tæksi/"
-	},
-	{
-		"chinese": "避免",
-		"english": "to avoid",
-		"soundmark": "/tə/ /əˈvɔɪd/"
-	},
-	{
-		"chinese": "他避免",
-		"english": "he avoids",
-		"soundmark": "/hi/ /əˈvɔɪdz/"
-	},
-	{
-		"chinese": "抽烟",
-		"english": "to smoke",
-		"soundmark": "/tə/ /smok/"
-	},
-	{
-		"chinese": "抽烟(ing形式)",
-		"english": "smoking",
-		"soundmark": "/'smokɪŋ/"
-	},
-	{
-		"chinese": "他避免抽烟",
-		"english": "he avoids smoking",
-		"soundmark": "/hi/ /əˈvɔɪdz/ /'smokɪŋ/"
-	},
-	{
-		"chinese": "健康的",
-		"english": "healthy",
-		"soundmark": "/'hɛlθi/"
-	},
-	{
-		"chinese": "健康",
-		"english": "health",
-		"soundmark": "/hɛlθ/"
-	},
-	{
-		"chinese": "他的健康",
-		"english": "his health",
-		"soundmark": "/hɪz/ /hɛlθ/"
-	},
-	{
-		"chinese": "保护",
-		"english": "to protect",
-		"soundmark": "/tə/ /prə'tɛkt/"
-	},
-	{
-		"chinese": "保护他的健康",
-		"english": "to protect his health",
-		"soundmark": "/tə/ /prə'tɛkt/ /hɪz/ /hɛlθ/"
-	},
-	{
-		"chinese": "他避免抽烟来保护他的健康",
-		"english": "he avoids smoking to protect his health",
-		"soundmark": "/hi/ /əˈvɔɪdz/ /'smokɪŋ/ /tə/ /prə'tɛkt/ /hɪz/ /hɛlθ/"
-	},
-	{
-		"chinese": "谎言",
-		"english": "lie",
-		"soundmark": "/laɪ/"
-	},
-	{
-		"chinese": "一个谎言",
-		"english": "a lie",
-		"soundmark": "/ə/ /laɪ/"
-	},
-	{
-		"chinese": "白色的",
-		"english": "white",
-		"soundmark": "/waɪt/"
-	},
-	{
-		"chinese": "一个善意的谎言",
-		"english": "a white lie",
-		"soundmark": "/ə/ /waɪt/ /laɪ/"
-	},
-	{
-		"chinese": "告诉",
-		"english": "to tell",
-		"soundmark": "/tə/ /tɛl/"
-	},
-	{
-		"chinese": "说一个善意的谎言",
-		"english": "to tell a white lie",
-		"soundmark": "/tə/ /tɛl/ /ə/ /waɪt/ /laɪ/"
-	},
-	{
-		"chinese": "说一个善意的谎言(ing形式)",
-		"english": "telling a white lie",
-		"soundmark": "/ˈtɛlɪŋ/ /ə/ /waɪt/ /laɪ/"
-	},
-	{
-		"chinese": "承认",
-		"english": "to admit",
-		"soundmark": "/tə/ /ədˈmɪt/"
-	},
-	{
-		"chinese": "他(过去)承认",
-		"english": "he admitted",
-		"soundmark": "/hi/ /ədˈmɪtɪd/"
-	},
-	{
-		"chinese": "他(过去)承认说一个善意的谎言(ing形式)",
-		"english": "he admitted telling a white lie",
-		"soundmark": "/hi/ /ədˈmɪtɪd/ /ˈtɛlɪŋ/ /ə/ /waɪt/ /laɪ/"
-	},
-	{
-		"chinese": "感觉",
-		"english": "to feel",
-		"soundmark": "/tə/ /fil/"
-	},
-	{
-		"chinese": "感情",
-		"english": "feelings",
-		"soundmark": "/'filɪŋz/"
-	},
-	{
-		"chinese": "某个人",
-		"english": "someone",
-		"soundmark": "/'sʌmwʌn/"
-	},
-	{
-		"chinese": "某个人的感情",
-		"english": "someone's feelings",
-		"soundmark": "/'sʌmwʌnz/ /'filɪŋz/"
-	},
-	{
-		"chinese": "伤害",
-		"english": "to hurt",
-		"soundmark": "/tə/ /hɝt/"
-	},
-	{
-		"chinese": "伤害某个人的感情",
-		"english": "to hurt someone's feelings",
-		"soundmark": "/tə/ /hɝt/ /'sʌmwʌnz/ /'filɪŋz/"
-	},
-	{
-		"chinese": "伤害某个人的感情(ing形式)",
-		"english": "hurting someone's feelings",
-		"soundmark": "/ˈhɝtɪŋ/ /'sʌmwʌnz/ /'filɪŋz/"
-	},
-	{
-		"chinese": "避免",
-		"english": "to avoid",
-		"soundmark": "/tə/ /əˈvɔɪd/"
-	},
-	{
-		"chinese": "避免伤害某个人的感情",
-		"english": "to avoid hurting someone's feelings",
-		"soundmark": "/tə/ /əˈvɔɪd/ /ˈhɝtɪŋ/ /'sʌmwʌnz/ /'filɪŋz/"
-	},
-	{
-		"chinese": "他(过去)承认说一个善意的谎言",
-		"english": "he admitted telling a white lie",
-		"soundmark": "/hi/ /ədˈmɪtɪd/ /ˈtɛlɪŋ/ /ə/ /waɪt/ /laɪ/"
-	},
-	{
-		"chinese": "他(过去)承认说一个善意的谎言来避免伤害某个人的感情",
-		"english": "he admitted telling a white lie to avoid hurting someone's feelings",
-		"soundmark": "/hi/ /ədˈmɪtɪd/ /tə/ /ədˈmɪt/ /tə/ /əˈvɔɪd/ /ˈhɝtɪŋ/ /'sʌmwʌnz/ /'filɪŋz/"
-	}
+  {
+    "chinese": "锁",
+    "english": "to lock",
+    "soundmark": "/tə/ /lɑk/"
+  },
+  {
+    "chinese": "门",
+    "english": "the door",
+    "soundmark": "/ðə/ /dɔr/"
+  },
+  {
+    "chinese": "锁门",
+    "english": "to lock the door tə/",
+    "soundmark": "/lɑk/ /ðə/ /dɔr/"
+  },
+  {
+    "chinese": "忘记",
+    "english": "to forget",
+    "soundmark": "/tə/ /fɚ'ɡɛt/"
+  },
+  {
+    "chinese": "忘记锁门",
+    "english": "to forget to lock the door",
+    "soundmark": "/tə/ /fɚ'ɡɛt/ /tə/ /lɑk/ /ðə/ /dɔr/"
+  },
+  {
+    "chinese": "忘记锁门(ing形式)",
+    "english": "forgetting to lock the door",
+    "soundmark": "/fɚ'ɡɛtɪŋ/ /tə/ /lɑk/ /ðə/ /dɔr/"
+  },
+  {
+    "chinese": "承认",
+    "english": "to admit",
+    "soundmark": "/tə/ /ədˈmɪt/"
+  },
+  {
+    "chinese": "他们承认",
+    "english": "they admit",
+    "soundmark": "/ðe/ /ədˈmɪt/"
+  },
+  {
+    "chinese": "他们(过去)承认",
+    "english": "they admitted",
+    "soundmark": "/ðe/ /ədˈmɪtɪd/"
+  },
+  {
+    "chinese": "他们(过去)承认忘记锁门",
+    "english": "they admitted forgetting to lock the door",
+    "soundmark": "/ðe/ /ədˈmɪtɪd/ /fɚ'ɡɛtɪŋ/ /tə/ /lɑk/ /ðə/ /dɔr/"
+  },
+  {
+    "chinese": "灯",
+    "english": "light",
+    "soundmark": "/laɪt/"
+  },
+  {
+    "chinese": "红色",
+    "english": "red",
+    "soundmark": "/rɛd/"
+  },
+  {
+    "chinese": "一个红灯",
+    "english": "a red light",
+    "soundmark": "/ə/ /rɛd/ /laɪt/"
+  },
+  {
+    "chinese": "跑",
+    "english": "to run",
+    "soundmark": "/tə/ /rʌn/"
+  },
+  {
+    "chinese": "闯一个红灯",
+    "english": "to run a red light",
+    "soundmark": "/tə/ /rʌn/ /ə/ /rɛd/ /laɪt/"
+  },
+  {
+    "chinese": "闯一个红灯(ing形式)",
+    "english": "running a red light",
+    "soundmark": "/'rʌnɪŋ/ /ə/ /rɛd/ /laɪt/ /(过去)承认 admitted/ /ədˈmɪtɪd/"
+  },
+  {
+    "chinese": "驾驶",
+    "english": "to drive",
+    "soundmark": "/tə/ /draɪv/"
+  },
+  {
+    "chinese": "司机",
+    "english": "the driver",
+    "soundmark": "/ðə/ /'draɪvɚ/"
+  },
+  {
+    "chinese": "司机(过去)承认",
+    "english": "the driver admitted",
+    "soundmark": "/ðə/ /'draɪvɚ/ /ədˈmɪtɪd/"
+  },
+  {
+    "chinese": "司机(过去)承认闯一个红灯",
+    "english": "the driver admitted running a red light",
+    "soundmark": "/ðə/ /'draɪvɚ/ /ədˈmɪtɪd/ /'rʌnɪŋ/ /ə/ /rɛd/ /laɪt/"
+  },
+  {
+    "chinese": "答案",
+    "english": "the answers",
+    "soundmark": "/ði/ /'ænsɚz/"
+  },
+  {
+    "chinese": "复制",
+    "english": "to copy",
+    "soundmark": "/tə/ /ˈkɑpɪ/"
+  },
+  {
+    "chinese": "抄答案",
+    "english": "to copy the answers",
+    "soundmark": "/tə/ /ˈkɑpɪ/ /ði/ /'ænsɚz/"
+  },
+  {
+    "chinese": "同学",
+    "english": "classmate",
+    "soundmark": "/'klæsmet/"
+  },
+  {
+    "chinese": "从......那里",
+    "english": "from",
+    "soundmark": "/frʌm/"
+  },
+  {
+    "chinese": "从一个同学那里",
+    "english": "from a classmate",
+    "soundmark": "/frʌm/ /ə/ /'klæsmet/"
+  },
+  {
+    "chinese": "从一个同学那里抄答案",
+    "english": "to copy the answers from a classmate",
+    "soundmark": "/tə/ /ˈkɑpɪ/ /ði/ /'ænsɚz/ /frʌm/ /ə/ /'klæsmet/"
+  },
+  {
+    "chinese": "从一个同学那里抄答案(ing形式)",
+    "english": "copying the answers from a classmate",
+    "soundmark": "/ˈkɑpɪɪŋ/ /ði/ /'ænsɚz/ /frʌm/ /ə/ /'klæsmet/ /(过去)承认 admitted/ /ədˈmɪtɪd/"
+  },
+  {
+    "chinese": "那个学生",
+    "english": "the student",
+    "soundmark": "/ðə/ /'studnt/"
+  },
+  {
+    "chinese": "那个学生(过去)承认",
+    "english": "the student admitted",
+    "soundmark": "/ðə/ /'studnt/ /ədˈmɪtɪd/"
+  },
+  {
+    "chinese": "那个学生(过去)承认从一个学生那里抄答案",
+    "english": "the student admitted copying the answers from a classmate",
+    "soundmark": "/ðə/ /'studnt/ /ədˈmɪtɪd/ /ˈkɑpɪɪŋ/ /ði/ /'ænsɚz/ /frʌm/ /ə/ /'klæsmet/"
+  },
+  {
+    "chinese": "迟到的",
+    "english": "late",
+    "soundmark": "/let/"
+  },
+  {
+    "chinese": "她是迟到的",
+    "english": "she is late",
+    "soundmark": "/ʃi/ /ɪz/ /let/"
+  },
+  {
+    "chinese": "碰面；见到",
+    "english": "to meet",
+    "soundmark": "/tə/ /mit/"
+  },
+  {
+    "chinese": "会议",
+    "english": "meeting",
+    "soundmark": "/'mitɪŋ/"
+  },
+  {
+    "chinese": "为了；对于",
+    "english": "for",
+    "soundmark": "/fɚ/"
+  },
+  {
+    "chinese": "对于这个会议",
+    "english": "for the meeting",
+    "soundmark": "/fɚ/ /ðə/ /'mitɪŋ/"
+  },
+  {
+    "chinese": "她是迟到的对于这个会议",
+    "english": "she is late for the meeting",
+    "soundmark": "/ʃi/ /ɪz/ /let/ /fɚ/ /ðə/ /'mitɪŋ/ /(过去)承认 admitted/ /ədˈmɪtɪd/"
+  },
+  {
+    "chinese": "是(ing形式)",
+    "english": "being",
+    "soundmark": "/ˈbiɪŋ/"
+  },
+  {
+    "chinese": "她(过去)承认是迟到的对于这个会议",
+    "english": "she admitted being late for the meeting",
+    "soundmark": "/ʃi/ /ədˈmɪtɪd/ /ˈbiɪŋ/ /let/ /fɚ/ /ðə/ /'mitɪŋ/"
+  },
+  {
+    "chinese": "说话",
+    "english": "to speak",
+    "soundmark": "/tə/ /spik/"
+  },
+  {
+    "chinese": "演讲",
+    "english": "speaking",
+    "soundmark": "/'spikɪŋ/"
+  },
+  {
+    "chinese": "公开的",
+    "english": "public",
+    "soundmark": "/ˈpʌblɪk/"
+  },
+  {
+    "chinese": "公开演讲",
+    "english": "public speaking",
+    "soundmark": "/ˈpʌblɪk/ /'spikɪŋ/"
+  },
+  {
+    "chinese": "害怕的",
+    "english": "afraid",
+    "soundmark": "/ə'fred/"
+  },
+  {
+    "chinese": "她是害怕的",
+    "english": "she is afraid",
+    "soundmark": "/ʃi/ /ɪz/ /ə'fred/"
+  },
+  {
+    "chinese": "她害怕公开演讲",
+    "english": "she is afraid of public speaking",
+    "soundmark": "/ʃi/ /ɪz/ /ə'fred/ /əv/ /ˈpʌblɪk/ /'spikɪŋ/ /(过去)承认 admitted/ /ədˈmɪtɪd/"
+  },
+  {
+    "chinese": "是(ing形式)",
+    "english": "being",
+    "soundmark": "/ˈbiɪŋ/"
+  },
+  {
+    "chinese": "她(过去)承认",
+    "english": "she admitted",
+    "soundmark": "/ʃi/ /ədˈmɪtɪd/"
+  },
+  {
+    "chinese": "她(过去)承认害怕公开演讲",
+    "english": "she admitted being afraid of public speaking",
+    "soundmark": "/ʃi/ /ədˈmɪtɪd/ /ˈbiɪŋ/ /ə'fred/ /əv/ /ˈpʌblɪk/ /'spikɪŋ/"
+  },
+  {
+    "chinese": "食物",
+    "english": "food",
+    "soundmark": "/fud/"
+  },
+  {
+    "chinese": "垃圾",
+    "english": "junk",
+    "soundmark": "/dʒʌŋk/"
+  },
+  {
+    "chinese": "垃圾食物",
+    "english": "junk food",
+    "soundmark": "/dʒʌŋk/ /fud/"
+  },
+  {
+    "chinese": "吃",
+    "english": "to eat",
+    "soundmark": "/tə/ /it/"
+  },
+  {
+    "chinese": "吃垃圾食物",
+    "english": "to eat junk food",
+    "soundmark": "/tə/ /it/ /dʒʌŋk/ /fud/"
+  },
+  {
+    "chinese": "吃垃圾食物(ing形式)",
+    "english": "eating junk food",
+    "soundmark": "/'itɪŋ/ /dʒʌŋk/ /fud/"
+  },
+  {
+    "chinese": "避免",
+    "english": "to avoid",
+    "soundmark": "/tə/ /əˈvɔɪd/"
+  },
+  {
+    "chinese": "她避免",
+    "english": "she avoids",
+    "soundmark": "/ʃi/ /əˈvɔɪdz/"
+  },
+  {
+    "chinese": "她避免吃垃圾食物",
+    "english": "she avoids eating junk food",
+    "soundmark": "/ʃi/ /əˈvɔɪdz/ /'itɪŋ/ /dʒʌŋk/ /fud/"
+  },
+  {
+    "chinese": "生活",
+    "english": "life",
+    "soundmark": "/laɪf/"
+  },
+  {
+    "chinese": "方式",
+    "english": "style",
+    "soundmark": "/staɪl/"
+  },
+  {
+    "chinese": "生活方式",
+    "english": "lifestyle",
+    "soundmark": "/'laɪfstaɪl/"
+  },
+  {
+    "chinese": "健康的",
+    "english": "healthy",
+    "soundmark": "/'hɛlθi/"
+  },
+  {
+    "chinese": "一个健康的生活方式",
+    "english": "a healthy lifestyle",
+    "soundmark": "/ə/ /'hɛlθi/ /'laɪfstaɪl/"
+  },
+  {
+    "chinese": "保持",
+    "english": "to maintain",
+    "soundmark": "/tə/ /menˈten/"
+  },
+  {
+    "chinese": "保持一个健康的生活方式",
+    "english": "to maintain a healthy lifestyle",
+    "soundmark": "/tə/ /menˈten/ /ə/ /'hɛlθi/ /'laɪfstaɪl/"
+  },
+  {
+    "chinese": "她避免吃垃圾食物",
+    "english": "she avoids eating junk food",
+    "soundmark": "/ʃi/ /əˈvɔɪdz/ /'itɪŋ/ /dʒʌŋk/ /fud/"
+  },
+  {
+    "chinese": "她避免吃垃圾食物来保持一个健康的生活方式",
+    "english": "she avoids eating junk food to maintain a healthy lifestyle",
+    "soundmark": "/ʃi/ /əˈvɔɪdz/ /'itɪŋ/ /dʒʌŋk/ /fud/ /tə/ /menˈten/ /ə/ /'hɛlθi/ /'laɪfstaɪl/"
+  },
+  {
+    "chinese": "告诉",
+    "english": "to tell",
+    "soundmark": "/tə/ /tɛl/"
+  },
+  {
+    "chinese": "事实",
+    "english": "the truth",
+    "soundmark": "/ðə/ /trʊθ/"
+  },
+  {
+    "chinese": "告诉事实",
+    "english": "to tell the truth",
+    "soundmark": "/tə/ /tɛl/ /ðə/ /trʊθ/"
+  },
+  {
+    "chinese": "告诉事实(ing形式)",
+    "english": "telling the truth",
+    "soundmark": "/ˈtɛlɪŋ/ /ðə/ /trʊθ/"
+  },
+  {
+    "chinese": "避免",
+    "english": "to avoid",
+    "soundmark": "/tə/ /əˈvɔɪd/"
+  },
+  {
+    "chinese": "她(过去)避免",
+    "english": "she avoided",
+    "soundmark": "/ʃi/ /əˈvɔɪdɪd/"
+  },
+  {
+    "chinese": "她(过去)避免告诉事实",
+    "english": "she avoided telling the truth",
+    "soundmark": "/ʃi/ /əˈvɔɪdɪd/ /ˈtɛlɪŋ/ /ðə/ /trʊθ/"
+  },
+  {
+    "chinese": "说谎",
+    "english": "to lie",
+    "soundmark": "/tə/ /laɪ/"
+  },
+  {
+    "chinese": "说谎(ing形式)",
+    "english": "lying",
+    "soundmark": "/'laɪɪŋ/"
+  },
+  {
+    "chinese": "父母",
+    "english": "parents",
+    "soundmark": "/'pɛrənts/"
+  },
+  {
+    "chinese": "她的父母",
+    "english": "her parents",
+    "soundmark": "/hɚ/ /'pɛrənts/"
+  },
+  {
+    "chinese": "向她的父母说谎(ing形式)",
+    "english": "lying to her parents",
+    "soundmark": "/'laɪɪŋ/ /tə/ /hɚ/ /'pɛrənts/"
+  },
+  {
+    "chinese": "通过",
+    "english": "by",
+    "soundmark": "/baɪ/"
+  },
+  {
+    "chinese": "通过向她的父母说谎",
+    "english": "by lying to her parents",
+    "soundmark": "/baɪ/ /'laɪɪŋ/ /tə/ /hɚ/ /'pɛrənts/"
+  },
+  {
+    "chinese": "她(过去)避免告诉事实",
+    "english": "she avoided telling the truth",
+    "soundmark": "/ʃi/ /əˈvɔɪdɪd/ /ˈtɛlɪŋ/ /ðə/ /trʊθ/"
+  },
+  {
+    "chinese": "她通过向她的父母说谎来(过去)避免告诉事实",
+    "english": "she avoided telling the truth by lying to her parents",
+    "soundmark": "/ʃi/ /əˈvɔɪdɪd/ /ˈtɛlɪŋ/ /ðə/ /trʊθ/ /baɪ/ /'laɪɪŋ/ /tə/ /hɚ/ /'pɛrənts/"
+  },
+  {
+    "chinese": "伤害",
+    "english": "to hurt",
+    "soundmark": "/tə/ /hɝt/"
+  },
+  {
+    "chinese": "她",
+    "english": "her",
+    "soundmark": "/hɚ/"
+  },
+  {
+    "chinese": "伤害她",
+    "english": "to hurt her",
+    "soundmark": "/tə/ /hɝt/ /hɚ/"
+  },
+  {
+    "chinese": "伤害她(ing形式)",
+    "english": "hurting her",
+    "soundmark": "/ˈhɝtɪŋ/ /hɚ/"
+  },
+  {
+    "chinese": "避免",
+    "english": "to avoid",
+    "soundmark": "/tə/ /əˈvɔɪd/"
+  },
+  {
+    "chinese": "我(过去)避免",
+    "english": "I avoided",
+    "soundmark": "/aɪ/ /əˈvɔɪdɪd/"
+  },
+  {
+    "chinese": "我(过去)避免伤害她",
+    "english": "I avoided hurting her",
+    "soundmark": "/aɪ/ /əˈvɔɪdɪd/ /ˈhɝtɪŋ/ /hɚ/"
+  },
+  {
+    "chinese": "保持",
+    "english": "to keep",
+    "soundmark": "/tə/ /kip/"
+  },
+  {
+    "chinese": "沉默",
+    "english": "silent",
+    "soundmark": "/'saɪlənt/"
+  },
+  {
+    "chinese": "保持沉默",
+    "english": "to keep silent",
+    "soundmark": "/tə/ /kip/ /'saɪlənt/"
+  },
+  {
+    "chinese": "保持沉默(ing形式)",
+    "english": "keeping silent",
+    "soundmark": "/'kipɪŋ/ /'saɪlənt/"
+  },
+  {
+    "chinese": "通过",
+    "english": "by",
+    "soundmark": "/baɪ/"
+  },
+  {
+    "chinese": "通过保持沉默",
+    "english": "by keeping silent",
+    "soundmark": "/baɪ/ /'kipɪŋ/ /'saɪlənt/"
+  },
+  {
+    "chinese": "我通过保持沉默来(过去)避免伤害她",
+    "english": "I avoided hurting her by keeping silent",
+    "soundmark": "/aɪ/ /əˈvɔɪdɪd/ /ˈhɝtɪŋ/ /hɚ/ /baɪ/ /'kipɪŋ/ /'saɪlənt/"
+  },
+  {
+    "chinese": "迟到的",
+    "english": "late",
+    "soundmark": "/let/"
+  },
+  {
+    "chinese": "我是迟到的",
+    "english": "I am late",
+    "soundmark": "/aɪ/ /æm/ /let/ /(过去)避免 avoided/ /əˈvɔɪdɪd/"
+  },
+  {
+    "chinese": "是(ing形式)",
+    "english": "being",
+    "soundmark": "/ˈbiɪŋ/"
+  },
+  {
+    "chinese": "我(过去)避免迟到",
+    "english": "I avoided being late",
+    "soundmark": "/aɪ/ /əˈvɔɪdɪd/ /ˈbiɪŋ/ /let/"
+  },
+  {
+    "chinese": "出租车",
+    "english": "taxi",
+    "soundmark": "/'tæksi/"
+  },
+  {
+    "chinese": "乘坐",
+    "english": "to take",
+    "soundmark": "/tə/ /tek/"
+  },
+  {
+    "chinese": "乘坐一辆出租车",
+    "english": "to take a taxi",
+    "soundmark": "/tə/ /tek/ /ə/ /'tæksi/"
+  },
+  {
+    "chinese": "乘坐一辆出租车(ing形式)",
+    "english": "taking a taxi",
+    "soundmark": "/ˈtekɪŋ/ /ə/ /'tæksi/"
+  },
+  {
+    "chinese": "通过",
+    "english": "by",
+    "soundmark": "/baɪ/"
+  },
+  {
+    "chinese": "通过乘坐一辆出租车",
+    "english": "by taking a taxi",
+    "soundmark": "/baɪ/ /ˈtekɪŋ/ /ə/ /'tæksi/"
+  },
+  {
+    "chinese": "我(过去)避免迟到",
+    "english": "I avoided being late",
+    "soundmark": "/aɪ/ /əˈvɔɪdɪd/ /ˈbiɪŋ/ /let/"
+  },
+  {
+    "chinese": "我通过乘坐一辆出租车来(过去)避免迟到",
+    "english": "I avoided being late by taking a taxi",
+    "soundmark": "/aɪ/ /əˈvɔɪdɪd/ /ˈbiɪŋ/ /let/ /baɪ/ /ˈtekɪŋ/ /ə/ /'tæksi/"
+  },
+  {
+    "chinese": "避免",
+    "english": "to avoid",
+    "soundmark": "/tə/ /əˈvɔɪd/"
+  },
+  {
+    "chinese": "他避免",
+    "english": "he avoids",
+    "soundmark": "/hi/ /əˈvɔɪdz/"
+  },
+  {
+    "chinese": "抽烟",
+    "english": "to smoke",
+    "soundmark": "/tə/ /smok/"
+  },
+  {
+    "chinese": "抽烟(ing形式)",
+    "english": "smoking",
+    "soundmark": "/'smokɪŋ/"
+  },
+  {
+    "chinese": "他避免抽烟",
+    "english": "he avoids smoking",
+    "soundmark": "/hi/ /əˈvɔɪdz/ /'smokɪŋ/"
+  },
+  {
+    "chinese": "健康的",
+    "english": "healthy",
+    "soundmark": "/'hɛlθi/"
+  },
+  {
+    "chinese": "健康",
+    "english": "health",
+    "soundmark": "/hɛlθ/"
+  },
+  {
+    "chinese": "他的健康",
+    "english": "his health",
+    "soundmark": "/hɪz/ /hɛlθ/"
+  },
+  {
+    "chinese": "保护",
+    "english": "to protect",
+    "soundmark": "/tə/ /prə'tɛkt/"
+  },
+  {
+    "chinese": "保护他的健康",
+    "english": "to protect his health",
+    "soundmark": "/tə/ /prə'tɛkt/ /hɪz/ /hɛlθ/"
+  },
+  {
+    "chinese": "他避免抽烟来保护他的健康",
+    "english": "he avoids smoking to protect his health",
+    "soundmark": "/hi/ /əˈvɔɪdz/ /'smokɪŋ/ /tə/ /prə'tɛkt/ /hɪz/ /hɛlθ/"
+  },
+  {
+    "chinese": "谎言",
+    "english": "lie",
+    "soundmark": "/laɪ/"
+  },
+  {
+    "chinese": "一个谎言",
+    "english": "a lie",
+    "soundmark": "/ə/ /laɪ/"
+  },
+  {
+    "chinese": "白色的",
+    "english": "white",
+    "soundmark": "/waɪt/"
+  },
+  {
+    "chinese": "一个善意的谎言",
+    "english": "a white lie",
+    "soundmark": "/ə/ /waɪt/ /laɪ/"
+  },
+  {
+    "chinese": "告诉",
+    "english": "to tell",
+    "soundmark": "/tə/ /tɛl/"
+  },
+  {
+    "chinese": "说一个善意的谎言",
+    "english": "to tell a white lie",
+    "soundmark": "/tə/ /tɛl/ /ə/ /waɪt/ /laɪ/"
+  },
+  {
+    "chinese": "说一个善意的谎言(ing形式)",
+    "english": "telling a white lie",
+    "soundmark": "/ˈtɛlɪŋ/ /ə/ /waɪt/ /laɪ/"
+  },
+  {
+    "chinese": "承认",
+    "english": "to admit",
+    "soundmark": "/tə/ /ədˈmɪt/"
+  },
+  {
+    "chinese": "他(过去)承认",
+    "english": "he admitted",
+    "soundmark": "/hi/ /ədˈmɪtɪd/"
+  },
+  {
+    "chinese": "他(过去)承认说一个善意的谎言(ing形式)",
+    "english": "he admitted telling a white lie",
+    "soundmark": "/hi/ /ədˈmɪtɪd/ /ˈtɛlɪŋ/ /ə/ /waɪt/ /laɪ/"
+  },
+  {
+    "chinese": "感觉",
+    "english": "to feel",
+    "soundmark": "/tə/ /fil/"
+  },
+  {
+    "chinese": "感情",
+    "english": "feelings",
+    "soundmark": "/'filɪŋz/"
+  },
+  {
+    "chinese": "某个人",
+    "english": "someone",
+    "soundmark": "/'sʌmwʌn/"
+  },
+  {
+    "chinese": "某个人的感情",
+    "english": "someone's feelings",
+    "soundmark": "/'sʌmwʌnz/ /'filɪŋz/"
+  },
+  {
+    "chinese": "伤害",
+    "english": "to hurt",
+    "soundmark": "/tə/ /hɝt/"
+  },
+  {
+    "chinese": "伤害某个人的感情",
+    "english": "to hurt someone's feelings",
+    "soundmark": "/tə/ /hɝt/ /'sʌmwʌnz/ /'filɪŋz/"
+  },
+  {
+    "chinese": "伤害某个人的感情(ing形式)",
+    "english": "hurting someone's feelings",
+    "soundmark": "/ˈhɝtɪŋ/ /'sʌmwʌnz/ /'filɪŋz/"
+  },
+  {
+    "chinese": "避免",
+    "english": "to avoid",
+    "soundmark": "/tə/ /əˈvɔɪd/"
+  },
+  {
+    "chinese": "避免伤害某个人的感情",
+    "english": "to avoid hurting someone's feelings",
+    "soundmark": "/tə/ /əˈvɔɪd/ /ˈhɝtɪŋ/ /'sʌmwʌnz/ /'filɪŋz/"
+  },
+  {
+    "chinese": "他(过去)承认说一个善意的谎言",
+    "english": "he admitted telling a white lie",
+    "soundmark": "/hi/ /ədˈmɪtɪd/ /ˈtɛlɪŋ/ /ə/ /waɪt/ /laɪ/"
+  },
+  {
+    "chinese": "他(过去)承认说一个善意的谎言来避免伤害某个人的感情",
+    "english": "he admitted telling a white lie to avoid hurting someone's feelings",
+    "soundmark": "/hi/ /ədˈmɪtɪd/ /tə/ /ədˈmɪt/ /tə/ /əˈvɔɪd/ /ˈhɝtɪŋ/ /'sʌmwʌnz/ /'filɪŋz/"
+  }
 ]


### PR DESCRIPTION
修复一些错误的课程数据，主要是 english 字段：

1. 删除包含的中文信息
2. 更正错误的单词拼写
3. 补充对应 chinese 字段缺少的单词