### PR TITLE
fix: clear commas and question marks from the course data

### DIFF
--- a/scripts/courses/20.5.json
+++ b/scripts/courses/20.5.json
@@ -361,7 +361,7 @@
 	},
 	{
 		"chinese": "我(过去)正在寻找我的钥匙但是我(过去)不能找到我的钥匙",
-		"english": "I was looking for my keys, but I couldn't find my keys",
+		"english": "I was looking for my keys but I couldn't find my keys",
 		"soundmark": "/aɪ/ /wəz/ /stɪl/ /ˈlʊkɪŋ/ /fɝ/ /maɪ/ /kiz/ /bʌt/ /aɪ/ /kʊdnt/ /faɪnd/ /maɪ/ /kiz/"
 	},
 	{
@@ -541,7 +541,7 @@
 	},
 	{
 		"chinese": "我(过去)听说你(过去)正在寻找我但是我(过去)不是你(过去)正在寻找的那个人",
-		"english": "I heard you were looking for me, but I was not the person you were looking for",
+		"english": "I heard you were looking for me but I was not the person you were looking for",
 		"soundmark": "/aɪ/ /hɚd/ /ju/ /wɚ/ /ˈlʊkɪŋ/ /fɝ/ /mi/ /bʌt/ /aɪ/ /wəz/ /nɑt/ /ðə/ /'pɝsn/ /ju/ /wɚ/ /ˈlʊkɪŋ/ /fɝ/"
 	}
 ]

