### PR TITLE
fix: delete ellipses and full stops from course data

### DIFF
--- a/scripts/courses/33.json
+++ b/scripts/courses/33.json
@@ -56,7 +56,7 @@
 	},
 	{
 		"chinese": "过去常常做......",
-		"english": "used to do......",
+		"english": "used to do",
 		"soundmark": "/juzd/ /tə/ /du/"
 	},
 	{
@@ -131,7 +131,7 @@
 	},
 	{
 		"chinese": "过去常常做......",
-		"english": "used to do......",
+		"english": "used to do",
 		"soundmark": "/juzd/ /tə/ /du/"
 	},
 	{
@@ -186,7 +186,7 @@
 	},
 	{
 		"chinese": "过去常常做......",
-		"english": "used to do......",
+		"english": "used to do",
 		"soundmark": "/juzd/ /tə/ /du/"
 	},
 	{
@@ -256,7 +256,7 @@
 	},
 	{
 		"chinese": "过去常常做......",
-		"english": "used to do......",
+		"english": "used to do",
 		"soundmark": "/juzd/ /tə/ /du/"
 	},
 	{
@@ -356,12 +356,12 @@
 	},
 	{
 		"chinese": "过去常常做......",
-		"english": "used to do......",
+		"english": "used to do",
 		"soundmark": "/juzd/ /tə/ /du/"
 	},
 	{
 		"chinese": "曾经是......",
-		"english": "used to be......",
+		"english": "used to be",
 		"soundmark": "/juzd/ /tə/ /bi/"
 	},
 	{
@@ -436,7 +436,7 @@
 	},
 	{
 		"chinese": "曾经是......",
-		"english": "used to be......",
+		"english": "used to be",
 		"soundmark": "/juzd/ /tə/ /bi/"
 	},
 	{
@@ -511,7 +511,7 @@
 	},
 	{
 		"chinese": "曾经是......",
-		"english": "used to be......",
+		"english": "used to be",
 		"soundmark": "/juzd/ /tə/ /bi/"
 	},
 	{
@@ -556,7 +556,7 @@
 	},
 	{
 		"chinese": "曾经是......",
-		"english": "used to be......",
+		"english": "used to be",
 		"soundmark": "/juzd/ /tə/ /bi/"
 	},
 	{
@@ -621,7 +621,7 @@
 	},
 	{
 		"chinese": "过去常常做......",
-		"english": "used to do......",
+		"english": "used to do",
 		"soundmark": "/juzd/ /tə/ /du/"
 	},
 	{
@@ -671,7 +671,7 @@
 	},
 	{
 		"chinese": "过去常常做......",
-		"english": "used to do......",
+		"english": "used to do",
 		"soundmark": "/juzd/ /tə/ /du/"
 	},
 	{
@@ -726,7 +726,7 @@
 	},
 	{
 		"chinese": "过去常常做......",
-		"english": "used to do......",
+		"english": "used to do",
 		"soundmark": "/juzd/ /tə/ /du/"
 	},
 	{
@@ -771,7 +771,7 @@
 	},
 	{
 		"chinese": "过去常常做......",
-		"english": "used to do......",
+		"english": "used to do",
 		"soundmark": "/juzd/ /tə/ /du/"
 	},
 	{
@@ -881,7 +881,7 @@
 	},
 	{
 		"chinese": "你再也不是我的老板。我辞职。",
-		"english": "you are not my boss anymore. I quit.",
+		"english": "you are not my boss anymore I quit",
 		"soundmark": "/ju/ /ɚ/ /nɑt/ /maɪ/ /bɔs/ /ɛniˈmɔr/ /aɪ/ /kwɪt/"
 	},
 	{

--- a/scripts/courses/37.json
+++ b/scripts/courses/37.json
@@ -301,7 +301,7 @@
 	},
 	{
 		"chinese": "他们(过去)否认用一个石头打破那个窗户",
-		"english": "they denied breaking the window with a stone.",
+		"english": "they denied breaking the window with a stone",
 		"soundmark": "/ðe/ /dɪ'naɪd/ /'brekɪŋ/ /ðə/ /'wɪndo/ /wɪð/ /ə/ /ston/"
 	},
 	{

--- a/scripts/courses/39.json
+++ b/scripts/courses/39.json
@@ -751,7 +751,7 @@
 	},
 	{
 		"chinese": "老师禁止从其他人那里抄作业",
-		"english": "the teacher prohibits copying homework from others.",
+		"english": "the teacher prohibits copying homework from others",
 		"soundmark": "/ðə/ /'titʃɚ/ /prəˈhɪbɪts/ /ˈkɑpɪɪŋ/ /'homwɝk/ /frʌm/ /'ʌðɚz/"
 	},
 	{

--- a/scripts/courses/41.json
+++ b/scripts/courses/41.json
@@ -261,7 +261,7 @@
 	},
 	{
 		"chinese": "她(过去)尝试练习和母语使用者说话",
-		"english": "she tried practicing speaking with native speakers.",
+		"english": "she tried practicing speaking with native speakers",
 		"soundmark": "/ʃi/ /traɪd/ /ˈpræktɪsɪŋ/ /'spikɪŋ/ /wɪð/ /ˈnetɪv/ /'spikɚz/"
 	},
 	{

--- a/scripts/courses/42.json
+++ b/scripts/courses/42.json
@@ -226,7 +226,7 @@
 	},
 	{
 		"chinese": "你(过去)如何设法做到......",
-		"english": "how did you manage...",
+		"english": "how did you manage",
 		"soundmark": "/haʊ/ /dɪd/ /ju/ /ˈmænɪdʒ/"
 	},
 	{


### PR DESCRIPTION
删除课程数据中的省略号和英文句号

近期大家反馈问题有提到的：关于课程数据中的多余的逗号、问号、省略号和英文句号在答题输入中会占位，不知道这些标点符号该在什么位置输入导致频繁答题失误的问题。

我的想法是既然是以单词为基础组成句子的初学练习，那这些标点符号都不是重点，可有可无，就是不知道该是直接从数据上删掉还是在代码中做一层校验好。

所以这里只删了比较影响输入的省略号和句号，其他标点符号暂时未处理。