--- a/scripts/courses/20.json
+++ b/scripts/courses/20.json
@@ -351,12 +351,12 @@
 	},
 	{
 		"chinese": "你可以递给我我的手机吗？",
-		"english": "can you hand me my phone?",
+		"english": "can you hand me my phone",
 		"soundmark": "/kən/ /ju/ /hænd/ /mi/ /maɪ/ /fon/"
 	},
 	{
 		"chinese": "你可以......吗？",
-		"english": "can you?",
+		"english": "can you",
 		"soundmark": "/kən/ /ju/"
 	},
 	{
@@ -376,7 +376,7 @@
 	},
 	{
 		"chinese": "你可以递给我一个香蕉吗？",
-		"english": "can you hand me a banana?",
+		"english": "can you hand me a banana",
 		"soundmark": "/kən/ /ju/ /hænd/ /mi/ /ə/ /bə'nænə/"
 	},
 	{
@@ -386,12 +386,12 @@
 	},
 	{
 		"chinese": "你可以麻烦一下递给我我的手机吗？",
-		"english": "can you please hand me my phone?",
+		"english": "can you please hand me my phone",
 		"soundmark": "/kən/ /ju/ /pliz/ /hænd/ /mi/ /maɪ/ /fon/"
 	},
 	{
 		"chinese": "你可以麻烦一下......吗？",
-		"english": "can you please?",
+		"english": "can you please",
 		"soundmark": "/kən/ /ju/ /pliz/"
 	},
 	{
@@ -401,7 +401,7 @@
 	},
 	{
 		"chinese": "你可以麻烦一下递给我一个香蕉吗？",
-		"english": "can you please hand me a banana?",
+		"english": "can you please hand me a banana",
 		"soundmark": "/kən/ /ju/ /pliz/ /hænd/ /mi/ /ə/ /bə'nænə/"
 	},
 	{
@@ -416,17 +416,17 @@
 	},
 	{
 		"chinese": "你可以麻烦一下递给我一个香蕉吗？",
-		"english": "can you please hand me a banana?",
+		"english": "can you please hand me a banana",
 		"soundmark": "/kən/ /ju/ /pliz/ /hænd/ /mi/ /ə/ /bə'nænə/"
 	},
 	{
 		"chinese": "你可以（礼貌版）麻烦一下递给我一个香蕉吗？",
-		"english": "could you please hand me a banana?",
+		"english": "could you please hand me a banana",
 		"soundmark": "/kʊd/ /ju/ /pliz/ /hænd/ /mi/ /ə/ /bə'nænə/"
 	},
 	{
 		"chinese": "你可以（礼貌版）麻烦一下......吗？",
-		"english": "could you please?",
+		"english": "could you please",
 		"soundmark": "/kʊd/ /ju/ /pliz/"
 	},
 	{
@@ -436,12 +436,12 @@
 	},
 	{
 		"chinese": "你可以（礼貌版）麻烦一下递给我我的手机吗？",
-		"english": "could you please hand me my phone?",
+		"english": "could you please hand me my phone",
 		"soundmark": "/kʊd/ /ju/ /pliz/ /hænd/ /mi/ /maɪ/ /fon/"
 	},
 	{
 		"chinese": "你可以（礼貌版）麻烦一下......吗？",
-		"english": "could you please?",
+		"english": "could you please",
 		"soundmark": "/kʊd/ /ju/ /pliz/"
 	},
 	{
@@ -451,12 +451,12 @@
 	},
 	{
 		"chinese": "你可以（礼貌版）麻烦一下递给我我的书包吗？",
-		"english": "could you please hand me my school bag?",
+		"english": "could you please hand me my school bag",
 		"soundmark": "/kʊd/ /ju/ /pliz/ /hænd/ /mi/ /maɪ/ /skul/ /bæɡ/"
 	},
 	{
 		"chinese": "你可以（礼貌版）麻烦一下......吗？",
-		"english": "could you please?",
+		"english": "could you please",
 		"soundmark": "/kʊd/ /ju/ /pliz/"
 	},
 	{
@@ -471,7 +471,7 @@
 	},
 	{
 		"chinese": "你可以（礼貌版）麻烦一下帮助我吗？",
-		"english": "could you please help me?",
+		"english": "could you please help me",
 		"soundmark": "/kʊd/ /ju/ /pliz/ /hɛlp/ /mi/"
 	},
 	{
@@ -501,12 +501,12 @@
 	},
 	{
 		"chinese": "请问你可以......吗？",
-		"english": "could you please?",
+		"english": "could you please",
 		"soundmark": "/kʊd/ /ju/ /pliz/"
 	},
 	{
 		"chinese": "请问你可以告诉我真相吗？",
-		"english": "could you please tell me the truth?",
+		"english": "could you please tell me the truth",
 		"soundmark": "/kʊd/ /ju/ /pliz/ /tɛl/ /mi/ /ðə/ /trʊθ/"
 	},
 	{
@@ -536,12 +536,12 @@
 	},
 	{
 		"chinese": "请问你可以......吗？",
-		"english": "could you please?",
+		"english": "could you please",
 		"soundmark": "/kʊd/ /ju/ /pliz/"
 	},
 	{
 		"chinese": "请问你可以走开别烦我吗？",
-		"english": "could you please leave me alone?",
+		"english": "could you please leave me alone",
 		"soundmark": "/kʊd/ /ju/ /pliz/ /tə/ /liv/ /mi/ /ə'lon/"
 	},
 	{
@@ -571,12 +571,12 @@
 	},
 	{
 		"chinese": "请问你可以......吗？",
-		"english": "could you please?",
+		"english": "could you please",
 		"soundmark": "/kʊd/ /ju/ /pliz/"
 	},
 	{
 		"chinese": "请问你可以今晚打电话给我吗？",
-		"english": "could you please call me tonight?",
+		"english": "could you please call me tonight",
 		"soundmark": "/kʊd/ /ju/ /pliz/ /kɔl/ /mi/ /tə'naɪt/"
 	},
 	{
@@ -611,12 +611,12 @@
 	},
 	{
 		"chinese": "请问你可以......吗？",
-		"english": "could you please?",
+		"english": "could you please",
 		"soundmark": "/kʊd/ /ju/ /pliz/"
 	},
 	{
 		"chinese": "请问你可以给我帮把手吗？",
-		"english": "could you please give me a hand?",
+		"english": "could you please give me a hand",
 		"soundmark": "/kʊd/ /ju/ /pliz/ /ɡɪv/ /mi/ /ə/ /hænd/"
 	},
 	{
@@ -636,12 +636,12 @@
 	},
 	{
 		"chinese": "请问你可以......吗？",
-		"english": "could you please?",
+		"english": "could you please",
 		"soundmark": "/kʊd/ /ju/ /pliz/"
 	},
 	{
 		"chinese": "请问你可以打开门吗",
-		"english": "could you please open the door?",
+		"english": "could you please open the door",
 		"soundmark": "/kʊd/ /ju/ /pliz/ /'opən/ /ðə/ /dɔr/"
 	}
 ]

--- a/scripts/courses/21.json
+++ b/scripts/courses/21.json
@@ -491,7 +491,7 @@
 	},
 	{
 		"chinese": "你可以听见我吗？",
-		"english": "can you hear me?",
+		"english": "can you hear me",
 		"soundmark": "/kæn/ /ju/ /hɪr/ /mi/"
 	},
 	{

--- a/scripts/courses/22.json
+++ b/scripts/courses/22.json
@@ -36,7 +36,7 @@
 	},
 	{
 		"chinese": "你可以听见我吗？",
-		"english": "can you hear me?",
+		"english": "can you hear me",
 		"soundmark": "/kæn/ /ju/ /hɪr/ /mi/"
 	},
 	{
@@ -56,7 +56,7 @@
 	},
 	{
 		"chinese": "你不可以听见我吗？",
-		"english": "can't you hear me?",
+		"english": "can't you hear me",
 		"soundmark": "/kænt/ /ju/ /hɪr/ /mi/"
 	},
 	{
@@ -81,7 +81,7 @@
 	},
 	{
 		"chinese": "你没有听见我吗？",
-		"english": "don't you hear me?",
+		"english": "don't you hear me",
 		"soundmark": "/dont/ /ju/ /hɪr/ /mi/"
 	},
 	{
@@ -96,7 +96,7 @@
 	},
 	{
 		"chinese": "你有听见我吗？",
-		"english": "do you hear me?",
+		"english": "do you hear me",
 		"soundmark": "/du/ /ju/ /hɪr/ /mi/"
 	},
 	{
@@ -111,7 +111,7 @@
 	},
 	{
 		"chinese": "你可以听见我吗？",
-		"english": "can you hear me?",
+		"english": "can you hear me",
 		"soundmark": "/kæn/ /ju/ /hɪr/ /mi/"
 	},
 	{
@@ -121,12 +121,12 @@
 	},
 	{
 		"chinese": "你有听见我吗？",
-		"english": "do you hear me?",
+		"english": "do you hear me",
 		"soundmark": "/du/ /ju/ /hɪr/ /mi/ /do过去式 did/ /dɪd/"
 	},
 	{
 		"chinese": "你(过去)有听见我吗？",
-		"english": "did you hear me?",
+		"english": "did you hear me",
 		"soundmark": "/dɪd/ /ju/ /hɪr/ /mi/"
 	},
 	{
@@ -186,7 +186,7 @@
 	},
 	{
 		"chinese": "你(过去)有做这件事吗？",
-		"english": "did you do it?",
+		"english": "did you do it",
 		"soundmark": "/dɪd/ /ju/ /du/ /ɪt/"
 	},
 	{
@@ -221,7 +221,7 @@
 	},
 	{
 		"chinese": "你(过去)如何做这件事？",
-		"english": "how did you do it?",
+		"english": "how did you do it",
 		"soundmark": "/haʊ/ /dɪd/ /ju/ /du/ /ɪt/"
 	},
 	{
@@ -231,7 +231,7 @@
 	},
 	{
 		"chinese": "你(过去)为什么做这件事？",
-		"english": "why did you do it?",
+		"english": "why did you do it",
 		"soundmark": "/waɪ/ /dɪd/ /ju/ /du/ /ɪt/"
 	},
 	{
@@ -241,7 +241,7 @@
 	},
 	{
 		"chinese": "你(过去)什么时候做这件事？",
-		"english": "when did you do it?",
+		"english": "when did you do it",
 		"soundmark": "/wɛn/ /dɪd/ /ju/ /du/ /ɪt/"
 	},
 	{
@@ -251,7 +251,7 @@
 	},
 	{
 		"chinese": "你(过去)在哪里做这件事？",
-		"english": "where did you do it?",
+		"english": "where did you do it",
 		"soundmark": "/wɛr/ /dɪd/ /ju/ /du/ /ɪt/"
 	},
 	{
@@ -261,12 +261,12 @@
 	},
 	{
 		"chinese": "你(过去)有做这件事吗？",
-		"english": "did you do it?",
+		"english": "did you do it",
 		"soundmark": "/dɪd/ /ju/ /du/ /ɪt/"
 	},
 	{
 		"chinese": "你(过去)做了什么？",
-		"english": "what did you do?",
+		"english": "what did you do",
 		"soundmark": "/wɑt/ /dɪd/ /ju/ /du/"
 	},
 	{
@@ -291,7 +291,7 @@
 	},
 	{
 		"chinese": "你(过去)是如何找到我的？",
-		"english": "how did you find me?",
+		"english": "how did you find me",
 		"soundmark": "/haʊ/ /dɪd/ /ju/ /faɪnd/ /mi/"
 	},
 	{
@@ -326,7 +326,7 @@
 	},
 	{
 		"chinese": "你(过去)是如何知道她的名字的？",
-		"english": "how did you know her name?",
+		"english": "how did you know her name",
 		"soundmark": "/haʊ/ /dɪd/ /ju/ /no/ /hɚ/ /nem/"
 	},
 	{
@@ -371,7 +371,7 @@
 	},
 	{
 		"chinese": "你(过去)是如何知道我的电话号码的？",
-		"english": "how did you know my phone number?",
+		"english": "how did you know my phone number",
 		"soundmark": "/haʊ/ /dɪd/ /ju/ /no/ /maɪ/ /fon/ /'nʌmbɚ/"
 	},
 	{
@@ -406,7 +406,7 @@
 	},
 	{
 		"chinese": "你(过去)为什么决定做这件事？",
-		"english": "why did you decide to do it?",
+		"english": "why did you decide to do it",
 		"soundmark": "/waɪ/ /dɪd/ /ju/ /dɪ'saɪd/ /tə/ /du/ /ɪt/"
 	},
 	{
@@ -431,7 +431,7 @@
 	},
 	{
 		"chinese": "你(过去)为什么离开我？",
-		"english": "why did you leave me?",
+		"english": "why did you leave me",
 		"soundmark": "/waɪ/ /dɪd/ /ju/ /liv/ /mi/"
 	},
 	{
@@ -456,7 +456,7 @@
 	},
 	{
 		"chinese": "你(过去)为什么说那句话？",
-		"english": "why did you say it?",
+		"english": "why did you say it",
 		"soundmark": "/waɪ/ /dɪd/ /ju/ /se/ /ɪt/"
 	},
 	{
@@ -481,7 +481,7 @@
 	},
 	{
 		"chinese": "你(过去)什么时候到达这里的？",
-		"english": "when did you get here?",
+		"english": "when did you get here",
 		"soundmark": "/wɛn/ /dɪd/ /ju/ /ɡɛt/ /hɪr/"
 	},
 	{
@@ -506,7 +506,7 @@
 	},
 	{
 		"chinese": "你(过去)什么时候见到他的？",
-		"english": "when did you meet him?",
+		"english": "when did you meet him",
 		"soundmark": "/wɛn/ /dɪd/ /ju/ /mit/ /hɪm/"
 	},
 	{
@@ -551,7 +551,7 @@
 	},
 	{
 		"chinese": "你(过去)什么时候完成你的家庭作业的？",
-		"english": "when did you finish your homework?",
+		"english": "when did you finish your homework",
 		"soundmark": "/wɛn/ /dɪd/ /ju/ /'fɪnɪʃ/ /jʊr/ /'homwɝk/"
 	},
 	{
@@ -576,7 +576,7 @@
 	},
 	{
 		"chinese": "你(过去)在哪里找到他们的？",
-		"english": "where did you find them?",
+		"english": "where did you find them",
 		"soundmark": "/wɛr/ /dɪd/ /ju/ /faɪnd/ /ðəm/"
 	},
 	{
@@ -601,7 +601,7 @@
 	},
 	{
 		"chinese": "你(过去)在哪里购买这个的？",
-		"english": "where did you buy this?",
+		"english": "where did you buy this",
 		"soundmark": "/wɛr/ /dɪd/ /ju/ /baɪ/ /ðɪs/"
 	},
 	{
@@ -616,7 +616,7 @@
 	},
 	{
 		"chinese": "你(过去)在哪里睡觉的？",
-		"english": "where did you sleep?",
+		"english": "where did you sleep",
 		"soundmark": "/wɛr/ /dɪd/ /ju/ /slip/"
 	},
 	{
@@ -636,7 +636,7 @@
 	},
 	{
 		"chinese": "你(过去)昨晚在哪里睡觉的？",
-		"english": "where did you sleep last night?",
+		"english": "where did you sleep last night",
 		"soundmark": "/wɛr/ /dɪd/ /ju/ /slip/ /læst/ /naɪt/"
 	},
 	{
@@ -651,7 +651,7 @@
 	},
 	{
 		"chinese": "你(过去)说了什么？",
-		"english": "what did you say?",
+		"english": "what did you say",
 		"soundmark": "/wɑt/ /dɪd/ /ju/ /se/"
 	},
 	{
@@ -666,7 +666,7 @@
 	},
 	{
 		"chinese": "你(过去)学到了什么？",
-		"english": "what did you learn?",
+		"english": "what did you learn",
 		"soundmark": "/wɑt/ /dɪd/ /ju/ /lɝn/"
 	},
 	{
@@ -681,7 +681,7 @@
 	},
 	{
 		"chinese": "你(过去)找到了什么？",
-		"english": "what did you find?",
+		"english": "what did you find",
 		"soundmark": "/wɑt/ /dɪd/ /ju/ /faɪnd/"
 	},
 	{
@@ -696,7 +696,7 @@
 	},
 	{
 		"chinese": "你(过去)听到了什么？",
-		"english": "what did you hear?",
+		"english": "what did you hear",
 		"soundmark": "/wɑt/ /dɪd/ /ju/ /hɪr/"
 	},
 	{
@@ -711,32 +711,32 @@
 	},
 	{
 		"chinese": "你(过去)看到了什么？",
-		"english": "what did you see?",
+		"english": "what did you see",
 		"soundmark": "/wɑt/ /dɪd/ /ju/ /si/"
 	},
 	{
 		"chinese": "你(过去)如何做这件事？",
-		"english": "how did you do it?",
+		"english": "how did you do it",
 		"soundmark": "/haʊ/ /dɪd/ /ju/ /du/ /ɪt/"
 	},
 	{
 		"chinese": "你(过去)为什么做这件事？",
-		"english": "why did you do it?",
+		"english": "why did you do it",
 		"soundmark": "/waɪ/ /dɪd/ /ju/ /du/ /ɪt/"
 	},
 	{
 		"chinese": "你(过去)什么时候做这件事？",
-		"english": "when did you do it?",
+		"english": "when did you do it",
 		"soundmark": "/wɛn/ /dɪd/ /ju/ /du/ /ɪt/"
 	},
 	{
 		"chinese": "你(过去)在哪里做这件事？",
-		"english": "where did you do it?",
+		"english": "where did you do it",
 		"soundmark": "/wɛr/ /dɪd/ /ju/ /du/ /ɪt/"
 	},
 	{
 		"chinese": "你(过去)做了什么？",
-		"english": "what did you do?",
+		"english": "what did you do",
 		"soundmark": "/wɑt/ /dɪd/ /ju/ /du/"
 	},
 	{

--- a/scripts/courses/25.5.json
+++ b/scripts/courses/25.5.json
@@ -106,7 +106,7 @@
 	},
 	{
 		"chinese": "你可以给我一些建议吗？",
-		"english": "can you give me some advice?",
+		"english": "can you give me some advice",
 		"soundmark": "/kæn/ /ju/ /ɡɪv/ /mi/ /səm/ /əd'vaɪs/"
 	},
 	{
@@ -196,7 +196,7 @@
 	},
 	{
 		"chinese": "你可以给我帮把手?",
-		"english": "can you give me a hand?",
+		"english": "can you give me a hand",
 		"soundmark": "/kæn/ /ju/ /ɡɪv/ /mi/ /ə/ /hænd/"
 	},
 	{
@@ -736,7 +736,7 @@
 	},
 	{
 		"chinese": "你可以做给我一杯咖啡吗？",
-		"english": "can you make me a cup of coffee?",
+		"english": "can you make me a cup of coffee",
 		"soundmark": "/kæn/ /ju/ /mek/ /mi/ /ə/ /kʌp/ /əv/ /'kɔfi/"
 	},
 	{
@@ -751,7 +751,7 @@
 	},
 	{
 		"chinese": "你可以做给她一杯咖啡吗？",
-		"english": "can you make her a cup of coffee?",
+		"english": "can you make her a cup of coffee",
 		"soundmark": "/kæn/ /ju/ /mek/ /hɚ/ /ə/ /kʌp/ /əv/ /'kɔfi/"
 	},
 	{
@@ -761,7 +761,7 @@
 	},
 	{
 		"chinese": "你可以让她开心吗？",
-		"english": "can you make her happy?",
+		"english": "can you make her happy",
 		"soundmark": "/kæn/ /ju/ /mek/ /hɚ/ /'hæpi/"
 	},
 	{

--- a/scripts/courses/29.json
+++ b/scripts/courses/29.json
@@ -56,7 +56,7 @@
 	},
 	{
 		"chinese": "我不想在这里我想要去那里",
-		"english": "I don't want to be here, I want to be there",
+		"english": "I don't want to be here I want to be there",
 		"soundmark": "/aɪ/ /dont/ /wɑnt/ /tə/ /bi/ /hɪr/ /aɪ/ /wɑnt/ /tə/ /bi/ /ðɛr/"
 	},
 	{
@@ -81,12 +81,12 @@
 	},
 	{
 		"chinese": "当我在这里的时候，我想要去那里",
-		"english": "when I am here, I want to be there",
+		"english": "when I am here I want to be there",
 		"soundmark": "/wɛn/ /aɪ/ /æm/ /hɪr/ /aɪ/ /wɑnt/ /tə/ /bi/ /ðɛr/"
 	},
 	{
 		"chinese": "当我(过去)在这里的时候，我(过去)想要去那里",
-		"english": "when I was here, I wanted to be there",
+		"english": "when I was here I wanted to be there",
 		"soundmark": "/wɛn/ /aɪ/ /wəz/ /hɪr/ /aɪ/ /wɑntɪd/ /tə/ /bi/ /ðɛr/"
 	},
 	{

--- a/scripts/courses/33.json
+++ b/scripts/courses/33.json
@@ -491,7 +491,7 @@
 	},
 	{
 		"chinese": "你曾经是一个烟民但是现在你戒了",
-		"english": "you used to be a smoker, but now you quit",
+		"english": "you used to be a smoker but now you quit",
 		"soundmark": "/ju/ /juzd/ /tə/ /bi/ /ə/ /'smokɚ/ /bʌt/ /naʊ/ /ju/ /kwɪt/"
 	},
 	{
@@ -596,7 +596,7 @@
 	},
 	{
 		"chinese": "我们曾经是亲密的朋友但是再也不是了",
-		"english": "we used to be close friends, but not anymore",
+		"english": "we used to be close friends but not anymore",
 		"soundmark": "/wi/ /juzd/ /tə/ /bi/ /klos/ /frɛndz/ /bʌt/ /nɑt/ /ɛniˈmɔr/"
 	},
 	{

--- a/scripts/courses/42.json
+++ b/scripts/courses/42.json
@@ -201,7 +201,7 @@
 	},
 	{
 		"chinese": "你(过去)有做这件事吗？",
-		"english": "did you do it?",
+		"english": "did you do it",
 		"soundmark": "/dɪd/ /ju/ /du/ /ɪt/"
 	},
 	{
@@ -221,7 +221,7 @@
 	},
 	{
 		"chinese": "你(过去)如何设法做到这件事的？",
-		"english": "how did you manage to do it?",
+		"english": "how did you manage to do it",
 		"soundmark": "/haʊ/ /dɪd/ /ju/ /ˈmænɪdʒ/ /tə/ /du/ /ɪt/"
 	},
 	{
@@ -271,7 +271,7 @@
 	},
 	{
 		"chinese": "你(过去)如何设法做到如此迅速地到达这里的？",
-		"english": "how did you manage to get here so quickly?",
+		"english": "how did you manage to get here so quickly",
 		"soundmark": "/haʊ/ /dɪd/ /ju/ /ˈmænɪdʒ/ /tə/ /ɡɛt/ /hɪr/ /so/ /ˈkwɪklɪ/"
 	},
 	{
@@ -336,7 +336,7 @@
 	},
 	{
 		"chinese": "你(过去)如何设法做到赚如此多的钱的？",
-		"english": "how did you manage to make so much money?",
+		"english": "how did you manage to make so much money",
 		"soundmark": "/haʊ/ /dɪd/ /ju/ /ˈmænɪdʒ/ /tə/ /mek/ /so/ /mʌtʃ/ /ˈmʌni/"
 	},
 	{
@@ -376,12 +376,12 @@
 	},
 	{
 		"chinese": "你(过去)如何设法做到赚如此多的钱的？",
-		"english": "how did you manage to make so much money?",
+		"english": "how did you manage to make so much money",
 		"soundmark": "/haʊ/ /dɪd/ /ju/ /ˈmænɪdʒ/ /tə/ /mek/ /so/ /mʌtʃ/ /ˈmʌni/"
 	},
 	{
 		"chinese": "你(过去)如何设法做到在一段如此短的时间里赚如此多的钱的？",
-		"english": "how did you manage to make so much money in such a short time?",
+		"english": "how did you manage to make so much money in such a short time",
 		"soundmark": "/haʊ/ /dɪd/ /ju/ /ˈmænɪdʒ/ /tə/ /mek/ /so/ /mʌtʃ/ /ˈmʌni/ /ɪn/ /sʌtʃ/ /ə/ /ʃɔrt/ /taɪm/"
 	},
 	{
@@ -406,7 +406,7 @@
 	},
 	{
 		"chinese": "你(过去)如何设法做到写这本书的？",
-		"english": "how did you manage to write this book?",
+		"english": "how did you manage to write this book",
 		"soundmark": "/haʊ/ /dɪd/ /ju/ /ˈmænɪdʒ/ /tə/ /raɪt/ /ðɪs/ /bʊk/"
 	},
 	{
@@ -446,12 +446,12 @@
 	},
 	{
 		"chinese": "你(过去)如何设法做到写这本书的？",
-		"english": "how did you manage to write this book?",
+		"english": "how did you manage to write this book",
 		"soundmark": "/haʊ/ /dɪd/ /ju/ /ˈmænɪdʒ/ /tə/ /raɪt/ /ðɪs/ /bʊk/"
 	},
 	{
 		"chinese": "你(过去)如何设法做到写这本书的当你(过去)在监狱里？",
-		"english": "how did you manage to write this book when you were in prison?",
+		"english": "how did you manage to write this book when you were in prison",
 		"soundmark": "/haʊ/ /dɪd/ /ju/ /ˈmænɪdʒ/ /tə/ /raɪt/ /ðɪs/ /bʊk/ /wɛn/ /ju/ /wɚ/ /ɪn/ /ˈprɪzn/"
 	},
 	{
@@ -506,7 +506,7 @@
 	},
 	{
 		"chinese": "你(过去)如何设法做到克服你的公开演讲的恐惧的？",
-		"english": "how did you manage to overcome your fear of public speaking?",
+		"english": "how did you manage to overcome your fear of public speaking",
 		"soundmark": "/haʊ/ /dɪd/ /ju/ /ˈmænɪdʒ/ /tə/ /ˌovɚˈkʌm/ /jʊr/ /fɪr/ /əv/ /ˈpʌblɪk/ /'spikɪŋ/"
 	},
 	{
@@ -561,7 +561,7 @@
 	},
 	{
 		"chinese": "你(过去)如何设法做到保持在工作和生活之间的平衡的？",
-		"english": "how did you manage to keep the balance between work and life?",
+		"english": "how did you manage to keep the balance between work and life",
 		"soundmark": "/haʊ/ /dɪd/ /ju/ /ˈmænɪdʒ/ /tə/ /kip/ /ðə/ /'bæləns/ /bɪ'twin/ /wɝk/ /ənd/ /laɪf/"
 	},
 	{
@@ -611,7 +611,7 @@
 	},
 	{
 		"chinese": "你(过去)如何设法做到为那个度假存足够的钱的？",
-		"english": "how did you manage to save enough money for that vacation?",
+		"english": "how did you manage to save enough money for that vacation",
 		"soundmark": "/haʊ/ /dɪd/ /ju/ /ˈmænɪdʒ/ /tə/ /sev/ /ɪ'nʌf/ /ˈmʌni/ /ðæt/ /veˈkeʃn/"
 	},
 	{
@@ -636,12 +636,12 @@
 	},
 	{
 		"chinese": "你(过去)如何设法做到为那个度假存足够的钱的？",
-		"english": "how did you manage to save enough money for that vacation?",
+		"english": "how did you manage to save enough money for that vacation",
 		"soundmark": "/haʊ/ /dɪd/ /ju/ /ˈmænɪdʒ/ /tə/ /sev/ /ɪ'nʌf/ /ˈmʌni/ /ðæt/ /veˈkeʃn/"
 	},
 	{
 		"chinese": "你(过去)如何设法做到在一段如此短的时间里为那个度假存足够的钱的？",
-		"english": "how did you manage to save enough money for that vacation in such a short time?",
+		"english": "how did you manage to save enough money for that vacation in such a short time",
 		"soundmark": "/haʊ/ /dɪd/ /ju/ /ˈmænɪdʒ/ /tə/ /sev/ /ɪ'nʌf/ /ˈmʌni/ /ðæt/ /veˈkeʃn/ /ɪn/ /sʌtʃ/ /ə/ /ʃɔrt/ /taɪm/"
 	}
 ]


### PR DESCRIPTION
将课程数据中多余的逗号和问号通过正则匹配的形式替换了，类似 PR https://github.com/cuixiaorui/earthworm/pull/88

![1705820482350](https://github.com/cuixiaorui/earthworm/assets/48991003/e49660c5-400e-47c6-9630-1f5dd36d74bf)
